### PR TITLE
feat: Parse Cargo's `--manifest-path` option to determine mounted docker root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- #494 - Parse Cargo's --manifest-path option to determine mounted docker root
 - Change rust edition to 2021 and bump MSRV for the cross binary to 1.58.1
 - #654 - Use color-eyre for error reporting
 - #658 - Upgrade dependencies

--- a/README.md
+++ b/README.md
@@ -354,6 +354,9 @@ $ QEMU_STRACE=1 cross run --target aarch64-unknown-linux-gnu
 - path dependencies (in Cargo.toml) that point outside the Cargo project won't
   work because `cross` use docker containers only mounts the Cargo project so
   the container doesn't have access to the rest of the filesystem.
+  However, you may use Cargo's `--manifest-path` option to reference your
+  target crate, executed from a common root directory from which all your
+  dependencies are available.
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -58,6 +58,7 @@ pub fn run(
     args: &[String],
     target_dir: &Option<PathBuf>,
     root: &Root,
+    docker_root: &Path,
     config: &Config,
     uses_xargo: bool,
     sysroot: &Path,
@@ -89,7 +90,7 @@ pub fn run(
     let cargo_dir = mount_finder.find_mount_path(cargo_dir);
     let xargo_dir = mount_finder.find_mount_path(xargo_dir);
     let target_dir = mount_finder.find_mount_path(target_dir);
-    let mount_root = mount_finder.find_mount_path(root);
+    let mount_root = mount_finder.find_mount_path(docker_root);
     let sysroot = mount_finder.find_mount_path(sysroot);
 
     let mut cmd = if uses_xargo {

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,7 +257,7 @@ fn run() -> Result<ExitStatus> {
 
     let version_meta =
         rustc_version::version_meta().wrap_err("couldn't fetch the `rustc` version")?;
-    if let Some(root) = cargo::root()? {
+    if let Some(root) = cargo::root(args.manifest_path)? {
         let host = version_meta.host();
 
         if host.is_supported(args.target.as_ref()) {
@@ -358,11 +358,13 @@ fn run() -> Result<ExitStatus> {
                     docker::register(&target, verbose)?
                 }
 
+                let docker_root = env::current_dir()?;
                 return docker::run(
                     &target,
                     &filtered_args,
                     &args.target_dir,
                     &root,
+                    &docker_root,
                     &config,
                     uses_xargo,
                     &sysroot,


### PR DESCRIPTION
This commits adds support for parsing the `--manifest-path` option to cross. So
far, the `Cargo.toml` manifest of the crate (or its Cargo workspace) to compile
has been assumed to be in the current working directory. This means, that
relative crate dependencies were not supported, because those paths were not
mapped into the docker container.

Take the following example structure, where `my-bin` depends on `my-lib`:
```
.
├── my-bin
│   ├── Cargo.toml
│   └── src
│       └── main.rs
└── my-lib
    ├── Cargo.toml
    └── src
        └── lib.rs
```

This commits enables such scenarios, by running cross from `.` like so:
`cross build --manifest-path=my-lib/Cargo.toml --target x86_64-pc-windows-gnu`,
as `.` is mapped as the container's root, and the options passed through to
Cargo.

Related #388 #139 #277 #78 #438

Co-authored-by: Kviring Alexey <alex@kviring.com>