### PR TITLE
freebsd: include libkvm in build image

### DIFF
--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -71,6 +71,7 @@ main() {
     cp -r "${td}/freebsd/usr/include" "${destdir}"
     cp "${td}/freebsd/lib/libc.so.7" "${destdir}/lib"
     cp "${td}/freebsd/lib/libm.so.5" "${destdir}/lib"
+    cp "${td}/freebsd/lib/libkvm.so.7" "${destdir}/lib"
     cp "${td}/freebsd/lib/libthr.so.3" "${destdir}/lib"
     cp "${td}/freebsd/lib/libutil.so.9" "${destdir}/lib"
     cp "${td}/freebsd/lib/libssp.so.0" "${destdir}/lib"
@@ -79,6 +80,7 @@ main() {
     cp "${td}/freebsd/usr/lib"/lib{c,util,m,ssp,ssp_nonshared}.a "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/lib{rt,execinfo,procstat}.so.1 "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/{crt1,Scrt1,crti,crtn}.o "${destdir}/lib"
+    cp "${td}/freebsd/usr/lib"/libkvm.a "${destdir}/lib"
 
     ln -s libc.so.7 "${destdir}/lib/libc.so"
     ln -s libc++.so.1 "${destdir}/lib/libc++.so"
@@ -89,6 +91,7 @@ main() {
     ln -s libutil.so.9 "${destdir}/lib/libutil.so"
     ln -s libthr.so.3 "${destdir}/lib/libpthread.so"
     ln -s libssp.so.0 "${destdir}/lib/libssp.so"
+    ln -s libkvm.so.7 "${destdir}/lib/libkvm.so"
 
     cd gcc-build
     ../gcc/configure \


### PR DESCRIPTION
Cross builds targeting FreeBSD currently fail for projects depending on version 0.2.105+ of the libc crate due to a new dependency on libkvm, introduced here: https://github.com/rust-lang/libc/commit/9ab890d42b8435517369320ae6a259386049917a#diff-75cac48df6376b0d5783bc764c591d1a896a92429653beda3f0b3e93aa8c339fR290

The compilation error looks like:

```
error: linking with `x86_64-unknown-freebsd12-gcc` failed: exit status: 1
...
  = note: /usr/local/lib/gcc/x86_64-unknown-freebsd12/6.4.0/../../../../x86_64-unknown-freebsd12/bin/ld: cannot find -lkvm
          collect2: error: ld returned 1 exit status
```

This PR adds the static and shared libkvm binaries to the build image to resolve this issue.
