### PR TITLE
make env.volumes only change package path when used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- #665 - when not using [env.volumes](https://github.com/cross-rs/cross#mounting-volumes-into-the-build-environment), mount project in /project
 - #624 - Add `build.default-target`
 - #670 - Use serde for deserialization of Cross.toml
 - Change rust edition to 2021 and bump MSRV for the cross binary to 1.58.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ version = "0.2.1"
 dependencies = [
  "atty",
  "color-eyre",
+ "dunce",
  "eyre",
  "home",
  "lazy_static",
@@ -113,6 +114,12 @@ dependencies = [
  "which",
  "winapi",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }
+dunce = "1"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
This fixes windows usage.

It also tries to fix windows builds when using `env.volumes` by making windows compatible
paths for `env.volumes`

not using env.volumes will now also mount the project in `/project` again