### PR TITLE
Update to latest stable Qemu release. Fixes #557.

### DIFF
--- a/docker/qemu.sh
+++ b/docker/qemu.sh
@@ -109,7 +109,7 @@ build_static_pixman() {
 }
 
 main() {
-    local version=5.1.0
+    local version=6.1.0
 
     if_centos version=4.2.1
 
@@ -125,6 +125,7 @@ main() {
         flex \
         libtool \
         make \
+        ninja-build \
         patch \
         python3 \
 


### PR DESCRIPTION
Update Qemu version to the latest stable release, v6.1.0. The latest Qemu release contains numerous bug fixes, and other improvements, and the existing patches various issues reported in older Qemu versions.

The only changes required are incrementing the Qemu version and adding `ninja-build` as a temporary dependency, since Qemu now uses it for the build system.