### PR TITLE
Update FreeBSD quarterly package versions

### DIFF
--- a/docker/freebsd-extras.sh
+++ b/docker/freebsd-extras.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 main() {
     local arch="${1}"
 
-    local sqlite_ver=3.35.5_3,1 \
-          openssl_ver=1.1.1l,1 \
+    local sqlite_ver=3.35.5_4,1 \
+          openssl_ver=1.1.1m_1,1 \
           target="${arch}-unknown-freebsd12"
 
     local td


### PR DESCRIPTION
FreeBSD updated their packages and current master fails to build docker image - as downloading packages fail.

Merging this PR does not necessitate new container image publication, it just fixes image building on master.