### PR TITLE
Update all GNU docker images to latest LTS version on Docker.

### DIFF
--- a/.changes/591.json
+++ b/.changes/591.json
@@ -1,0 +1,6 @@
+{
+    "description": "Update Ubuntu images to 20.04 LTS.",
+    "type": "changed",
+    "breaking": true,
+    "issues": [417, 517, 556, 616]
+}

--- a/.changes/591.json
+++ b/.changes/591.json
@@ -1,6 +1,13 @@
-{
-    "description": "Update Ubuntu images to 20.04 LTS.",
-    "type": "changed",
-    "breaking": true,
-    "issues": [417, 517, 556, 616]
-}
+[
+    {
+        "description": "update Ubuntu images to 20.04 LTS.",
+        "type": "changed",
+        "breaking": true,
+        "issues": [417, 517, 556, 616]
+    },
+    {
+        "description": "remove Linux image from `mips-unknown-linux-gnu`.",
+        "type": "removed",
+        "breaking": true
+    }
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
             - { target: thumbv7neon-unknown-linux-gnueabihf, os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }
             - { target: i586-unknown-linux-gnu,           os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1 }
             - { target: i686-unknown-linux-gnu,           os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: native qemu-user qemu-system }
-            - { target: mips-unknown-linux-gnu,           os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }
+            - { target: mips-unknown-linux-gnu,           os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user }
             - { target: mipsel-unknown-linux-gnu,         os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }
             - { target: mips64-unknown-linux-gnuabi64,    os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1 }
             - { target: mips64el-unknown-linux-gnuabi64,  os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
       - name: Build Docker image
         id: build-docker-image
         if: steps.prepare-meta.outputs.has-image
-        timeout-minutes: 60
+        timeout-minutes: 120
         run: cargo xtask build-docker-image -v "${TARGET}${SUB:+.$SUB}"
         env:
           TARGET: ${{ matrix.target }}

--- a/README.md
+++ b/README.md
@@ -320,58 +320,58 @@ terminate.
 | Target                               |  libc  |   GCC   | C++ | QEMU  | `test` |
 |--------------------------------------|-------:|--------:|:---:|------:|:------:|
 | `aarch64-linux-android` [1]          | 9.0.8  | 9.0.8   | ✓   | 6.1.0 |   ✓    |
-| `aarch64-unknown-linux-gnu`          | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `aarch64-unknown-linux-musl`         | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `aarch64-unknown-linux-gnu`          | 2.31   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
+| `aarch64-unknown-linux-musl`         | 1.1.24 | 9.2.0   | ✓   | 6.1.0 |   ✓    |
 | `arm-linux-androideabi` [1]          | 9.0.8  | 9.0.8   | ✓   | 6.1.0 |   ✓    |
-| `arm-unknown-linux-gnueabi`          | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `arm-unknown-linux-gnueabi`          | 2.31   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
 | `arm-unknown-linux-gnueabihf`        | 2.17   | 8.3.0   | ✓   | 6.1.0 |   ✓    |
-| `arm-unknown-linux-musleabi`         | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
-| `arm-unknown-linux-musleabihf`       | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
-| `armv5te-unknown-linux-gnueabi`      | 2.27   | 7.5.0   | ✓   | 6.1.0 |   ✓    |
-| `armv5te-unknown-linux-musleabi`     | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `arm-unknown-linux-musleabi`         | 1.1.24 | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `arm-unknown-linux-musleabihf`       | 1.1.24 | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `armv5te-unknown-linux-gnueabi`      | 2.31   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
+| `armv5te-unknown-linux-musleabi`     | 1.1.24 | 9.2.0   | ✓   | 6.1.0 |   ✓    |
 | `armv7-linux-androideabi` [1]        | 9.0.8  | 9.0.8   | ✓   | 6.1.0 |   ✓    |
-| `armv7-unknown-linux-gnueabi`        | 2.27   | 7.5.0   | ✓   | 6.1.0 |   ✓    |
-| `armv7-unknown-linux-gnueabihf`      | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `armv7-unknown-linux-musleabi`       | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
-| `armv7-unknown-linux-musleabihf`     | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
-| `i586-unknown-linux-gnu`             | 2.23   | 5.4.0   | ✓   | N/A   |   ✓    |
-| `i586-unknown-linux-musl`            | 1.1.24  | 9.2.0   | ✓   | N/A   |   ✓    |
+| `armv7-unknown-linux-gnueabi`        | 2.31   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
+| `armv7-unknown-linux-gnueabihf`      | 2.31   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
+| `armv7-unknown-linux-musleabi`       | 1.1.24 | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `armv7-unknown-linux-musleabihf`     | 1.1.24 | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `i586-unknown-linux-gnu`             | 2.31   | 9.4.0   | ✓   | N/A   |   ✓    |
+| `i586-unknown-linux-musl`            | 1.1.24 | 9.2.0   | ✓   | N/A   |   ✓    |
 | `i686-unknown-freebsd`               | 1.5    | 6.4.0   | ✓   | N/A   |       |
 | `i686-linux-android` [1]             | 9.0.8  | 9.0.8   | ✓   | 6.1.0 |   ✓    |
-| `i686-pc-windows-gnu`                | N/A    | 7.5     | ✓   | N/A   |   ✓    |
-| `i686-unknown-linux-gnu`             | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `i686-unknown-linux-musl`            | 1.1.24  | 9.2.0   | ✓   | N/A   |   ✓    |
-| `mips-unknown-linux-gnu`             | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `i686-pc-windows-gnu`                | N/A    | 9.4     | ✓   | N/A   |   ✓    |
+| `i686-unknown-linux-gnu`             | 2.31   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
+| `mips-unknown-linux-musl`            | 1.1.24 | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `mips-unknown-linux-gnu`             | 2.30   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
 | `mips-unknown-linux-musl`            | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
-| `mips64-unknown-linux-gnuabi64`      | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `mips64-unknown-linux-muslabi64`     | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
-| `mips64el-unknown-linux-gnuabi64`    | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `mips64el-unknown-linux-muslabi64`   | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
-| `mipsel-unknown-linux-gnu`           | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `mipsel-unknown-linux-musl`          | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
-| `powerpc-unknown-linux-gnu`          | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `powerpc64-unknown-linux-gnu`        | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `powerpc64le-unknown-linux-gnu`      | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `riscv64gc-unknown-linux-gnu`        | 2.27   | 7.5.0   | ✓   | 6.1.0 |   ✓    |
-| `s390x-unknown-linux-gnu`            | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `sparc64-unknown-linux-gnu`          | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `mips64-unknown-linux-gnuabi64`      | 2.30   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
+| `mips64-unknown-linux-muslabi64`     | 1.1.24 | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `mips64el-unknown-linux-gnuabi64`    | 2.30   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
+| `mips64el-unknown-linux-muslabi64`   | 1.1.24 | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `mipsel-unknown-linux-gnu`           | 2.30   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
+| `mipsel-unknown-linux-musl`          | 1.1.24 | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `powerpc-unknown-linux-gnu`          | 2.31   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
+| `powerpc64-unknown-linux-gnu`        | 2.31   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
+| `powerpc64le-unknown-linux-gnu`      | 2.31   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
+| `riscv64gc-unknown-linux-gnu`        | 2.31   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
+| `s390x-unknown-linux-gnu`            | 2.31   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
+| `sparc64-unknown-linux-gnu`          | 2.31   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
 | `sparcv9-sun-solaris`                | 1.22.7 | 8.4.0   | ✓   | N/A   |       |
-| `thumbv6m-none-eabi` [4]             | 2.2.0  | 4.9.3   |     | N/A   |       |
-| `thumbv7em-none-eabi` [4]            | 2.2.0  | 4.9.3   |     | N/A   |       |
-| `thumbv7em-none-eabihf` [4]          | 2.2.0  | 4.9.3   |     | N/A   |       |
-| `thumbv7m-none-eabi` [4]             | 2.2.0  | 4.9.3   |     | N/A   |       |
+| `thumbv6m-none-eabi` [4]             | 3.3.0  | 9.2.1   |     | N/A   |       |
+| `thumbv7em-none-eabi` [4]            | 3.3.0  | 9.2.1   |     | N/A   |       |
+| `thumbv7em-none-eabihf` [4]          | 3.3.0  | 9.2.1   |     | N/A   |       |
+| `thumbv7m-none-eabi` [4]             | 3.3.0  | 9.2.1   |     | N/A   |       |
 | `thumbv7neon-linux-androideabi` [1]  | 9.0.8  | 9.0.8   | ✓   | 6.1.0 |   ✓    |
-| `thumbv7neon-unknown-linux-gnueabihf`| 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `thumbv7neon-unknown-linux-gnueabihf`| 2.31   | 9.4.0   | ✓   | N/A   |   ✓    |
 | `wasm32-unknown-emscripten` [6]        | 3.1.14 | 15.0.0  | ✓   | N/A   |   ✓    |
 | `x86_64-linux-android` [1]           | 9.0.8  | 9.0.8   | ✓   | 6.1.0 |   ✓    |
-| `x86_64-pc-windows-gnu`              | N/A    | 7.3     | ✓   | N/A   |   ✓    |
+| `x86_64-pc-windows-gnu`              | N/A    | 9.3     | ✓   | N/A   |   ✓    |
 | `x86_64-sun-solaris`                 | 1.22.7 | 8.4.0   | ✓   | N/A   |       |
 | `x86_64-unknown-freebsd`             | 1.5    | 6.4.0   | ✓   | N/A   |       |
-| `x86_64-unknown-dragonfly` [2] [3]   | 6.0.1  | 5.3.0   | ✓   | N/A   |       |
+| `x86_64-unknown-dragonfly` [2] [3]   | 6.0.1  | 10.3.0  | ✓   | N/A   |       |
 | `x86_64-unknown-illumos`             | 1.20.4 | 8.4.0   | ✓   | N/A   |       |
-| `x86_64-unknown-linux-gnu`           | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `x86_64-unknown-linux-gnu`           | 2.31   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
 | `x86_64-unknown-linux-gnu:centos` [5]  | 2.17   | 4.8.5   | ✓   | 4.2.1 |   ✓    |
-| `x86_64-unknown-linux-musl`          | 1.1.24  | 9.2.0   | ✓   | N/A   |   ✓    |
+| `x86_64-unknown-linux-musl`          | 1.1.24 | 9.2.0   | ✓   | N/A   |   ✓    |
 | `x86_64-unknown-netbsd` [3]          | 9.2.0  | 9.4.0   | ✓   | N/A   |       |
 <!--| `asmjs-unknown-emscripten` [7]       | 3.1.14 | 15.0.0  | ✓   | N/A   |   ✓    |-->
 

--- a/docker/Dockerfile.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.aarch64-unknown-linux-musl
+++ b/docker/Dockerfile.aarch64-unknown-linux-musl
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.arm-unknown-linux-gnueabi
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabi
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.arm-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabihf
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.arm-unknown-linux-musleabi
+++ b/docker/Dockerfile.arm-unknown-linux-musleabi
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.arm-unknown-linux-musleabihf
+++ b/docker/Dockerfile.arm-unknown-linux-musleabihf
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.armv5te-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-gnueabi
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.armv5te-unknown-linux-musleabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-musleabi
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabi
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.armv7-unknown-linux-musleabi
+++ b/docker/Dockerfile.armv7-unknown-linux-musleabi
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.i586-unknown-linux-gnu
+++ b/docker/Dockerfile.i586-unknown-linux-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.i586-unknown-linux-musl
+++ b/docker/Dockerfile.i586-unknown-linux-musl
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.i686-pc-windows-gnu
+++ b/docker/Dockerfile.i686-pc-windows-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.i686-unknown-freebsd
+++ b/docker/Dockerfile.i686-unknown-freebsd
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.i686-unknown-linux-gnu
+++ b/docker/Dockerfile.i686-unknown-linux-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.i686-unknown-linux-musl
+++ b/docker/Dockerfile.i686-unknown-linux-musl
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.mips-unknown-linux-gnu
+++ b/docker/Dockerfile.mips-unknown-linux-gnu
@@ -15,18 +15,12 @@ RUN apt-get install --assume-yes --no-install-recommends \
     libc6-dev-mips-cross
 
 COPY qemu.sh /
-RUN /qemu.sh mips softmmu
+RUN /qemu.sh mips
 
-COPY dropbear.sh /
-RUN /dropbear.sh
-
-COPY linux-image.sh /
-RUN /linux-image.sh mips
-
-COPY linux-runner /
+COPY qemu-runner /
 
 ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc \
-    CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner mips" \
+    CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER="/qemu-runner mips" \
     CC_mips_unknown_linux_gnu=mips-linux-gnu-gcc \
     CXX_mips_unknown_linux_gnu=mips-linux-gnu-g++ \
     BINDGEN_EXTRA_CLANG_ARGS_mips_unknown_linux_gnu="--sysroot=/usr/mips-linux-gnu" \

--- a/docker/Dockerfile.mips-unknown-linux-gnu
+++ b/docker/Dockerfile.mips-unknown-linux-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.mips-unknown-linux-musl
+++ b/docker/Dockerfile.mips-unknown-linux-musl
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.mips64-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-gnuabi64
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.mips64-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-muslabi64
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 COPY common.sh lib.sh /
 RUN /common.sh

--- a/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.mips64el-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-muslabi64
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 COPY common.sh lib.sh /
 RUN /common.sh

--- a/docker/Dockerfile.mipsel-unknown-linux-gnu
+++ b/docker/Dockerfile.mipsel-unknown-linux-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.mipsel-unknown-linux-musl
+++ b/docker/Dockerfile.mipsel-unknown-linux-musl
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.powerpc-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc-unknown-linux-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.powerpc64-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64-unknown-linux-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.powerpc64le-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64le-unknown-linux-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.riscv64gc-unknown-linux-gnu
+++ b/docker/Dockerfile.riscv64gc-unknown-linux-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.s390x-unknown-linux-gnu
+++ b/docker/Dockerfile.s390x-unknown-linux-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.sparc64-unknown-linux-gnu
+++ b/docker/Dockerfile.sparc64-unknown-linux-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.sparcv9-sun-solaris
+++ b/docker/Dockerfile.sparcv9-sun-solaris
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.thumbv6m-none-eabi
+++ b/docker/Dockerfile.thumbv6m-none-eabi
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.thumbv7em-none-eabi
+++ b/docker/Dockerfile.thumbv7em-none-eabi
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.thumbv7em-none-eabihf
+++ b/docker/Dockerfile.thumbv7em-none-eabihf
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.thumbv7m-none-eabi
+++ b/docker/Dockerfile.thumbv7m-none-eabi
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.thumbv7neon-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.thumbv7neon-unknown-linux-gnueabihf
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.x86_64-pc-windows-gnu
+++ b/docker/Dockerfile.x86_64-pc-windows-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.x86_64-sun-solaris
+++ b/docker/Dockerfile.x86_64-sun-solaris
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.x86_64-unknown-dragonfly
+++ b/docker/Dockerfile.x86_64-unknown-dragonfly
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.x86_64-unknown-freebsd
+++ b/docker/Dockerfile.x86_64-unknown-freebsd
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.x86_64-unknown-linux-gnu
+++ b/docker/Dockerfile.x86_64-unknown-linux-gnu
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/Dockerfile.x86_64-unknown-linux-gnu.centos
+++ b/docker/Dockerfile.x86_64-unknown-linux-gnu.centos
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY lib.sh /

--- a/docker/Dockerfile.x86_64-unknown-netbsd
+++ b/docker/Dockerfile.x86_64-unknown-netbsd
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/dragonfly.sh
+++ b/docker/dragonfly.sh
@@ -10,14 +10,14 @@ main() {
     local nproc=
     local binutils=2.32 \
           dragonfly=6.0.1_REL \
-          gcc=5.3.0 \
+          gcc=10.3.0 \
           target=x86_64-unknown-dragonfly \
           url="https://mirror-master.dragonflybsd.org/iso-images"
     if [[ $# != "0" ]]; then
         nproc="${1}"
     fi
 
-    install_packages bsdtar \
+    install_packages libarchive-tools \
         bzip2 \
         ca-certificates \
         curl \
@@ -42,47 +42,11 @@ main() {
     cd gcc
     sed -i -e 's/ftp:/https:/g' ./contrib/download_prerequisites
     ./contrib/download_prerequisites
-    patch -p0 <<'EOF'
---- libatomic/configure.tgt.orig   2015-07-09 16:08:55 UTC
-+++ libatomic/configure.tgt
-@@ -110,7 +110,7 @@ case "${target}" in
-   ;;
-
-   *-*-linux* | *-*-gnu* | *-*-k*bsd*-gnu \
--  | *-*-netbsd* | *-*-freebsd* | *-*-openbsd* \
-+  | *-*-netbsd* | *-*-freebsd* | *-*-openbsd* | *-*-dragonfly* \
-   | *-*-solaris2* | *-*-sysv4* | *-*-irix6* | *-*-osf* | *-*-hpux11* \
-   | *-*-darwin* | *-*-aix* | *-*-cygwin*)
-   # POSIX system.  The OS is supported.
-EOF
-
-    patch -p0 <<'EOF'
---- libstdc++-v3/config/os/bsd/dragonfly/os_defines.h.orig  2015-07-09 16:08:54 UTC
-+++ libstdc++-v3/config/os/bsd/dragonfly/os_defines.h
-@@ -29,4 +29,9 @@
- // System-specific #define, typedefs, corrections, etc, go here.  This
- // file will come before all others.
-
-+#define _GLIBCXX_USE_C99_CHECK 1
-+#define _GLIBCXX_USE_C99_DYNAMIC (!(__ISO_C_VISIBLE >= 1999))
-+#define _GLIBCXX_USE_C99_LONG_LONG_CHECK 1
-+#define _GLIBCXX_USE_C99_LONG_LONG_DYNAMIC (_GLIBCXX_USE_C99_DYNAMIC || !defined __LONG_LONG_SUPPORTED)
-+
- #endif
-EOF
-
-    patch -p0 <<'EOF'
---- libstdc++-v3/configure.orig    2016-05-26 18:34:47.163132921 +0200
-+++ libstdc++-v3/configure 2016-05-26 18:35:29.594590648 +0200
-@@ -52013,7 +52013,7 @@
-
-     ;;
-
--  *-freebsd*)
-+  *-freebsd* | *-dragonfly*)
-     SECTION_FLAGS='-ffunction-sections -fdata-sections'
-
-
+    patch libstdc++-v3/configure <<'EOF'
+47159c47159
+<   *-freebsd*)
+---
+>   *-freebsd* | *-dragonfly*)
 EOF
     cd ..
 

--- a/docker/mingw.sh
+++ b/docker/mingw.sh
@@ -34,7 +34,7 @@ main() {
     pushd gcc-mingw-w64-*
 
     # We are using dwarf exceptions instead of sjlj
-    sed -i -e 's/libgcc_s_sjlj-1/libgcc_s_dw2-1/g' debian/gcc-mingw-w64-i686.install
+    sed -i -e 's/libgcc_s_sjlj-1/libgcc_s_dw2-1/g' debian/gcc-mingw-w64-i686.install.in
 
     # Only build i686 packages (disable x86_64)
     patch -p0 <<'EOF'
@@ -96,7 +96,7 @@ EOF
  threads := posix win32
 
  # Hardening on the host, none on the target
-@@ -216,6 +216,10 @@
+@@ -220,6 +220,10 @@
  # Enable libatomic
  CONFFLAGS += \
  	--enable-libatomic
@@ -104,10 +104,15 @@ EOF
 +CONFFLAGS += \
 +	--disable-sjlj-exceptions \
 +	--with-dwarf2
- # Enable experimental::filesystem
+ # Enable experimental::filesystem and std::filesystem
  CONFFLAGS += \
  	--enable-libstdcxx-filesystem-ts=yes
 EOF
+
+    # Need symlinks for specific autoconf versions, since it
+    # attempts to use autoconf2.69 and autom4te2.69.
+    ln -s /usr/bin/autoconf /usr/bin/autoconf2.69
+    ln -s /usr/bin/autom4te /usr/bin/autom4te2.69
 
     # Build the modified mingw packages
     MAKEFLAGS=--silent dpkg-buildpackage -nc -B --jobs=auto
@@ -122,6 +127,10 @@ EOF
 
     rm -rf "${td}"
     rm "${0}"
+
+    # Unlink our temporary aliases
+    unlink /usr/bin/autoconf2.69
+    unlink /usr/bin/autom4te2.69
 }
 
 main "${@}"

--- a/docker/solaris.sh
+++ b/docker/solaris.sh
@@ -16,7 +16,9 @@ main() {
     install_packages bzip2 \
         ca-certificates \
         curl \
+        dirmngr \
         g++ \
+        gpg-agent \
         make \
         patch \
         software-properties-common \

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -25,7 +25,7 @@ pub use super::custom::CROSS_CUSTOM_DOCKERFILE_IMAGE_PREFIX;
 
 pub const CROSS_IMAGE: &str = "ghcr.io/cross-rs";
 // note: this is the most common base image for our images
-pub const UBUNTU_BASE: &str = "ubuntu:16.04";
+pub const UBUNTU_BASE: &str = "ubuntu:20.04";
 
 // secured profile based off the docker documentation for denied syscalls:
 // https://docs.docker.com/engine/security/seccomp/#significant-syscalls-blocked-by-the-default-profile


### PR DESCRIPTION
Increment Ubuntu base image versions to 20.04.

Update linux-image script to latest kernel and debian versions.

Update by default to kernel version 5.10.0-8. This means updating our debian source to bullseye from buster. 32-bit big-endian mips was discontinued in bullseye, so we revert to buster. For some images, due to constantly updating linux kernel versions, we need to use wildcards otherwise the build step breaks. Since there may be more than one relevant package, we've added a function to manually expand wildcards and select the best kernel version, `max_kernel_version`. Likewise, on 32-bit big-endian mips, we need to specify the ncurses version.

Created temporary symlinks for autconf and autom4te due to the build expecting a hard-coded version (2.69) of these binaries. Fixed the patch for `debian/rules` due to changed line numbers. Updated the patch to use dwarf rather than sjlj exceptions to patch the template file (`debian/gcc-mingw-w64-i686.install.in`) since `debian/gcc-mingw-w64-i686.install` is overwritten during the build.

For `x86_64-unknown-linux-gnu`, building the linux image fails unless we download specific versions of `libgcc-s1` and `libstdc++6`, since the pre-installed Ubuntu versions are higher than the Debian versions. We therefore extract the specific versions. However, while building the linux image, it prefers these system versions, so we must uninstall them or else while running `qemu-system` it cannot find `libgcc_s1.so.1`. Since `apt` and basically every other package besides `dpkg` relies on `libgcc-s1`, we have to temporarily delete it and reinstall it.

Closes #616.
Closes #557. We've already addressed the Qemu fixes, which will be applied automatically.
Closes #517.
Closes #417.

Replaces #481.