### PR TITLE
revert part of changes done in #443 due to file mount issues on windows

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -187,10 +187,10 @@ pub fn run(target: &Target,
         .args(&["-v", &format!("{}:/cargo:Z", cargo_dir.display())])
         // Prevent `bin` from being mounted inside the Docker container.
         .args(&["-v", "/cargo/bin"])
-        .args(&["-v", &format!("{}:/{}:Z", mount_root.display(), mount_root.display())])
+        .args(&["-v", &format!("{}:/project:Z", mount_root.display())])
         .args(&["-v", &format!("{}:/rust:Z,ro", sysroot.display())])
         .args(&["-v", &format!("{}:/target:Z", target_dir.display())])
-        .args(&["-w", &mount_root.display().to_string()]);
+        .args(&["-w", "/project"]);
 
     if atty::is(Stream::Stdin) {
         docker.arg("-i");


### PR DESCRIPTION
Without this, cross on windows with docker for windows errors on

> cross build --target armv7-unknown-linux-gnueabihf
docker: Error response from daemon: Mount denied:
The source path "\\working\\dir:/C:\\working\\dir:Z"
too many colons.
See 'docker run --help'.

If we somehow fixed that error, we'd then get

> cross build --target armv7-unknown-linux-gnueabihf
docker: Error response from daemon: the working directory 'C:\working\dir' is invalid, it needs to be an absolute path.
See 'docker run --help'.

this pr simply reverts the project structure changes done in #443 to try and resolve that. 

I'm unclear if this functionality is needed for the build env volumes.

cc @reitermarkus 