### PR TITLE
Add pre-build hooks

### DIFF
--- a/docker/Dockerfile.x86_64-unknown-linux-gnu
+++ b/docker/Dockerfile.x86_64-unknown-linux-gnu
@@ -20,6 +20,9 @@ RUN /qemu.sh x86_64 softmmu
 COPY dropbear.sh /
 RUN /dropbear.sh
 
+COPY gosu.sh /
+RUN /gosu.sh
+
 COPY --from=0 /qemu /qemu
 
 COPY linux-runner /

--- a/docker/gosu.sh
+++ b/docker/gosu.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -x
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. lib.sh
+
+main() {
+  local version=1.14
+  local arch=amd64
+  gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+  curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/${version}/gosu-${arch}"
+  curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/${version}/gosu-${arch}.asc"
+  gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu
+  rm /usr/local/bin/gosu.asc
+  rm -r /root/.gnupg/
+  chmod +x /usr/local/bin/gosu
+  # Verify that the binary works
+  gosu nobody true
+}
+
+main "${@}"

--- a/src/config.rs
+++ b/src/config.rs
@@ -180,6 +180,10 @@ impl Config {
         Ok(collected)
     }
 
+    pub fn pre_build(&self, target: &Target) -> Result<Option<String>> {
+        self.toml.as_ref().map_or(Ok(None), |t| t.pre_build(target))
+    }
+
     fn sum_of_env_toml_values<'a>(
         toml_getter: impl FnOnce() -> Option<Result<Vec<&'a str>>>,
         env_values: Option<Vec<String>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -469,7 +469,7 @@ impl Toml {
     pub fn env_passthrough_target(&self, target: &Target) -> Result<Vec<&str>> {
         self.target_env(target, "passthrough")
     }
-    
+
     /// Returns the list of environment variables to pass through for `build`,
     pub fn env_volumes_build(&self) -> Result<Vec<&str>> {
         self.build_env("volumes")
@@ -478,6 +478,24 @@ impl Toml {
     /// Returns the list of environment variables to pass through for `target`,
     pub fn env_volumes_target(&self, target: &Target) -> Result<Vec<&str>> {
         self.target_env(target, "volumes")
+    }
+
+    /// Returns the `target.{}.pre-build` part of `Cross.toml`
+    pub fn pre_build(&self, target: &Target) -> Result<Option<String>> {
+        let triple = target.triple();
+
+        if let Some(value) = self
+            .table
+            .get("target")
+            .and_then(|t| t.get(triple))
+            .and_then(|t| t.get("pre-build"))
+        {
+            Ok(Some(value.as_str().ok_or_else(|| {
+                format!("target.{}.pre-build must be a string", triple)
+            })?.to_string()))
+        } else {
+            Ok(None)
+        }
     }
 
     fn target_env(&self, target: &Target, key: &str) -> Result<Vec<&str>> {


### PR DESCRIPTION
This PR addresses #565 and hopefully a number of the open issues about the lack of openssl in the builders. It does add a dependency on [gosu](https://github.com/tianon/gosu) which handles lowering the privileges down to user level after the pre-build hooks are run. For now I've only added it to the x86_64-unknown-linux-gnu target for testing pending feedback on it.

I was able to build Cargo successfully with all features with
```toml
[target.x86_64-unknown-linux-gnu]
image = "rustembedded/cross:x86_64-unknown-linux-gnu-0.2.1"
pre-build = """
yum update -y
yum install -y openssl-devel
"""
```