### PR TITLE
warn when used toolchain is out-of-date

### DIFF
--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -45,11 +45,9 @@ pub fn target_list(verbose: bool) -> Result<TargetList> {
 pub fn sysroot(host: &Host, target: &Target, verbose: bool) -> Result<PathBuf> {
     let mut stdout = Command::new("rustc")
         .args(&["--print", "sysroot"])
-        .run_and_get_stdout(verbose)?;
-
-    if stdout.ends_with('\n') {
-        stdout.pop();
-    }
+        .run_and_get_stdout(verbose)?
+        .trim()
+        .to_owned();
 
     // On hosts other than Linux, specify the correct toolchain path.
     if host != &Host::X86_64UnknownLinuxGnu && target.needs_docker() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use once_cell::sync::OnceCell;
+use rustc_version::VersionMeta;
 use serde::Deserialize;
 
 static WORKSPACE: OnceCell<PathBuf> = OnceCell::new();
@@ -50,4 +51,80 @@ pub fn walk_dir<'a>(
         }
         e.path().extension() == Some("md".as_ref())
     })
+}
+
+#[test]
+pub fn target_mismatch() {
+    use crate::{warn_host_version_mismatch, VersionMatch};
+
+    fn make_meta(input: &str) -> VersionMeta {
+        let mut split = input.split(' ');
+        let version = split.next().unwrap();
+        let hash_short = &split.next().unwrap().strip_prefix('(').unwrap();
+        let date = split.next().unwrap().strip_suffix(")").unwrap();
+        rustc_version::version_meta_for(&format!(
+            r#"rustc {version} ({hash_short} {date})
+binary: rustc
+commit-hash: {hash_short:f<40}
+commit-date: {date}
+host: xxxx
+release: {version}
+"#
+        ))
+        .unwrap()
+    }
+
+    fn make_rustc_version(input: &str) -> (rustc_version::Version, String) {
+        let (version, meta) = input.split_once(' ').unwrap();
+        (version.parse().unwrap(), meta.to_owned())
+    }
+
+    #[track_caller]
+    fn compare(expected: VersionMatch, host: &str, targ: &str) {
+        let host_meta = dbg!(make_meta(host));
+        let target_meta = dbg!(make_rustc_version(targ));
+        assert_eq!(
+            expected,
+            warn_host_version_mismatch(&host_meta, "xxxx", &target_meta.0, &target_meta.1).unwrap(),
+            "\nhost = {}\ntarg = {}",
+            host,
+            targ
+        );
+    }
+
+    compare(
+        VersionMatch::Same,
+        "1.0.0 (11111111 2022-01-01)",
+        "1.0.0 (11111111 2022-01-01)",
+    );
+    compare(
+        VersionMatch::Same,
+        "1.0.0-nightly (11111111 2022-01-01)",
+        "1.0.0-nightly (11111111 2022-01-01)",
+    );
+    compare(
+        VersionMatch::OlderTarget,
+        "1.2.0 (22222222 2022-02-02)",
+        "1.0.0 (11111111 2022-01-01)",
+    );
+    compare(
+        VersionMatch::NewerTarget,
+        "1.0.0 (11111111 2022-01-01)",
+        "1.2.0 (22222222 2022-02-02)",
+    );
+    compare(
+        VersionMatch::Different,
+        "1.0.0-nightly (11111111 2022-01-01)",
+        "1.0.0-nightly (22222222 2022-01-01)",
+    );
+    compare(
+        VersionMatch::OlderTarget,
+        "1.0.0-nightly (22222222 2022-02-02)",
+        "1.0.0-nightly (11111111 2022-01-01)",
+    );
+    compare(
+        VersionMatch::NewerTarget,
+        "1.0.0-nightly (11111111 2022-01-01)",
+        "1.0.0-nightly (22222222 2022-02-02)",
+    );
 }


### PR DESCRIPTION
on non-linux hosts, warn when toolchain is out of date.

# Example

```
$ cross build
Warning: using older rustc `1.61.0-nightly (9f4dc0b4d 2022-03-23)` for the target. Current active rustc on the host is `rustc 1.62.0-nightly (879aff385 2022-04-20)`.
 > Update with `rustup update --force-non-host nightly-x86_64-unknown-linux-gnu`
```