### PR TITLE
don't set `SQLITE3_LIB_DIR` in FreeBSD images

### DIFF
--- a/docker/Dockerfile.i686-unknown-freebsd
+++ b/docker/Dockerfile.i686-unknown-freebsd
@@ -18,5 +18,4 @@ RUN /freebsd-extras.sh i686
 ENV CARGO_TARGET_I686_UNKNOWN_FREEBSD_LINKER=i686-unknown-freebsd12-gcc \
     CC_i686_unknown_freebsd=i686-unknown-freebsd12-gcc \
     CXX_i686_unknown_freebsd=i686-unknown-freebsd12-g++ \
-    I686_UNKNOWN_FREEBSD_OPENSSL_DIR=/usr/local/i686-unknown-freebsd12/  \
-    SQLITE3_LIB_DIR=/usr/local/x86_64-unknown-freebsd12/lib/
+    I686_UNKNOWN_FREEBSD_OPENSSL_DIR=/usr/local/i686-unknown-freebsd12/

--- a/docker/Dockerfile.x86_64-unknown-freebsd
+++ b/docker/Dockerfile.x86_64-unknown-freebsd
@@ -18,5 +18,4 @@ RUN /freebsd-extras.sh x86_64
 ENV CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER=x86_64-unknown-freebsd12-gcc \
     CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd12-gcc \
     CXX_x86_64_unknown_freebsd=x86_64-unknown-freebsd12-g++ \
-    X86_64_UNKNOWN_FREEBSD_OPENSSL_DIR=/usr/local/x86_64-unknown-freebsd12/ \
-    SQLITE3_LIB_DIR=/usr/local/x86_64-unknown-freebsd12/lib/
+    X86_64_UNKNOWN_FREEBSD_OPENSSL_DIR=/usr/local/x86_64-unknown-freebsd12/


### PR DESCRIPTION
The environment variable has broken procedural macro crates which depend on `libsqlite3-sys`, such as `migrations_macros`.

Even without the variable, `libsqlite3-sys` finds the correct path anyway.

This fixes #520, as shown in the CI at [tesaguri/cross-freebsd-diesel_migrations-test] repository.

~Additionally, this PR updates `freebsd{,-extras}.sh` to use OpenSSL from the base system, because the URLs `https://pkg.freebsd.org/FreeBSD:12:{amd64,i686}/quarterly/All/openssl-1.1.1j,1.txz` returns `404` now.~

[tesaguri/cross-freebsd-diesel_migrations-test]: https://github.com/tesaguri/cross-freebsd-diesel_migrations-test