### PR TITLE
freebsd: Include libdevstat in build image

### DIFF
--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -74,6 +74,7 @@ main() {
     cp "${td}/freebsd/lib/libthr.so.3" "${destdir}/lib"
     cp "${td}/freebsd/lib/libutil.so.9" "${destdir}/lib"
     cp "${td}/freebsd/lib/libssp.so.0" "${destdir}/lib"
+    cp "${td}/freebsd/lib/libdevstat.so.7" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib/libc++.so.1" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib/libc++.a" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/lib{c,util,m,ssp,ssp_nonshared}.a "${destdir}/lib"
@@ -89,6 +90,7 @@ main() {
     ln -s libutil.so.9 "${destdir}/lib/libutil.so"
     ln -s libthr.so.3 "${destdir}/lib/libpthread.so"
     ln -s libssp.so.0 "${destdir}/lib/libssp.so"
+    ln -s libdevstat.so.7 "${destdir}/lib/libdevstat.so"
 
     cd gcc-build
     ../gcc/configure \


### PR DESCRIPTION
Similar to https://github.com/rust-embedded/cross/pull/613 include libdevstat seems to be required by the libc crate now too. Probably due to https://github.com/rust-lang/libc/commit/ac6e16b90fd36775341724cf0c6b00b4c8d33d60
