### PR TITLE
Allow setting default build target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- #624 - Add `build.default-target`
 - #670 - Use serde for deserialization of Cross.toml
 - Change rust edition to 2021 and bump MSRV for the cross binary to 1.58.1
 - #654 - Use color-eyre for error reporting

--- a/docs/cross_toml.md
+++ b/docs/cross_toml.md
@@ -6,6 +6,7 @@ The `build` key allows you to set global variables, e.g.:
 ```toml
 [build]
 xargo = true
+default-target = "x86_64-unknown-linux-gnu"
 ```
 
 # `build.env`

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::{CrossToml, Result, Target};
+use crate::{CrossToml, Result, Target, TargetList};
 
 use crate::errors::*;
 use std::collections::HashMap;
@@ -181,6 +181,10 @@ impl Config {
         Ok(collected)
     }
 
+    pub fn target(&self, _target_list: &TargetList) -> Option<Target> {
+        None
+    }
+
     fn sum_of_env_toml_values(
         toml_getter: impl FnOnce() -> Option<Vec<String>>,
         env_values: Option<Vec<String>>,
@@ -201,11 +205,17 @@ mod tests {
     use super::*;
     use crate::{Target, TargetList};
 
-    fn target() -> Target {
-        let target_list = TargetList {
-            triples: vec!["aarch64-unknown-linux-gnu".to_string()],
-        };
+    fn target_list() -> TargetList {
+        TargetList {
+            triples: vec![
+                "aarch64-unknown-linux-gnu".to_string(),
+                "armv7-unknown-linux-musleabihf".to_string(),
+            ],
+        }
+    }
 
+    fn target() -> Target {
+        let target_list = target_list();
         Target::from("aarch64-unknown-linux-gnu", &target_list)
     }
 
@@ -345,6 +355,15 @@ mod tests {
             assert!(result.len() == 2);
             assert!(result.contains(&expected[0]));
             assert!(result.contains(&expected[1]));
+
+            Ok(())
+        }
+
+        #[test]
+        pub fn no_env_and_no_toml_default_target_then_none() -> Result<()> {
+            let config = Config::new_with(None, Environment::new(None));
+            let config_target = config.target(&target_list());
+            assert!(matches!(config_target, None));
 
             Ok(())
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -189,7 +189,7 @@ impl Config {
         if let Some(env_value) = self.env.target() {
             return Some(Target::from(&env_value, target_list));
         }
-        None
+        self.toml.as_ref().map_or(None, |t| t.target(target_list))
     }
 
     fn sum_of_env_toml_values(
@@ -386,6 +386,20 @@ mod tests {
             assert!(matches!(
                 config_target.triple(),
                 "armv7-unknown-linux-musleabihf"
+            ));
+
+            Ok(())
+        }
+
+        #[test]
+        pub fn no_env_but_toml_default_target_then_use_toml() -> Result<()> {
+            let env = Environment::new(None);
+            let config = Config::new_with(Some(toml(TOML_DEFAULT_TARGET)?), env);
+
+            let config_target = config.target(&target_list()).unwrap();
+            assert!(matches!(
+                config_target.triple(),
+                "aarch64-unknown-linux-gnu"
             ));
 
             Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -189,7 +189,9 @@ impl Config {
         if let Some(env_value) = self.env.target() {
             return Some(Target::from(&env_value, target_list));
         }
-        self.toml.as_ref().map_or(None, |t| t.target(target_list))
+        self.toml
+            .as_ref()
+            .and_then(|t| t.default_target(target_list))
     }
 
     fn sum_of_env_toml_values(
@@ -424,7 +426,7 @@ mod tests {
 
         static TOML_DEFAULT_TARGET: &str = r#"
     [build]
-    target = "aarch64-unknown-linux-gnu"
+    default-target = "aarch64-unknown-linux-gnu"
     "#;
     }
 }

--- a/src/cross_toml.rs
+++ b/src/cross_toml.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../docs/cross_toml.md")]
 
 use crate::errors::*;
-use crate::Target;
+use crate::{Target, TargetList};
 use serde::Deserialize;
 use std::collections::HashMap;
 
@@ -91,6 +91,11 @@ impl CrossToml {
             .map_or(Vec::new(), |t| t.volumes.clone())
     }
 
+    /// Returns the default target to build,
+    pub fn target(&self, target_list: &TargetList) -> Option<Target> {
+        self.build.as_ref().and_then(|b| b.target.as_ref()).map(|t| Target::from(t, target_list))
+    }
+
     /// Returns a reference to the [`CrossTargetConfig`] of a specific `target`
     fn get_target(&self, target: &Target) -> Option<&CrossTargetConfig> {
         self.targets.get(target)
@@ -136,7 +141,7 @@ mod tests {
         let test_str = r#"
           [build]
           xargo = true
- 
+
           [build.env]
           volumes = ["VOL1_ARG", "VOL2_ARG"]
           passthrough = ["VAR1", "VAR2"]

--- a/src/cross_toml.rs
+++ b/src/cross_toml.rs
@@ -16,10 +16,11 @@ pub struct CrossBuildEnvConfig {
 
 /// Build configuration
 #[derive(Debug, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "kebab-case")]
 pub struct CrossBuildConfig {
     env: Option<CrossBuildEnvConfig>,
     xargo: Option<bool>,
-    target: Option<String>,
+    default_target: Option<String>,
 }
 
 /// Target configuration
@@ -92,8 +93,11 @@ impl CrossToml {
     }
 
     /// Returns the default target to build,
-    pub fn target(&self, target_list: &TargetList) -> Option<Target> {
-        self.build.as_ref().and_then(|b| b.target.as_ref()).map(|t| Target::from(t, target_list))
+    pub fn default_target(&self, target_list: &TargetList) -> Option<Target> {
+        self.build
+            .as_ref()
+            .and_then(|b| b.default_target.as_ref())
+            .map(|t| Target::from(t, target_list))
     }
 
     /// Returns a reference to the [`CrossTargetConfig`] of a specific `target`
@@ -134,7 +138,7 @@ mod tests {
                     passthrough: vec!["VAR1".to_string(), "VAR2".to_string()],
                 }),
                 xargo: Some(true),
-                target: None,
+                default_target: None,
             }),
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,14 +270,14 @@ fn run() -> Result<ExitStatus> {
         rustc_version::version_meta().wrap_err("couldn't fetch the `rustc` version")?;
     if let Some(root) = cargo::root()? {
         let host = version_meta.host();
+        let toml = toml(&root)?;
+        let config = Config::new(toml);
+        let target = args
+            .target
+            .or(config.target(&target_list))
+            .unwrap_or_else(|| Target::from(host.triple(), &target_list));
 
-        if host.is_supported(args.target.as_ref()) {
-            let target = args
-                .target
-                .unwrap_or_else(|| Target::from(host.triple(), &target_list));
-            let toml = toml(&root)?;
-            let config = Config::new(toml);
-
+        if host.is_supported(Some(&target)) {
             let mut sysroot = rustc::sysroot(&host, &target, verbose)?;
             let default_toolchain = sysroot
                 .file_name()
@@ -353,6 +353,12 @@ fn run() -> Result<ExitStatus> {
                     }
                 }
                 filtered_args
+            // Make sure --target is present
+            } else if !args.all.iter().any(|a| a.starts_with("--target")) {
+                let mut args_with_target = args.all.clone();
+                args_with_target.push("--target".to_string());
+                args_with_target.push(target.triple().to_string());
+                args_with_target
             } else {
                 args.all.clone()
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,7 +274,7 @@ fn run() -> Result<ExitStatus> {
         let config = Config::new(toml);
         let target = args
             .target
-            .or(config.target(&target_list))
+            .or_else(|| config.target(&target_list))
             .unwrap_or_else(|| Target::from(host.triple(), &target_list));
 
         if host.is_supported(Some(&target)) {

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -7,6 +7,7 @@ use crate::errors::*;
 use crate::extensions::CommandExt;
 use crate::{Host, Target};
 
+#[derive(Debug)]
 pub struct TargetList {
     pub triples: Vec<String>,
 }


### PR DESCRIPTION
This implements #368 

This feature allows to specify the default target to build either in `Cross.toml`

```toml
[build]
target = "aarch64-unknown-linux-gnu"
```
or by setting `CROSS_BUILD_TARGET` to avoid the need to always specify `--target`.

I've opted for `build.target` as this resembles the configuration of [cargo](https://doc.rust-lang.org/cargo/reference/config.html#buildtarget).