### PR TITLE
Warn user if there's a file cross.toml with wrong capitalization

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -538,6 +538,10 @@ fn toml(root: &Root) -> Result<Option<Toml>> {
             },
         }))
     } else {
+        // Let's check if there is a lower case version of the file
+        if root.path().join("cross.toml").exists() {
+            eprintln!("There's a file named cross.toml, instead of Cross.toml. You may want to rename it, or it won't be considered.");
+        }
         Ok(None)
     }
 }


### PR DESCRIPTION
I've lost some good days struggling with errors because I've created a file named cross.toml and it wouldn't affect the build, because the name was not capitalized correctly. So, I think it should be cool if cross could warn the user if there's a file with a capitalization problem present on the project root.