### PR TITLE
enable cargo workspace and path dependencies to work seamlessly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - #543 - Added environment variables to control the UID and GID in the container
 - #524 - docker: Add Nix Store volume support
 - Added support for mounting volumes.
+- #684 - Enable cargo workspaces to work from any path in the workspace, and make path dependencies mount seamlessly.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Re-enabled `sparc64-unknown-linux-gnu` image
 - #582 - Added `libprocstat.so` to FreeBSD images
 - #665 - when not using [env.volumes](https://github.com/cross-rs/cross#mounting-volumes-into-the-build-environment), mount project in /project
+- #494 - Parse Cargo's --manifest-path option to determine mounted docker root
 
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -362,15 +362,6 @@ $ QEMU_STRACE=1 cross run --target aarch64-unknown-linux-gnu
 9 exit_group(0)
 ```
 
-## Caveats
-
-- path dependencies (in Cargo.toml) that point outside the Cargo project won't
-  work because `cross` use docker containers only mounts the Cargo project so
-  the container doesn't have access to the rest of the filesystem.
-  However, you may use Cargo's `--manifest-path` option to reference your
-  target crate, executed from a common root directory from which all your
-  dependencies are available.
-
 ## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile on stable Rust 1.58.1 and up. It *might*

--- a/README.md
+++ b/README.md
@@ -367,6 +367,9 @@ $ QEMU_STRACE=1 cross run --target aarch64-unknown-linux-gnu
 - path dependencies (in Cargo.toml) that point outside the Cargo project won't
   work because `cross` use docker containers only mounts the Cargo project so
   the container doesn't have access to the rest of the filesystem.
+  However, you may use Cargo's `--manifest-path` option to reference your
+  target crate, executed from a common root directory from which all your
+  dependencies are available.
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -135,6 +135,21 @@ EOF
                 popd
 
                 rm -rf "${td}"
+                td=$(mktemp -d)
+                git clone \
+                    --depth 1 \
+                    --recursive \
+                    https://github.com/cross-rs/test-workspace "${td}"
+                
+                pushd "${td}"
+      cross run --target "${TARGET}" -p binary --manifest-path="./workspace/Cargo.toml"
+                pushd "workspace"
+                cross run --target "${TARGET}" -p binary
+                pushd "binary"
+                cross run --target "${TARGET}"
+                popd
+                popd
+                popd
             ;;
         esac
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -25,6 +25,13 @@ function retry {
   return ${exit_code}
 }
 
+workspace_test() {
+  cross build --target "${TARGET}" --workspace "${@}"
+  cross run --target "${TARGET}" -p binary "${@}"
+  cross run --target "${TARGET}" --bin dependencies \
+    --features=dependencies "${@}"
+}
+
 main() {
     local td=
 
@@ -142,9 +149,9 @@ EOF
                     https://github.com/cross-rs/test-workspace "${td}"
                 
                 pushd "${td}"
-      cross run --target "${TARGET}" -p binary --manifest-path="./workspace/Cargo.toml"
+                TARGET="${TARGET}" workspace_test --manifest-path="./workspace/Cargo.toml"
                 pushd "workspace"
-                cross run --target "${TARGET}" -p binary
+                TARGET="${TARGET}" workspace_test
                 pushd "binary"
                 cross run --target "${TARGET}"
                 popd

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -26,10 +26,11 @@ function retry {
 }
 
 workspace_test() {
-  cross build --target "${TARGET}" --workspace "${@}"
-  cross run --target "${TARGET}" -p binary "${@}"
+  # "${@}" is an unbound variable for bash 3.2, which is the installed version on macOS
+  cross build --target "${TARGET}" --workspace "$@"
+  cross run --target "${TARGET}" -p binary "$@"
   cross run --target "${TARGET}" --bin dependencies \
-    --features=dependencies "${@}"
+    --features=dependencies "$@"
 }
 
 main() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,7 @@ pub struct Args {
     pub subcommand: Option<Subcommand>,
     pub channel: Option<String>,
     pub target: Option<Target>,
+    pub features: Vec<String>,
     pub target_dir: Option<PathBuf>,
     pub docker_in_docker: bool,
     pub enable_doctests: bool,
@@ -73,6 +74,7 @@ pub fn fmt_subcommands(stdout: &str) {
 pub fn parse(target_list: &TargetList) -> Result<Args> {
     let mut channel = None;
     let mut target = None;
+    let mut features = Vec::new();
     let mut manifest_path: Option<PathBuf> = None;
     let mut target_dir = None;
     let mut sc = None;
@@ -111,6 +113,15 @@ pub fn parse(target_list: &TargetList) -> Result<Args> {
                     .split_once('=')
                     .map(|(_, t)| Target::from(t, target_list));
                 all.push(arg);
+            } else if arg == "--features" {
+                all.push(arg);
+                if let Some(t) = args.next() {
+                    features.push(t.clone());
+                    all.push(t);
+                }
+            } else if arg.starts_with("--features=") {
+                features.extend(arg.split_once('=').map(|(_, t)| t.to_owned()));
+                all.push(arg);
             } else if arg == "--target-dir" {
                 all.push(arg);
                 if let Some(td) = args.next() {
@@ -144,6 +155,7 @@ pub fn parse(target_list: &TargetList) -> Result<Args> {
         subcommand: sc,
         channel,
         target,
+        features,
         target_dir,
         docker_in_docker,
         enable_doctests,

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use config::Config;
 use rustc_version::Channel;
 use serde::Deserialize;
 
-use self::cargo::{Root, Subcommand};
+use self::cargo::{CargoMetadata, Subcommand};
 use self::cross_toml::CrossToml;
 use self::errors::*;
 use self::extensions::OutputExt;
@@ -282,9 +282,10 @@ fn run() -> Result<ExitStatus> {
 
     let host_version_meta =
         rustc_version::version_meta().wrap_err("couldn't fetch the `rustc` version")?;
-    if let Some(root) = cargo::root(None)? {
+    let cwd = std::env::current_dir()?;
+    if let Some(metadata) = cargo::cargo_metadata_with_args(Some(&cwd), Some(&args))? {
         let host = host_version_meta.host();
-        let toml = toml(&root)?;
+        let toml = toml(&metadata)?;
         let config = Config::new(toml);
         let target = args
             .target
@@ -407,16 +408,18 @@ fn run() -> Result<ExitStatus> {
                     docker::register(&target, verbose)?
                 }
 
+                let docker_root = env::current_dir()?;
                 return docker::run(
                     &target,
                     &filtered_args,
                     &args.target_dir,
-                    &root,
+                    &metadata,
                     &config,
                     uses_xargo,
                     &sysroot,
                     verbose,
                     args.docker_in_docker,
+                    &cwd,
                 );
             }
         }
@@ -489,10 +492,10 @@ pub(crate) fn warn_host_version_mismatch(
 
 /// Parses the `Cross.toml` at the root of the Cargo project or from the
 /// `CROSS_CONFIG` environment variable (if any exist in either location).
-fn toml(root: &Root) -> Result<Option<CrossToml>> {
+fn toml(root: &CargoMetadata) -> Result<Option<CrossToml>> {
     let path = match env::var("CROSS_CONFIG") {
         Ok(var) => PathBuf::from(var),
-        Err(_) => root.path().join("Cross.toml"),
+        Err(_) => root.workspace_root().join("Cross.toml"),
     };
 
     if path.exists() {
@@ -505,7 +508,7 @@ fn toml(root: &Root) -> Result<Option<CrossToml>> {
         Ok(Some(config))
     } else {
         // Checks if there is a lowercase version of this file
-        if root.path().join("cross.toml").exists() {
+        if root.workspace_root().join("cross.toml").exists() {
             eprintln!("There's a file named cross.toml, instead of Cross.toml. You may want to rename it, or it won't be considered.");
         }
         Ok(None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,7 @@ fn run() -> Result<ExitStatus> {
 
     let host_version_meta =
         rustc_version::version_meta().wrap_err("couldn't fetch the `rustc` version")?;
-    if let Some(root) = cargo::root()? {
+    if let Some(root) = cargo::root(None)? {
         let host = host_version_meta.host();
         let toml = toml(&root)?;
         let config = Config::new(toml);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,23 +15,10 @@ static WORKSPACE: OnceCell<PathBuf> = OnceCell::new();
 pub fn get_cargo_workspace() -> &'static Path {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     WORKSPACE.get_or_init(|| {
-        #[derive(Deserialize)]
-        struct Manifest {
-            workspace_root: PathBuf,
-        }
-        let output = std::process::Command::new(
-            std::env::var("CARGO")
-                .ok()
-                .unwrap_or_else(|| "cargo".to_string()),
-        )
-        .arg("metadata")
-        .arg("--format-version=1")
-        .arg("--no-deps")
-        .current_dir(manifest_dir)
-        .output()
-        .unwrap();
-        let manifest: Manifest = serde_json::from_slice(&output.stdout).unwrap();
-        manifest.workspace_root
+        crate::cargo::root(Some(manifest_dir.as_ref()))
+            .unwrap()
+            .unwrap()
+            .path
     })
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,7 +7,6 @@ use std::{
 
 use once_cell::sync::OnceCell;
 use rustc_version::VersionMeta;
-use serde::Deserialize;
 
 static WORKSPACE: OnceCell<PathBuf> = OnceCell::new();
 
@@ -15,10 +14,10 @@ static WORKSPACE: OnceCell<PathBuf> = OnceCell::new();
 pub fn get_cargo_workspace() -> &'static Path {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     WORKSPACE.get_or_init(|| {
-        crate::cargo::root(Some(manifest_dir.as_ref()))
+        crate::cargo::cargo_metadata(Some(manifest_dir.as_ref()))
             .unwrap()
             .unwrap()
-            .path
+            .workspace_root
     })
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,7 +14,7 @@ static WORKSPACE: OnceCell<PathBuf> = OnceCell::new();
 pub fn get_cargo_workspace() -> &'static Path {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     WORKSPACE.get_or_init(|| {
-        crate::cargo::cargo_metadata(Some(manifest_dir.as_ref()))
+        crate::cargo::cargo_metadata_with_args(Some(manifest_dir.as_ref()), None, true)
             .unwrap()
             .unwrap()
             .workspace_root


### PR DESCRIPTION
This will allow cargo workspaces to work seamlessly with cross, assuming they don't reference anything outside the current workspace root. This change also automatically mounts (if needed) path dependencies.

If they do reference things outside the workspace root, and that fact is not know to `cargo metadata` (e.g, it's not a workspace member or a path dependency), you'll have to mount it with

```toml
[build.env]
volumes = ["THING"]
```

and set `$THING="/path/to/thing"` (we need to work on accessibility for this feature too, a lot of reported issues are solved by it)

I'm sure there is an issue directly related to workspaces, but I can't find any.

fixes #388 