### PR TITLE
fix env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --locked
+          args: --locked --all-targets --workspace
         timeout-minutes: 5
 
   generate-matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-target
+**/target/
+**/.idea/
+**/.vscode/*.*
+**/*.log
+/cargo-timing*.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,15 +112,17 @@ dependencies = [
  "dunce",
  "eyre",
  "home",
- "lazy_static",
  "libc",
  "nix",
+ "once_cell",
+ "regex",
  "rustc_version",
  "serde",
  "serde_ignored",
  "serde_json",
  "shell-escape",
  "toml",
+ "walkdir",
  "which",
  "winapi",
 ]
@@ -270,6 +281,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +317,15 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -435,6 +472,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "which"
 version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +508,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ atty = "0.2"
 color-eyre = "0.6"
 eyre = "0.6"
 home = "0.5"
-lazy_static = "1"
 rustc_version = "0.4"
 toml = "0.5"
 which = { version = "4", default_features = false }
@@ -33,3 +32,8 @@ dunce = "1"
 
 [profile.release]
 lto = true
+
+[dev-dependencies]
+regex = "1"
+once_cell = "1"
+walkdir = "2"

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ non-standard targets (i.e. something not reported by rustc/rustup). However,
 you can use the `build.xargo` or `target.{{TARGET}}.xargo` field in
 `Cross.toml` to force the use of `xargo`:
 
-``` toml
+```toml
 # all the targets will use `xargo`
 [build]
 xargo = true
@@ -234,7 +234,7 @@ xargo = true
 
 Or,
 
-``` toml
+```toml
 # only this target will use `xargo`
 [target.aarch64-unknown-linux-gnu]
 xargo = true

--- a/docs/cross_toml.md
+++ b/docs/cross_toml.md
@@ -25,9 +25,17 @@ The `target` key allows you to specify parameters for specific compilation targe
 
 ```toml
 [target.aarch64-unknown-linux-gnu]
-volumes = ["VOL1_ARG", "VOL2_ARG"]
-passthrough = ["VAR1", "VAR2"]
 xargo = false
 image = "test-image"
 runner = "custom-runner"
+```
+
+# `target.TARGET.env`
+The `target` key allows you to specify environment variables that should be used for a specific compilation target.
+This is similar to `build.env`, but allows you to be more specific per target.
+
+```toml
+[target.x86_64-unknown-linux-gnu.env]
+volumes = ["VOL1_ARG", "VOL2_ARG"]
+passthrough = ["IMPORTANT_ENV_VARIABLES"]
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -319,7 +319,7 @@ mod tests {
         use std::matches;
 
         fn toml(content: &str) -> Result<crate::CrossToml> {
-            Ok(CrossToml::from_str(content).wrap_err("couldn't parse toml")?)
+            Ok(CrossToml::parse(content).wrap_err("couldn't parse toml")?.0)
         }
 
         #[test]

--- a/src/cross_toml.rs
+++ b/src/cross_toml.rs
@@ -5,9 +5,9 @@ use crate::{Target, TargetList};
 use serde::Deserialize;
 use std::collections::HashMap;
 
-/// Build environment configuration
-#[derive(Debug, Deserialize, PartialEq)]
-pub struct CrossBuildEnvConfig {
+/// Environment configuration
+#[derive(Debug, Deserialize, PartialEq, Default)]
+pub struct CrossEnvConfig {
     #[serde(default)]
     volumes: Vec<String>,
     #[serde(default)]
@@ -18,7 +18,8 @@ pub struct CrossBuildEnvConfig {
 #[derive(Debug, Deserialize, PartialEq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct CrossBuildConfig {
-    env: Option<CrossBuildEnvConfig>,
+    #[serde(default)]
+    env: CrossEnvConfig,
     xargo: Option<bool>,
     default_target: Option<String>,
 }
@@ -26,13 +27,11 @@ pub struct CrossBuildConfig {
 /// Target configuration
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct CrossTargetConfig {
-    #[serde(default)]
-    passthrough: Vec<String>,
-    #[serde(default)]
-    volumes: Vec<String>,
     xargo: Option<bool>,
     image: Option<String>,
     runner: Option<String>,
+    #[serde(default)]
+    env: CrossEnvConfig,
 }
 
 /// Cross configuration
@@ -40,7 +39,8 @@ pub struct CrossTargetConfig {
 pub struct CrossToml {
     #[serde(default, rename = "target")]
     pub targets: HashMap<Target, CrossTargetConfig>,
-    pub build: Option<CrossBuildConfig>,
+    #[serde(default)]
+    pub build: CrossBuildConfig,
 }
 
 impl CrossToml {
@@ -76,7 +76,7 @@ impl CrossToml {
 
     /// Returns the `build.xargo` or the `target.{}.xargo` part of `Cross.toml`
     pub fn xargo(&self, target: &Target) -> (Option<bool>, Option<bool>) {
-        let build_xargo = self.build.as_ref().and_then(|b| b.xargo);
+        let build_xargo = self.build.xargo;
         let target_xargo = self.get_target(target).and_then(|t| t.xargo);
 
         (build_xargo, target_xargo)
@@ -84,44 +84,37 @@ impl CrossToml {
 
     /// Returns the list of environment variables to pass through for `build`,
     pub fn env_passthrough_build(&self) -> Vec<String> {
-        self.get_build_env()
-            .map_or(Vec::new(), |e| e.passthrough.clone())
+        self.build.env.passthrough.clone()
     }
 
     /// Returns the list of environment variables to pass through for `target`,
     pub fn env_passthrough_target(&self, target: &Target) -> Vec<String> {
         self.get_target(target)
-            .map_or(Vec::new(), |t| t.passthrough.clone())
+            .map_or(Vec::new(), |t| t.env.passthrough.clone())
     }
 
     /// Returns the list of environment variables to pass through for `build`,
     pub fn env_volumes_build(&self) -> Vec<String> {
-        self.get_build_env()
-            .map_or(Vec::new(), |e| e.volumes.clone())
+        self.build.env.volumes.clone()
     }
 
     /// Returns the list of environment variables to pass through for `target`,
     pub fn env_volumes_target(&self, target: &Target) -> Vec<String> {
         self.get_target(target)
-            .map_or(Vec::new(), |t| t.volumes.clone())
+            .map_or(Vec::new(), |t| t.env.volumes.clone())
     }
 
     /// Returns the default target to build,
     pub fn default_target(&self, target_list: &TargetList) -> Option<Target> {
         self.build
+            .default_target
             .as_ref()
-            .and_then(|b| b.default_target.as_ref())
             .map(|t| Target::from(t, target_list))
     }
 
     /// Returns a reference to the [`CrossTargetConfig`] of a specific `target`
     fn get_target(&self, target: &Target) -> Option<&CrossTargetConfig> {
         self.targets.get(target)
-    }
-
-    /// Returns a reference to the [`CrossBuildEnvConfig`]
-    fn get_build_env(&self) -> Option<&CrossBuildEnvConfig> {
-        self.build.as_ref().and_then(|b| b.env.as_ref())
     }
 }
 
@@ -133,7 +126,7 @@ mod tests {
     pub fn parse_empty_toml() -> Result<()> {
         let cfg = CrossToml {
             targets: HashMap::new(),
-            build: None,
+            build: CrossBuildConfig::default(),
         };
         let parsed_cfg = CrossToml::from_str("")?;
 
@@ -146,14 +139,14 @@ mod tests {
     pub fn parse_build_toml() -> Result<()> {
         let cfg = CrossToml {
             targets: HashMap::new(),
-            build: Some(CrossBuildConfig {
-                env: Some(CrossBuildEnvConfig {
+            build: CrossBuildConfig {
+                env: CrossEnvConfig {
                     volumes: vec!["VOL1_ARG".to_string(), "VOL2_ARG".to_string()],
                     passthrough: vec!["VAR1".to_string(), "VAR2".to_string()],
-                }),
+                },
                 xargo: Some(true),
                 default_target: None,
-            }),
+            },
         };
 
         let test_str = r#"
@@ -179,8 +172,10 @@ mod tests {
                 triple: "aarch64-unknown-linux-gnu".to_string(),
             },
             CrossTargetConfig {
-                passthrough: vec!["VAR1".to_string(), "VAR2".to_string()],
-                volumes: vec!["VOL1_ARG".to_string(), "VOL2_ARG".to_string()],
+                env: CrossEnvConfig {
+                    passthrough: vec!["VAR1".to_string(), "VAR2".to_string()],
+                    volumes: vec!["VOL1_ARG".to_string(), "VOL2_ARG".to_string()],
+                },
                 xargo: Some(false),
                 image: Some("test-image".to_string()),
                 runner: None,
@@ -189,15 +184,16 @@ mod tests {
 
         let cfg = CrossToml {
             targets: target_map,
-            build: None,
+            build: CrossBuildConfig::default(),
         };
 
         let test_str = r#"
-          [target.aarch64-unknown-linux-gnu]
-          volumes = ["VOL1_ARG", "VOL2_ARG"]
-          passthrough = ["VAR1", "VAR2"]
-          xargo = false
-          image = "test-image"
+            [target.aarch64-unknown-linux-gnu.env]
+            volumes = ["VOL1_ARG", "VOL2_ARG"]
+            passthrough = ["VAR1", "VAR2"]
+            [target.aarch64-unknown-linux-gnu]
+            xargo = false
+            image = "test-image"
         "#;
         let parsed_cfg = CrossToml::from_str(test_str)?;
 

--- a/src/cross_toml.rs
+++ b/src/cross_toml.rs
@@ -128,9 +128,10 @@ mod tests {
             targets: HashMap::new(),
             build: CrossBuildConfig::default(),
         };
-        let (parsed_cfg, _) = CrossToml::parse("")?;
+        let (parsed_cfg, unused) = CrossToml::parse("")?;
 
         assert_eq!(parsed_cfg, cfg);
+        assert!(unused.is_empty());
 
         Ok(())
     }
@@ -157,9 +158,10 @@ mod tests {
           volumes = ["VOL1_ARG", "VOL2_ARG"]
           passthrough = ["VAR1", "VAR2"]
         "#;
-        let (parsed_cfg, _) = CrossToml::parse(test_str)?;
+        let (parsed_cfg, unused) = CrossToml::parse(test_str)?;
 
         assert_eq!(parsed_cfg, cfg);
+        assert!(unused.is_empty());
 
         Ok(())
     }
@@ -195,9 +197,10 @@ mod tests {
             xargo = false
             image = "test-image"
         "#;
-        let (parsed_cfg, _) = CrossToml::parse(test_str)?;
+        let (parsed_cfg, unused) = CrossToml::parse(test_str)?;
 
         assert_eq!(parsed_cfg, cfg);
+        assert!(unused.is_empty());
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 #![deny(missing_debug_implementations, rust_2018_idioms)]
 
+#[cfg(test)]
+mod tests;
+
 mod cargo;
 mod cli;
 mod config;
@@ -405,7 +408,7 @@ fn toml(root: &Root) -> Result<Option<CrossToml>> {
         let content = file::read(&path)
             .wrap_err_with(|| format!("could not read file `{}`", path.display()))?;
 
-        let config = CrossToml::from_str(&content)
+        let (config, _) = CrossToml::parse(&content)
             .wrap_err_with(|| format!("failed to parse file `{}` as TOML", path.display()))?;
 
         Ok(Some(config))

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,53 @@
+mod toml;
+
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
+
+use once_cell::sync::OnceCell;
+use serde::Deserialize;
+
+static WORKSPACE: OnceCell<PathBuf> = OnceCell::new();
+
+/// Returns the cargo workspace for the manifest
+pub fn get_cargo_workspace() -> &'static Path {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    WORKSPACE.get_or_init(|| {
+        #[derive(Deserialize)]
+        struct Manifest {
+            workspace_root: PathBuf,
+        }
+        let output = std::process::Command::new(
+            std::env::var("CARGO")
+                .ok()
+                .unwrap_or_else(|| "cargo".to_string()),
+        )
+        .arg("metadata")
+        .arg("--format-version=1")
+        .arg("--no-deps")
+        .current_dir(manifest_dir)
+        .output()
+        .unwrap();
+        let manifest: Manifest = serde_json::from_slice(&output.stdout).unwrap();
+        manifest.workspace_root
+    })
+}
+
+pub fn walk_dir<'a>(
+    root: &'_ Path,
+    skip: &'a [impl AsRef<OsStr>],
+) -> impl Iterator<Item = Result<walkdir::DirEntry, walkdir::Error>> + 'a {
+    walkdir::WalkDir::new(root).into_iter().filter_entry(|e| {
+        if skip
+            .iter()
+            .map(|s| -> &std::ffi::OsStr { s.as_ref() })
+            .any(|dir| e.file_name() == dir)
+        {
+            return false;
+        } else if e.file_type().is_dir() {
+            return true;
+        }
+        e.path().extension() == Some("md".as_ref())
+    })
+}

--- a/src/tests/toml.rs
+++ b/src/tests/toml.rs
@@ -1,0 +1,63 @@
+use std::io::Read;
+
+use once_cell::sync::Lazy;
+use regex::{Regex, RegexBuilder};
+
+static TOML_REGEX: Lazy<Regex> = Lazy::new(|| {
+    RegexBuilder::new(r#"```toml\n(.*?)```"#)
+        .multi_line(true)
+        .dot_matches_new_line(true)
+        .build()
+        .unwrap()
+});
+
+#[test]
+fn toml_check() -> Result<(), Box<dyn std::error::Error>> {
+    let workspace_root = super::get_cargo_workspace();
+    let walk = super::walk_dir(
+        workspace_root,
+        &[
+            "target",
+            ".git",
+            "src",
+            "CODE_OF_CONDUCT.md",
+            "CHANGELOG.md",
+        ],
+    );
+
+    for dir_entry in walk {
+        let dir_entry = dir_entry?;
+        if dir_entry.file_type().is_dir() {
+            continue;
+        }
+        eprintln!("File: {:?}", dir_entry.path().display());
+        let mut file = std::fs::File::open(dir_entry.path()).unwrap();
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).unwrap();
+        for matches in TOML_REGEX.captures_iter(&contents) {
+            let fence = matches.get(1).unwrap();
+            eprintln!(
+                "testing snippet at: {}:{:?}",
+                dir_entry.path().display(),
+                text_line_no(&contents, fence.range().start),
+            );
+            assert!(crate::cross_toml::CrossToml::parse(fence.as_str())?
+                .1
+                .is_empty());
+        }
+    }
+    Ok(())
+}
+
+pub fn text_line_no(text: &str, index: usize) -> usize {
+    let mut line_no = 0;
+    let mut count = 0;
+    for line in text.split('\n') {
+        line_no += 1;
+        count += line.as_bytes().len() + 1;
+        if count >= index {
+            break;
+        }
+    }
+    line_no
+}


### PR DESCRIPTION
Fixes a wrong assumption done in #670 where we went from

```toml
[target.aarch64-unknown-linux-gnu.env]
volumes = [
    "BUILD_DIR",
]
```

to

```toml
[target.aarch64-unknown-linux-gnu]
volumes = [
    "BUILD_DIR",
]
```

this fixes that, and makes sure that all markdown toml fences are checked in CI for correctness.

This pr also "un-opts" what was previously `CrossBuildConfig` to simplify a bit, see https://github.com/cross-rs/cross/pull/670#discussion_r832571356