### PR TITLE
Remove hard-coded old Qemu version for PPC targets.

### DIFF
--- a/docker/qemu.sh
+++ b/docker/qemu.sh
@@ -69,15 +69,6 @@ build_static_pixman() {
 main() {
     local version=4.2.0
 
-    # Qemu versions 3.1.0 and above break 32-bit float conversions
-    # on powerpc, powerpc64, and powerpc64le. Last known working version
-    # is 3.0.1.
-    # Upstream Issue:
-    #   https://bugs.launchpad.net/qemu/+bug/1821444
-    if [[ "${1}" == ppc* ]]; then
-        version=3.0.1
-    fi
-
     local arch="${1}" \
           softmmu="${2:-}"
 


### PR DESCRIPTION
Fixes #585. The relevant upstream issues that have made this possible are [1821444](https://bugs.launchpad.net/qemu/+bug/1821444) ("qemu-ppc (user) incorrectly translates float32 arithmetics"), so this initial [workaround](https://github.com/rust-embedded/cross/pull/316)  is no longer required.