### PR TITLE
don't require other approval for bors

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,6 +1,5 @@
 block_labels = ["needs-decision"]
 delete_merged_branches = true
-required_approvals = 1
 use_codeowners = true
 status = ["conclusion"]
 timeout_sec = 21600


### PR DESCRIPTION
This change removes the required approvals condition that was required by convention before we switched to our own organization.

With this change, more care has to be taken into account from maintainers (who have `bors r+` privileges) when merging their own PRs, but this also allows quicker development when members are not available to review prs and sufficient thought has been taken into account. Ideally, "bad" changes would be caught by CI.

For the above reason, before merging this I think it'd be good if current @cross-rs/maintainers could sign off and approve the PR (leave a tick next to your name and possibly approve via review) before it's ultimately merged (we do not currently have a policy on how breaking changes or expectations are managed, so this is kinda arbitrary but takes from regular practice).

* [x] @adamgreig 
* [x] @Dylan-DPC 
* [x] @Emilgardis 
* [x] @reitermarkus 
* [x] @svenstaro 
* [x] @therealprof