### PR TITLE
add clang as a common build tool

### DIFF
--- a/docker/common.sh
+++ b/docker/common.sh
@@ -19,6 +19,7 @@ install_packages \
     automake \
     binutils \
     ca-certificates \
+    clang \
     curl \
     file \
     gcc \

--- a/docker/common.sh
+++ b/docker/common.sh
@@ -24,11 +24,11 @@ install_packages \
     gcc \
     git \
     libtool \
-    libclang-dev \
     m4 \
     make
 
 if_centos install_packages \
+    clang \
     gcc-c++ \
     glibc-devel \
     pkgconfig
@@ -36,4 +36,5 @@ if_centos install_packages \
 if_ubuntu install_packages \
     g++ \
     libc6-dev \
+    libclang-dev \
     pkg-config

--- a/docker/common.sh
+++ b/docker/common.sh
@@ -19,12 +19,12 @@ install_packages \
     automake \
     binutils \
     ca-certificates \
-    clang \
     curl \
     file \
     gcc \
     git \
     libtool \
+    libclang-dev \
     m4 \
     make
 

--- a/docker/common.sh
+++ b/docker/common.sh
@@ -28,7 +28,7 @@ install_packages \
     make
 
 if_centos install_packages \
-    clang \
+    clang-devel \
     gcc-c++ \
     glibc-devel \
     pkgconfig


### PR DESCRIPTION
Closes #174

This PR adds clang as a common build tool.
The libclang will be used by bindgen so It's better to have clang on all platforms so I add to common.sh

This works for bindgen for the following targets with `ffmpeg-next` of `libavformat`, `libavcodec`, and `libavutil`  with my built ffmpeg binaries:
- `x86_64-pc-windows-gnu`
- `x86_64-unknown-linux-musl`

I couldn't test `x86_64-unknown-linux-gnu` because of #455

<details>
<summary>#455 error message. This will be happened without this PR (with the image from DockerHub)</summary>

```
   Compiling libc v0.2.107
   Compiling ffmpeg-sys-next v4.4.0
error: failed to run custom build command for `libc v0.2.107`

Caused by:
  process didn't exit successfully: `/target/release/build/libc-e4387d0c49bcd20f/build-script-build` (exit status: 1)
  --- stderr
  /target/release/build/libc-e4387d0c49bcd20f/build-script-build: /lib64/libc.so.6: version `GLIBC_2.18' not found (required by /target/release/build/libc-e4387d0c49bcd20f/build-script-build)
warning: build failed, waiting for other jobs to finish...
error: build failed
```

</details>
