### PR TITLE
Add cross subcommands shortcuts

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -38,12 +38,12 @@ impl Subcommand {
 impl<'a> From<&'a str> for Subcommand {
     fn from(s: &str) -> Subcommand {
         match s {
-            "build" => Subcommand::Build,
-            "check" => Subcommand::Check,
+            "b" | "build" => Subcommand::Build,
+            "c" | "check" => Subcommand::Check,
             "doc" => Subcommand::Doc,
-            "run" => Subcommand::Run,
+            "r" | "run" => Subcommand::Run,
             "rustc" => Subcommand::Rustc,
-            "test" => Subcommand::Test,
+            "t" | "test" => Subcommand::Test,
             "bench" => Subcommand::Bench,
             "deb" => Subcommand::Deb,
             "clippy" => Subcommand::Clippy,


### PR DESCRIPTION
Hi, this pr adds sub-commands shortcuts `['b','c','r', 't']` to the cli.
The main reason is currently the error when using them is misleading.
Example:
this command:
`cross b --target arm-linux-androideabi`
outputs this error: 
`error: linking with `cc` failed: exit code: 1` 
which took me a while to figure out that cross is not recognizing the sub-command and is falling-back to cargo.
Also they are useful to have.
