### PR TITLE
Download ssh deps over http, allow passing in credentials

### DIFF
--- a/docker/common.sh
+++ b/docker/common.sh
@@ -36,3 +36,13 @@ if_ubuntu install_packages \
     g++ \
     libc6-dev \
     pkg-config
+
+# Allow for passing in git credentials via environment variable in the format described here https://git-scm.com/docs/git-credential-store#_storage_format
+cat <<'EOF' >/usr/local/bin/git_env_credential
+#!/bin/bash
+echo url=$GIT_CREDENTIALS
+EOF
+
+chmod +x /usr/local/bin/git_env_credential
+git config --system credential.helper "/usr/local/bin/git_env_credential"
+git config --system url."https://".insteadOf ssh://git@


### PR DESCRIPTION
This is an attempt to deal with #401 by creating a thin credential wrapper (https://git-scm.com/docs/git-credential-store#_storage_format) that uses the `GIT_CREDENTIALS` environment variable. Then it rewrites any ssh dependencies (which wouldn't have worked anyway) with their https equivalent. I've tested this as working on a project of mine with the following `Cross.toml` and `GIT_CREDENTIALS=https://aig787:<github personal access token>@github.com`

```toml
[build.env]
passthrough = [
    "GIT_CREDENTIALS",
    "CARGO_NET_GIT_FETCH_WITH_CLI"
]
```

I put it here because it's where git gets installed, but it should be easy to move it elsewhere if there's a better fit.