### PR TITLE
freebsd: Add libkvm.so

### DIFF
--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -74,6 +74,7 @@ main() {
     cp "${td}/freebsd/lib/libthr.so.3" "${destdir}/lib"
     cp "${td}/freebsd/lib/libutil.so.9" "${destdir}/lib"
     cp "${td}/freebsd/lib/libssp.so.0" "${destdir}/lib"
+    cp "${td}/freebsd/lib/libkvm.so.7" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib/libc++.so.1" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib/libc++.a" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/lib{c,util,m,ssp,ssp_nonshared}.a "${destdir}/lib"
@@ -89,6 +90,7 @@ main() {
     ln -s libutil.so.9 "${destdir}/lib/libutil.so"
     ln -s libthr.so.3 "${destdir}/lib/libpthread.so"
     ln -s libssp.so.0 "${destdir}/lib/libssp.so"
+    ln -s libkvm.so.7 "${destdir}/lib/libkvm.so"
 
     cd gcc-build
     ../gcc/configure \


### PR DESCRIPTION
I have noticed that [Starship](https://github.com/starship/starship) [fails to create FreeBSD build](https://github.com/starship/starship/runs/5094984722?check_suite_focus=true). Command `cross build --release --locked --target x86_64-unknown-freebsd` fails with error:

```
/usr/local/lib/gcc/x86_64-unknown-freebsd12/6.4.0/../../../../x86_64-unknown-freebsd12/bin/ld: cannot find -lkvm
```

While trying to debug the issue, I have noticed that file `libkvm.so.7` exists in temporary directory [during container build](https://github.com/cross-rs/cross/blob/master/docker/freebsd.sh), but it's not copied over to destination directory and doesn't end up in final image.

This file is only 70 kB, so I thought we might just add it to image, which should allow all projects depending on libkvm to build FreeBSD binaries without any extra effort.

But if you don't want to add more libraries to container image, please let me know - I'll work with starship people on finding an approach that works for them.
