### PR TITLE
Add x86_64-apple-darwin target

### DIFF
--- a/docker/Dockerfile.x86_64-apple-darwin
+++ b/docker/Dockerfile.x86_64-apple-darwin
@@ -1,0 +1,18 @@
+FROM ubuntu:20.04
+
+COPY common.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+COPY darwin.sh /
+RUN /darwin.sh
+
+ENV CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=x86_64-apple-darwin14-clang \
+    CARGO_TARGET_X86_64_APPLE_DARWIN_AR=x86_64-apple-darwin14-ar \
+    CC_x86_64_apple_darwin=o64-clang \
+    CXX_x86_64_apple_darwin=o64-clang++

--- a/docker/darwin.sh
+++ b/docker/darwin.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -x
+set -euo pipefail
+
+main() {
+    local dependencies=(
+        clang
+        curl
+        gcc
+        g++
+        make
+        patch
+        libmpc-dev
+        libmpfr-dev
+        libgmp-dev
+        libssl-dev
+        libxml2-dev
+        xz-utils
+        zlib1g-dev
+    )
+
+    apt-get update
+
+    # this must be installed first, otherwise an interactive prompt is
+    # triggered by another package install
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+
+    for dep in "${dependencies[@]}"; do
+        if ! dpkg -L "${dep}"; then
+            apt-get install --assume-yes --no-install-recommends "${dep}"
+        fi
+    done
+
+    cd /opt
+    git clone https://github.com/tpoechtrager/osxcross
+    cd osxcross
+    curl -L https://s3.dockerproject.org/darwin/v2/MacOSX10.10.sdk.tar.xz -o tarballs/MacOSX10.10.sdk.tar.xz
+    UNATTENDED=yes OSX_VERSION_MIN=10.7 ./build.sh
+    ln -s /opt/osxcross/target/bin/* /usr/local/bin/
+
+    local purge_list=(
+        curl
+        gcc
+        g++
+        make
+        patch
+        xz-utils
+    )
+
+    if (( ${#purge_list[@]} )); then
+      apt-get purge --assume-yes --auto-remove "${purge_list[@]}"
+    fi
+}
+
+main "${@}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ impl Host {
         if *self == Host::X86_64AppleDarwin {
             target.map(|t| t.is_apple() || t.needs_docker()).unwrap_or(false)
         } else if *self == Host::X86_64UnknownLinuxGnu {
-            target.map(|t| t.needs_docker()).unwrap_or(true)
+            target.map(|t| t.is_apple() || t.needs_docker()).unwrap_or(true)
         } else if *self == Host::X86_64PcWindowsMsvc {
             target.map(|t| t.triple() != Host::X86_64PcWindowsMsvc.triple() && t.needs_docker()).unwrap_or(false)
         } else {
@@ -296,7 +296,12 @@ fn run() -> Result<ExitStatus> {
                 args.all.clone()
             };
 
-            if image_exists && target.needs_docker() &&
+            let needs_docker = match host {
+                Host::X86_64UnknownLinuxGnu => target.needs_docker() || target.is_apple(),
+                _ => target.needs_docker(),
+            };
+
+            if image_exists && needs_docker &&
                args.subcommand.map(|sc| sc.needs_docker()).unwrap_or(false) {
                 if version_meta.needs_interpreter() &&
                     needs_interpreter &&


### PR DESCRIPTION
This adds support for the x86_64-apple-darwin target using [osxcross](https://github.com/tpoechtrager/osxcross).  This would fix #223 (at least partially depending upon desire for other darwin targets like i386) and maybe addresses #436 because of the changes made to `needs_docker()` in `src/main.rs`.

I tried to reuse/imitate as many things as I could from the other targets to try and make the first pass at this consistent with them, but let me know if something is missing or needs to be improved.