### PR TITLE
allow specifying a dockerfile to use for a target and implement "pre-build"ing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #795 - added images for additional toolchains maintained by cross-rs.
 - #792 - added `CROSS_CONTAINER_IN_CONTAINER` environment variable to replace `CROSS_DOCKER_IN_DOCKER`.
 - #782 - added `build-std` config option, which builds the rust standard library from source if enabled.
-- #775 - forward Cargo exit code to host
+- #678 - Add optional `target.{target}.dockerfile[.file]`, `target.{target}.dockerfile.context` and `target.{target}.dockerfile.build-args` to invoke docker/podman build before using an image.
+- #678 - Add `target.{target}.pre-build` config for running commands before building the image.
 - #772 - added `CROSS_CONTAINER_OPTS` environment variable to replace `DOCKER_OPTS`.
 - #767, #788 - added the `cross-util` and `xtask` commands.
 - #745 - added `thumbv7neon-*` targets.
@@ -27,6 +28,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- #775 - forward Cargo exit code to host
 - #762 - re-enabled `x86_64-unknown-dragonfly` target.
 - #747 - reduced android image sizes.
 - #746 - limit image permissions for android images.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,7 @@ dependencies = [
  "serde",
  "serde_ignored",
  "serde_json",
+ "sha1_smol",
  "shell-escape",
  "shell-words",
  "thiserror",
@@ -472,6 +473,12 @@ dependencies = [
  "serde",
  "yaml-rust",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sharded-slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_ignored = "0.1.2"
 shell-words = "1.1.0"
+sha1_smol = "1.0.0"
 
 [target.'cfg(not(windows))'.dependencies]
 nix = { version = "0.24", default-features = false, features = ["user"] }

--- a/README.md
+++ b/README.md
@@ -112,10 +112,22 @@ the default one. Normal Docker behavior applies, so:
 
 - If only `tag` is omitted, then Docker will use the `latest` tag.
 
+#### Dockerfiles
+
+If you're using a custom Dockerfile, you can use `target.{{TARGET}}.dockerfile` to automatically build it
+
+``` toml
+[target.aarch64-unknown-linux-gnu.dockerfile]
+dockerfile = "./path/to/where/the/Dockerfile/resides"
+```
+
+`cross` will build and use the image that was built instead of the default image.
+
 It's recommended to base your custom image on the default Docker image that
 cross uses: `ghcr.io/cross-rs/{{TARGET}}:{{VERSION}}` (where `{{VERSION}}` is cross's version).
 This way you won't have to figure out how to install a cross C toolchain in your
-custom image. Example below:
+custom image.
+
 
 ``` Dockerfile
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:latest
@@ -125,8 +137,23 @@ RUN dpkg --add-architecture arm64 && \
     apt-get install --assume-yes libfoo:arm64
 ```
 
+If you want cross to provide the `FROM` instruction, you can do the following
+
+``` Dockerfile
+ARG CROSS_BASE_IMAGE
+FROM $CROSS_BASE_IMAGE
+
+RUN ...
 ```
-$ docker build -t my/image:tag path/to/where/the/Dockerfile/resides
+
+#### Pre-build hook
+
+`cross` enables you to add dependencies and run other necessary commands in the image before using it.
+This action will be added to the used image, so it won't be ran/built every time you use `cross`.
+
+``` toml
+[target.x86_64-unknown-linux-gnu]
+pre-build = ["dpkg --add-architecture arm64 && apt-get update && apt-get install --assume-yes libfoo:arm64"]
 ```
 
 ### Docker in Docker

--- a/docs/cross_toml.md
+++ b/docs/cross_toml.md
@@ -1,6 +1,7 @@
 The `cross` configuration in the `Cross.toml` file, can contain the following elements:
 
 # `build`
+
 The `build` key allows you to set global variables, e.g.:
 
 ```toml
@@ -11,6 +12,7 @@ default-target = "x86_64-unknown-linux-gnu"
 ```
 
 # `build.env`
+
 With the `build.env` key you can globally set volumes that should be mounted
 in the Docker container or environment variables that should be passed through.
 For example:
@@ -22,6 +24,7 @@ passthrough = ["IMPORTANT_ENV_VARIABLES"]
 ```
 
 # `target.TARGET`
+
 The `target` key allows you to specify parameters for specific compilation targets.
 
 ```toml
@@ -29,10 +32,12 @@ The `target` key allows you to specify parameters for specific compilation targe
 xargo = false
 build-std = false
 image = "test-image"
+pre-build = ["apt-get update"]
 runner = "custom-runner"
 ```
 
 # `target.TARGET.env`
+
 The `target` key allows you to specify environment variables that should be used for a specific compilation target.
 This is similar to `build.env`, but allows you to be more specific per target.
 
@@ -40,4 +45,20 @@ This is similar to `build.env`, but allows you to be more specific per target.
 [target.x86_64-unknown-linux-gnu.env]
 volumes = ["VOL1_ARG", "VOL2_ARG"]
 passthrough = ["IMPORTANT_ENV_VARIABLES"]
+```
+
+# `target.TARGET.dockerfile`
+
+```toml
+[target.x86_64-unknown-linux-gnu.dockerfile]
+file = "./Dockerfile" # The dockerfile to use relative to the `Cargo.toml`
+context = "." # What folder to run the build script in
+build-args = { ARG1 = "foo" } # https://docs.docker.com/engine/reference/builder/#arg
+```
+
+also supports
+
+```toml
+[target.x86_64-unknown-linux-gnu]
+dockerfile = "./Dockerfile"
 ```

--- a/src/bin/commands/images.rs
+++ b/src/bin/commands/images.rs
@@ -186,7 +186,7 @@ fn remove_images(
     }
     command.args(images);
     if execute {
-        command.run(verbose).map_err(Into::into)
+        command.run(verbose, false).map_err(Into::into)
     } else {
         println!("{:?}", command);
         Ok(())

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -148,7 +148,9 @@ pub fn cargo_metadata_with_args(
 
 /// Pass-through mode
 pub fn run(args: &[String], verbose: bool) -> Result<ExitStatus, CommandError> {
-    Command::new("cargo").args(args).run_and_get_status(verbose)
+    Command::new("cargo")
+        .args(args)
+        .run_and_get_status(verbose, false)
 }
 
 /// run cargo and get the output, does not check the exit status

--- a/src/docker/custom.rs
+++ b/src/docker/custom.rs
@@ -1,0 +1,141 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::docker::Engine;
+use crate::{config::Config, docker, CargoMetadata, Target};
+use crate::{errors::*, file, CommandExt};
+
+use super::{image_name, parse_docker_opts};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Dockerfile<'a> {
+    File {
+        path: &'a str,
+        context: Option<&'a str>,
+        name: Option<&'a str>,
+    },
+    Custom {
+        content: String,
+    },
+}
+
+impl<'a> Dockerfile<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn build(
+        &self,
+        config: &Config,
+        metadata: &CargoMetadata,
+        engine: &Engine,
+        host_root: &Path,
+        build_args: impl IntoIterator<Item = (impl AsRef<str>, impl AsRef<str>)>,
+        target_triple: &Target,
+        verbose: bool,
+    ) -> Result<String> {
+        let mut docker_build = docker::subcommand(engine, "build");
+        docker_build.current_dir(host_root);
+        docker_build.env("DOCKER_SCAN_SUGGEST", "false");
+        docker_build.args([
+            "--label",
+            &format!(
+                "{}.for-cross-target={target_triple}",
+                crate::CROSS_LABEL_DOMAIN
+            ),
+        ]);
+
+        docker_build.args([
+            "--label",
+            &format!(
+                "{}.workspace_root={}",
+                crate::CROSS_LABEL_DOMAIN,
+                metadata.workspace_root.display()
+            ),
+        ]);
+
+        let image_name = self.image_name(target_triple, metadata);
+        docker_build.args(["--tag", &image_name]);
+
+        for (key, arg) in build_args.into_iter() {
+            docker_build.args(["--build-arg", &format!("{}={}", key.as_ref(), arg.as_ref())]);
+        }
+
+        if let Some(arch) = target_triple.deb_arch() {
+            docker_build.args(["--build-arg", &format!("CROSS_DEB_ARCH={arch}")]);
+        }
+
+        let path = match self {
+            Dockerfile::File { path, .. } => PathBuf::from(path),
+            Dockerfile::Custom { content } => {
+                let path = metadata
+                    .target_directory
+                    .join(target_triple.to_string())
+                    .join(format!("Dockerfile.{}-custom", target_triple,));
+                {
+                    let mut file = file::write_file(&path, true)?;
+                    file.write_all(content.as_bytes())?;
+                }
+                path
+            }
+        };
+
+        if matches!(self, Dockerfile::File { .. }) {
+            if let Ok(cross_base_image) = self::image_name(config, target_triple) {
+                docker_build.args([
+                    "--build-arg",
+                    &format!("CROSS_BASE_IMAGE={cross_base_image}"),
+                ]);
+            }
+        }
+
+        docker_build.args(["--file".into(), path]);
+
+        if let Ok(build_opts) = std::env::var("CROSS_BUILD_OPTS") {
+            // FIXME: Use shellwords
+            docker_build.args(parse_docker_opts(&build_opts)?);
+        }
+        if let Some(context) = self.context() {
+            docker_build.arg(&context);
+        } else {
+            docker_build.arg(".");
+        }
+
+        docker_build.run(verbose, true)?;
+        Ok(image_name)
+    }
+
+    pub fn image_name(&self, target_triple: &Target, metadata: &CargoMetadata) -> String {
+        match self {
+            Dockerfile::File {
+                name: Some(name), ..
+            } => name.to_string(),
+            _ => format!(
+                "cross-custom-{package_name}:{target_triple}-{path_hash}{custom}",
+                package_name = metadata
+                    .workspace_root
+                    .file_name()
+                    .expect("workspace_root can't end in `..`")
+                    .to_string_lossy(),
+                path_hash =
+                    sha1_smol::Sha1::from(&metadata.workspace_root.to_string_lossy().as_bytes())
+                        .digest()
+                        .to_string()
+                        .get(..5)
+                        .expect("sha1 is expected to be at least 5 characters long"),
+                custom = if matches!(self, Self::File { .. }) {
+                    ""
+                } else {
+                    "-pre-build"
+                }
+            ),
+        }
+    }
+
+    fn context(&self) -> Option<&'a str> {
+        match self {
+            Dockerfile::File {
+                context: Some(context),
+                ..
+            } => Some(context),
+            _ => None,
+        }
+    }
+}

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -1,3 +1,4 @@
+mod custom;
 mod engine;
 mod local;
 mod shared;

--- a/src/file.rs
+++ b/src/file.rs
@@ -44,9 +44,16 @@ pub fn write_file(path: impl AsRef<Path>, overwrite: bool) -> Result<File> {
         })?,
     )
     .wrap_err_with(|| format!("couldn't create directory `{}`", path.display()))?;
-    fs::OpenOptions::new()
-        .write(true)
-        .create_new(!overwrite)
-        .open(&path)
-        .wrap_err(format!("could't write to file `{}`", path.display()))
+
+    let mut open = fs::OpenOptions::new();
+    open.write(true);
+
+    if overwrite {
+        open.truncate(true).create(true);
+    } else {
+        open.create_new(true);
+    }
+
+    open.open(&path)
+        .wrap_err(format!("couldn't write to file `{}`", path.display()))
 }

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -73,7 +73,7 @@ pub fn available_targets(toolchain: &str, verbose: bool) -> Result<AvailableTarg
 pub fn install_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
     Command::new("rustup")
         .args(&["toolchain", "add", toolchain, "--profile", "minimal"])
-        .run(verbose)
+        .run(verbose, false)
         .wrap_err_with(|| format!("couldn't install toolchain `{toolchain}`"))
 }
 
@@ -82,14 +82,14 @@ pub fn install(target: &Target, toolchain: &str, verbose: bool) -> Result<()> {
 
     Command::new("rustup")
         .args(&["target", "add", target, "--toolchain", toolchain])
-        .run(verbose)
+        .run(verbose, false)
         .wrap_err_with(|| format!("couldn't install `std` for {target}"))
 }
 
 pub fn install_component(component: &str, toolchain: &str, verbose: bool) -> Result<()> {
     Command::new("rustup")
         .args(&["component", "add", component, "--toolchain", toolchain])
-        .run(verbose)
+        .run(verbose, false)
         .wrap_err_with(|| format!("couldn't install the `{component}` component"))
 }
 

--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -214,6 +214,11 @@ pub fn build_docker_image(
             docker_build.args(&["--label", label]);
         }
 
+        docker_build.args([
+            "--label",
+            &format!("{}.for-cross-target={target}", cross::CROSS_LABEL_DOMAIN),
+        ]);
+
         docker_build.args(&["-f", dockerfile]);
 
         if gha || progress == "plain" {
@@ -225,7 +230,7 @@ pub fn build_docker_image(
         docker_build.arg(".");
 
         if !dry_run && (force || !push || gha) {
-            let result = docker_build.run(verbose);
+            let result = docker_build.run(verbose, false);
             if gha && targets.len() > 1 {
                 if let Err(e) = &result {
                     // TODO: Determine what instruction errorred, and place warning on that line with appropriate warning

--- a/xtask/src/target_info.rs
+++ b/xtask/src/target_info.rs
@@ -58,7 +58,7 @@ fn pull_image(engine: &Path, image: &str, verbose: bool) -> cross::Result<()> {
         command.stdout(Stdio::null());
         command.stderr(Stdio::null());
     }
-    command.run(verbose).map_err(Into::into)
+    command.run(verbose, false).map_err(Into::into)
 }
 
 fn image_info(
@@ -88,7 +88,7 @@ fn image_info(
         // capture stderr to avoid polluting table
         command.stderr(Stdio::null());
     }
-    command.run(verbose).map_err(Into::into)
+    command.run(verbose, false).map_err(Into::into)
 }
 
 pub fn target_info(


### PR DESCRIPTION
Add optional `target.{target}.dockerfile[.file]`, `target.{target}.dockerfile.context` and `target.{target}.dockerfile.build-args` to invoke `docker/podman build` before using an image.

also adds `target.{target}.pre-build` to allow pre-building as per #565

In total, this PR allows a user to do the following:

```toml
[build]
pre-build = [
    "dpkg --add-architecture $CROSS_DEB_ARCH", 
    "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH"
    ]
[target.x86_64-unknown-linux-gnu]
dockerfile = { file = "./Dockerfile.x86_64_ssl", context = "..", build-args = { ARG1 = "foo" }}
image = "my-image:latest"
pre-build = ["echo 'Hello world!'"]
```

fixes #565