### PR TITLE
Build binary crate in CI test with nightly as well as stable

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -88,6 +88,8 @@ EOF
         cargo init --bin --name hello .
         retry cargo fetch
         cross build --target "${TARGET}"
+        echo nightly > rust-toolchain
+        cross build --target "${TARGET}"
         popd
 
         rm -rf "${td}"


### PR DESCRIPTION
Hopefully this isn't a completely silly idea :) but I wonder if (in connection with #598) building with nightly as part of CI makes sense? This PR makes an extremely small change to `test.sh` which should (?) build the binary `hello` crate both with stable and nightly toolchains.