### PR TITLE
Add support for `CROSS_CONFIG` environment var

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ $ cross rustc --target powerpc-unknown-linux-gnu --release -- -C lto
 
 ## Configuration
 
-You can place a `Cross.toml` file in the root of your Cargo project to tweak
-`cross`'s behavior:
+You can place a `Cross.toml` file in the root of your Cargo project or use a
+`CROSS_CONFIG` environment variable to tweak `cross`'s behavior:
 
 ### Custom Docker images
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod rustc;
 mod rustup;
 
 use std::io::Write;
+use std::path::PathBuf;
 use std::process::ExitStatus;
 use std::{env, io, process};
 
@@ -525,9 +526,13 @@ impl Toml {
     }
 }
 
-/// Parses the `Cross.toml` at the root of the Cargo project (if any)
+/// Parses the `Cross.toml` at the root of the Cargo project or from the
+/// `CROSS_CONFIG` environment variable (if any exist in either location).
 fn toml(root: &Root) -> Result<Option<Toml>> {
-    let path = root.path().join("Cross.toml");
+    let path = match env::var("CROSS_CONFIG") {
+        Ok(var) => PathBuf::from(var),
+        Err(_) => root.path().join("Cross.toml")
+    };
 
     if path.exists() {
         Ok(Some(Toml {


### PR DESCRIPTION
This allows for the use of a `CROSS_CONFIG` environment variable to explicitly set the path to a `Cross.toml` file to use for builds.