### PR TITLE
Specify `edge` for the example of Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This way you won't have to figure out how to install a cross C toolchain in your
 custom image. Example below:
 
 ``` Dockerfile
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:latest
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge
 
 RUN dpkg --add-architecture arm64 && \
     apt-get update && \


### PR DESCRIPTION
`README.md` recommends writing `Dockerfile` based on the default
Docker image that cross uses. The example indicates the base
image's tag as `latest`, but `latest` does not seem to exist on container
packages.

https://github.com/orgs/cross-rs/packages?repo_name=cross

So, I updated `README.md` to specify `edge` instead of `latest`
in order for developers to use the snippet just by copying it.