### PR TITLE
Update Android NDK version and API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- #629 - Update Android NDK version and API version
 - #681 - Warn on unknown fields and confusable targets
 - #665 - when not using [env.volumes](https://github.com/cross-rs/cross#mounting-volumes-into-the-build-environment), mount project in /project
 - #624 - Add `build.default-target`

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -144,7 +144,7 @@ EOF
     if (( ${CPP:-0} )); then
         td="$(mktemp -d)"
 
-        git clone --depth 1 https://github.com/dalance/hellopp -b update_cc "${td}"
+        git clone --depth 1 https://github.com/cross-rs/rust-cpp-hello-word "${td}"
 
         pushd "${td}"
         cargo update -p gcc

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -147,7 +147,6 @@ EOF
         git clone --depth 1 https://github.com/cross-rs/rust-cpp-hello-word "${td}"
 
         pushd "${td}"
-        cargo update -p gcc
         retry cargo fetch
         if (( ${RUN:-0} )); then
             cross_run --target "${TARGET}"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -144,7 +144,7 @@ EOF
     if (( ${CPP:-0} )); then
         td="$(mktemp -d)"
 
-        git clone --depth 1 https://github.com/japaric/hellopp "${td}"
+        git clone --depth 1 https://github.com/dalance/hellopp -b update_cc "${td}"
 
         pushd "${td}"
         cargo update -p gcc

--- a/docker/Dockerfile.aarch64-linux-android
+++ b/docker/Dockerfile.aarch64-linux-android
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh arm64 21
+RUN /android-ndk.sh arm64 28
 ENV PATH=$PATH:/android-ndk/bin
 
 COPY android-system.sh /
@@ -19,7 +19,7 @@ RUN /android-system.sh arm64
 COPY qemu.sh /
 RUN /qemu.sh aarch64
 
-RUN cp /android-ndk/sysroot/usr/lib/libz.so /system/lib/
+RUN cp /android-ndk/sysroot/usr/lib/aarch64-linux-android/28/libz.so /system/lib/
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT

--- a/docker/Dockerfile.arm-linux-androideabi
+++ b/docker/Dockerfile.arm-linux-androideabi
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh arm 21
+RUN /android-ndk.sh arm 28
 ENV PATH=$PATH:/android-ndk/bin
 
 COPY android-system.sh /
@@ -19,7 +19,7 @@ RUN /android-system.sh arm
 COPY qemu.sh /
 RUN /qemu.sh arm
 
-RUN cp /android-ndk/sysroot/usr/lib/libz.so /system/lib/
+RUN cp /android-ndk/sysroot/usr/lib/arm-linux-androideabi/28/libz.so /system/lib/
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT

--- a/docker/Dockerfile.armv7-linux-androideabi
+++ b/docker/Dockerfile.armv7-linux-androideabi
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh arm 21
+RUN /android-ndk.sh arm 28
 ENV PATH=$PATH:/android-ndk/bin
 
 COPY android-system.sh /
@@ -19,7 +19,7 @@ RUN /android-system.sh arm
 COPY qemu.sh /
 RUN /qemu.sh arm
 
-RUN cp /android-ndk/sysroot/usr/lib/libz.so /system/lib/
+RUN cp /android-ndk/sysroot/usr/lib/arm-linux-androideabi/28/libz.so /system/lib/
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT

--- a/docker/Dockerfile.i686-linux-android
+++ b/docker/Dockerfile.i686-linux-android
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh x86 21
+RUN /android-ndk.sh x86 28
 ENV PATH=$PATH:/android-ndk/bin
 
 COPY android-system.sh /
@@ -26,7 +26,7 @@ RUN /android-system.sh x86
 COPY qemu.sh /
 RUN /qemu.sh i386
 
-RUN cp /android-ndk/sysroot/usr/lib/libz.so /system/lib/
+RUN cp /android-ndk/sysroot/usr/lib/i686-linux-android/28/libz.so /system/lib/
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT

--- a/docker/Dockerfile.x86_64-linux-android
+++ b/docker/Dockerfile.x86_64-linux-android
@@ -10,7 +10,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh x86_64 21
+RUN /android-ndk.sh x86_64 28
 ENV PATH=$PATH:/android-ndk/bin
 
 COPY android-system.sh /
@@ -20,7 +20,7 @@ RUN /android-system.sh x86_64
 COPY qemu.sh /
 RUN /qemu.sh x86_64
 
-RUN cp /android-ndk/sysroot/usr/lib/libz.so /system/lib/
+RUN cp /android-ndk/sysroot/usr/lib/x86_64-linux-android/28/libz.so /system/lib/
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT

--- a/docker/android-ndk.sh
+++ b/docker/android-ndk.sh
@@ -3,7 +3,7 @@
 set -x
 set -euo pipefail
 
-NDK_URL=https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip
+NDK_URL=https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip
 
 main() {
     local arch="${1}" \

--- a/docker/android-system.sh
+++ b/docker/android-system.sh
@@ -15,10 +15,13 @@ main() {
         gcc-multilib
         git
         g++-multilib
+        libncurses5
+        libtinfo5
         make
         openssh-client
         python
         python3
+        xz-utils
     )
 
     # fake java and javac, it is not necessary for what we build, but the build
@@ -57,41 +60,78 @@ EOF
 
     # this is the minimum set of modules that are need to build bionic
     # this was created by trial and error
-    python3 ./repo init -u https://android.googlesource.com/platform/manifest -b android-5.0.0_r1
+    python3 ./repo init -u https://android.googlesource.com/platform/manifest -b android-9.0.0_r1
+
+    python3 ./repo sync -c art
     python3 ./repo sync -c bionic
-    python3 ./repo sync -c build
+    python3 ./repo sync -c build/make
+    python3 ./repo sync -c build/blueprint
+    python3 ./repo sync -c build/soong
+    python3 ./repo sync -c external/clang
     python3 ./repo sync -c external/compiler-rt
+    python3 ./repo sync -c external/elfutils
     python3 ./repo sync -c external/jemalloc
     python3 ./repo sync -c external/libcxx
     python3 ./repo sync -c external/libcxxabi
-    python3 ./repo sync -c external/libselinux
+    python3 ./repo sync -c external/libunwind
+    python3 ./repo sync -c external/libunwind_llvm
+    python3 ./repo sync -c external/llvm
+    python3 ./repo sync -c external/lzma
     python3 ./repo sync -c external/mksh
-    python3 ./repo sync -c external/openssl
-    python3 ./repo sync -c external/stlport
-    python3 ./repo sync -c prebuilts/clang/linux-x86/host/3.5
+    python3 ./repo sync -c external/safe-iop
+    python3 ./repo sync -c external/valgrind
+    python3 ./repo sync -c external/vixl
+    python3 ./repo sync -c external/zlib
+    python3 ./repo sync -c frameworks/hardware/interfaces
+    python3 ./repo sync -c hardware/interfaces
+    python3 ./repo sync -c libnativehelper
+    python3 ./repo sync -c prebuilts/build-tools
+    python3 ./repo sync -c prebuilts/clang/host/linux-x86
+    python3 ./repo sync -c prebuilts/clang-tools
+    #python3 ./repo sync -c prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9
+    #python3 ./repo sync -c prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9
+    python3 ./repo sync -c prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.15-4.8
+    python3 ./repo sync -c prebuilts/go/linux-x86
+    python3 ./repo sync -c prebuilts/misc
+    python3 ./repo sync -c prebuilts/sdk
     python3 ./repo sync -c system/core
+    python3 ./repo sync -c system/libhidl
+    python3 ./repo sync -c system/tools/hidl
+
     case "${arch}" in
         arm)
-            python3 ./repo sync prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8
+            python3 ./repo sync prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9
         ;;
         arm64)
-            python3 ./repo sync prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8
+            python3 ./repo sync prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9
             python3 ./repo sync prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9
         ;;
         x86)
-            python3 ./repo sync prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.8
+            python3 ./repo sync prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9
         ;;
         x86_64)
-            python3 ./repo sync prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.8
+            python3 ./repo sync prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9
         ;;
     esac
 
     # avoid build tests
-    rm bionic/linker/tests/Android.mk bionic/tests/Android.mk bionic/benchmarks/Android.mk
+    rm bionic/linker/tests/Android.mk
+    rm bionic/tests/Android.mk
+    rm bionic/tests/Android.bp
+    rm bionic/benchmarks/Android.bp
+    rm bionic/tests/libs/Android.bp
+    rm bionic/tests/headers/Android.bp
+    rm bionic/tests/headers/posix/Android.bp
+
+    sed -i -z -e 's/cc_test {.*}//g' bionic/libc/malloc_debug/Android.bp
+    sed -i -z -e 's/cc_test {.*}//g' bionic/libc/malloc_hooks/Android.bp
+    sed -i -z -e 's/cc_test_host {.*}//g' bionic/tools/relocation_packer/Android.bp
+
+    export ALLOW_MISSING_DEPENDENCIES=true
 
     # patch the linker to avoid the error
     # FATAL: kernel did not supply AT_SECURE
-    sed -i -e 's/if (!kernel_supplied_AT_SECURE)/if (false)/g' bionic/linker/linker_environ.cpp
+    #sed -i -e 's/if (!kernel_supplied_AT_SECURE)/if (false)/g' bionic/linker/linker_environ.cpp
 
     set +u
     # shellcheck disable=SC1091
@@ -109,9 +149,9 @@ EOF
     fi
 
     # list from https://elinux.org/Android_toolbox
-    for tool in cat chmod chown cmp cp ctrlaltdel date dd df dmesg du getevent \
-        getprop grep hd id ifconfig iftop insmod ioctl ionice kill ln log ls \
-        lsmod lsof lsusb md5 mkdir mount mv nandread netstat newfs_msdos notify \
+    for tool in cat chmod chown cmp cp ctrlaltdel date df dmesg du \
+        hd id ifconfig iftop insmod ioctl ionice kill ln log ls \
+        lsmod lsof lsusb md5 mkdir mount mv nandread netstat notify \
         printenv ps reboot renice rm rmdir rmmod route schedtop sendevent \
         setconsole setprop sleep smd start stop sync top touch umount \
         uptime vmstat watchprops wipe; do

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -168,7 +168,10 @@ pub fn run(
     docker.args(&["-e", "PKG_CONFIG_ALLOW_CROSS=1"]);
 
     docker.arg("--rm");
-    docker.arg("--privileged");
+
+    if target.needs_docker_privileged() {
+        docker.arg("--privileged");
+    }
 
     // We need to specify the user for Docker, but not for Podman.
     if let Ok(ce) = get_container_engine() {

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -168,6 +168,7 @@ pub fn run(
     docker.args(&["-e", "PKG_CONFIG_ALLOW_CROSS=1"]);
 
     docker.arg("--rm");
+    docker.arg("--privileged");
 
     // We need to specify the user for Docker, but not for Podman.
     if let Ok(ce) = get_container_engine() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,6 +204,14 @@ impl Target {
 
         !native && (self.is_linux() || self.is_windows() || self.is_bare_metal())
     }
+
+    fn needs_docker_privileged(&self) -> bool {
+        let arch_32bit = self.triple().starts_with("arm")
+            || self.triple().starts_with("i586")
+            || self.triple().starts_with("i686");
+
+        arch_32bit && self.is_android()
+    }
 }
 
 impl std::fmt::Display for Target {


### PR DESCRIPTION
This PR updates Android NDK version and API version as the same as libc crate.

https://github.com/rust-lang/libc/blob/master/ci/android-install-ndk.sh

Fix https://github.com/rust-embedded/cross/issues/195