### PR TITLE
Ensure apt-get update is run during Docker builds.

### DIFF
--- a/docker/Dockerfile.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-aarch64-linux-gnu \
     libc6-dev-arm64-cross
 

--- a/docker/Dockerfile.arm-unknown-linux-gnueabi
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabi
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY qemu.sh /
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-arm-linux-gnueabi \
     libc6-dev-armel-cross && \
     /qemu.sh arm

--- a/docker/Dockerfile.armv5te-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-gnueabi
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY qemu.sh /
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-arm-linux-gnueabi \
     crossbuild-essential-armel \
     libc6-dev-armel-cross && \

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-arm-linux-gnueabihf \
     libc6-dev-armhf-cross
 

--- a/docker/Dockerfile.asmjs-unknown-emscripten
+++ b/docker/Dockerfile.asmjs-unknown-emscripten
@@ -23,7 +23,7 @@ ENV PATH="${EMSDK}:${EMSDK}/emscripten/sdk:${EMSDK}/llvm/clang/bin:${EMSDK}/node
 
 ENTRYPOINT ["/emsdk_portable/entrypoint"]
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get update && apt-get install --assume-yes --no-install-recommends \
   libxml2 \
   python
 

--- a/docker/Dockerfile.i586-unknown-linux-gnu
+++ b/docker/Dockerfile.i586-unknown-linux-gnu
@@ -9,5 +9,5 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-multilib

--- a/docker/Dockerfile.i686-unknown-linux-gnu
+++ b/docker/Dockerfile.i686-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-multilib
 
 COPY qemu.sh /

--- a/docker/Dockerfile.mips64-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-gnuabi64
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY qemu.sh /
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-mips64-linux-gnuabi64 \
     libc6-dev-mips64-cross && \
     /qemu.sh mips64

--- a/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-mips64el-linux-gnuabi64 \
     libc6-dev-mips64el-cross
 

--- a/docker/Dockerfile.mipsel-unknown-linux-gnu
+++ b/docker/Dockerfile.mipsel-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-mipsel-linux-gnu \
     libc6-dev-mipsel-cross
 

--- a/docker/Dockerfile.powerpc-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-powerpc-linux-gnu \
     libc6-dev-powerpc-cross
 

--- a/docker/Dockerfile.powerpc64-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-powerpc64-linux-gnu \
     libc6-dev-ppc64-cross
 

--- a/docker/Dockerfile.powerpc64le-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64le-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-powerpc64le-linux-gnu \
     libc6-dev-ppc64el-cross
 

--- a/docker/Dockerfile.riscv64gc-unknown-linux-gnu
+++ b/docker/Dockerfile.riscv64gc-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /common.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     g++-riscv64-linux-gnu \
     libc6-dev-riscv64-cross
 

--- a/docker/Dockerfile.s390x-unknown-linux-gnu
+++ b/docker/Dockerfile.s390x-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-s390x-linux-gnu \
     libc6-dev-s390x-cross
 

--- a/docker/Dockerfile.sparc64-unknown-linux-gnu
+++ b/docker/Dockerfile.sparc64-unknown-linux-gnu
@@ -9,7 +9,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-sparc64-linux-gnu \
     libc6-dev-sparc64-cross
 

--- a/docker/Dockerfile.thumbv6m-none-eabi
+++ b/docker/Dockerfile.thumbv6m-none-eabi
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY qemu.sh /
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi && \
     /qemu.sh arm

--- a/docker/Dockerfile.thumbv7em-none-eabi
+++ b/docker/Dockerfile.thumbv7em-none-eabi
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY qemu.sh /
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi && \
     /qemu.sh arm

--- a/docker/Dockerfile.thumbv7em-none-eabihf
+++ b/docker/Dockerfile.thumbv7em-none-eabihf
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY qemu.sh /
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi && \
     /qemu.sh arm

--- a/docker/Dockerfile.thumbv7m-none-eabi
+++ b/docker/Dockerfile.thumbv7m-none-eabi
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY qemu.sh /
-RUN apt-get install --assume-yes --no-install-recommends \
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi && \
     /qemu.sh arm

--- a/docker/Dockerfile.x86_64-pc-windows-gnu
+++ b/docker/Dockerfile.x86_64-pc-windows-gnu
@@ -16,7 +16,7 @@ RUN dpkg --add-architecture i386 && apt-get update && \
         wine32 \
         libz-mingw-w64-dev
 
-RUN apt-get install --assume-yes --no-install-recommends g++-mingw-w64-x86-64
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends g++-mingw-w64-x86-64
 
 # run-detectors are responsible for calling the correct interpreter for exe
 # files. For some reason it does not work inside a docker container (it works


### PR DESCRIPTION
Fixed #590, by preventing caching of layers which can prevent builds
from completing when a step fails, causing the package repository to
become out-of-date and the install step to fail.