### PR TITLE
Add sysroot to `BINDGEN_EXTRA_CLANG_ARGS` env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- #707 - Set `BINDGEN_EXTRA_CLANG_ARGS` environment variable to pass sysroot to `rust-bindgen`
 - #696 - bump freebsd to 12.3
 - #629 - Update Android NDK version and API version
 - #681 - Warn on unknown fields and confusable targets

--- a/docker/Dockerfile.aarch64-linux-android
+++ b/docker/Dockerfile.aarch64-linux-android
@@ -29,6 +29,7 @@ ENV CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android-gcc \
     CC_aarch64_linux_android=aarch64-linux-android-gcc \
     CXX_aarch64_linux_android=aarch64-linux-android-g++ \
     DEP_Z_INCLUDE=/android-ndk/sysroot/usr/include/ \
+    BINDGEN_EXTRA_CLANG_ARGS_AARCH64_LINUX_ANDROID="--sysroot=/android-ndk/sysroot" \
     RUST_TEST_THREADS=1 \
     HOME=/tmp/ \
     TMPDIR=/tmp/ \

--- a/docker/Dockerfile.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu
@@ -30,4 +30,5 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
     CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
     CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
     QEMU_LD_PREFIX=/usr/aarch64-linux-gnu \
+    BINDGEN_EXTRA_CLANG_ARGS_AARCH64_UNKNOWN_LINUX_GNU="--sysroot=/usr/aarch64-linux-gnu" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.aarch64-unknown-linux-musl
+++ b/docker/Dockerfile.aarch64-unknown-linux-musl
@@ -20,7 +20,6 @@ RUN /musl.sh TARGET=aarch64-linux-musl
 RUN ln -sf \
     /usr/local/aarch64-linux-musl/lib/libc.so \
     /usr/local/aarch64-linux-musl/lib/ld-musl-aarch64.so.1
-ENV QEMU_LD_PREFIX=/usr/local/aarch64-linux-musl
 
 COPY aarch64-linux-musl-gcc.sh /usr/bin/
 
@@ -28,4 +27,6 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc.sh \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER=qemu-aarch64 \
     CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc \
     CXX_aarch64_unknown_linux_musl=aarch64-linux-musl-g++ \
+    QEMU_LD_PREFIX=/usr/local/aarch64-linux-musl \
+    BINDGEN_EXTRA_CLANG_ARGS_AARCH64_UNKNOWN_LINUX_MUSL="--sysroot=/usr/local/aarch64-linux-musl" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.arm-linux-androideabi
+++ b/docker/Dockerfile.arm-linux-androideabi
@@ -29,6 +29,7 @@ ENV CARGO_TARGET_ARM_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc \
     CC_arm_linux_androideabi=arm-linux-androideabi-gcc \
     CXX_arm_linux_androideabi=arm-linux-androideabi-g++ \
     DEP_Z_INCLUDE=/android-ndk/sysroot/usr/include/ \
+    BINDGEN_EXTRA_CLANG_ARGS_ARM_LINUX_ANDROIDEABI="--sysroot=/android-ndk/sysroot" \
     RUST_TEST_THREADS=1 \
     HOME=/tmp/ \
     TMPDIR=/tmp/ \

--- a/docker/Dockerfile.arm-unknown-linux-gnueabi
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabi
@@ -21,4 +21,5 @@ ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER=arm-linux-gnueabi-gcc \
     CC_arm_unknown_linux_gnueabi=arm-linux-gnueabi-gcc \
     CXX_arm_unknown_linux_gnueabi=arm-linux-gnueabi-g++ \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabi \
+    BINDGEN_EXTRA_CLANG_ARGS_ARM_UNKNOWN_LINUX_GNUEABI="--sysroot=/usr/arm-linux-gnueabi" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.arm-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabihf
@@ -27,5 +27,6 @@ ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
     CC_arm_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
     CXX_arm_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++ \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf/arm-linux-gnueabihf/libc \
+    BINDGEN_EXTRA_CLANG_ARGS_ARM_UNKNOWN_LINUX_GNUEABIHF="--sysroot=/usr/arm-linux-gnueabihf/arm-linux-gnueabihf/libc" \
     LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/arm-linux-gnueabihf/libc/lib:/usr/arm-linux-gnueabihf/arm-linux-gnueabihf/lib:/usr/arm-linux-gnueabihf/lib \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.arm-unknown-linux-musleabi
+++ b/docker/Dockerfile.arm-unknown-linux-musleabi
@@ -24,10 +24,11 @@ RUN /musl.sh \
 RUN ln -sf \
     /usr/local/arm-linux-musleabi/lib/libc.so \
     /usr/local/arm-linux-musleabi/lib/ld-musl-arm.so.1
-ENV QEMU_LD_PREFIX=/usr/local/arm-linux-musleabi
 
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABI_LINKER=arm-linux-musleabi-gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABI_RUNNER=qemu-arm \
     CC_arm_unknown_linux_musleabi=arm-linux-musleabi-gcc \
     CXX_arm_unknown_linux_musleabi=arm-linux-musleabi-g++ \
+    QEMU_LD_PREFIX=/usr/local/arm-linux-musleabi \
+    BINDGEN_EXTRA_CLANG_ARGS_ARM_UNKNOWN_LINUX_MUSLEABI="--sysroot=/usr/local/arm-linux-musleabi" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.arm-unknown-linux-musleabihf
+++ b/docker/Dockerfile.arm-unknown-linux-musleabihf
@@ -25,10 +25,11 @@ RUN /musl.sh \
 RUN ln -sf \
     /usr/local/arm-linux-musleabihf/lib/libc.so \
     /usr/local/arm-linux-musleabihf/lib/ld-musl-armhf.so.1
-ENV QEMU_LD_PREFIX=/usr/local/arm-linux-musleabihf
 
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_LINKER=arm-linux-musleabihf-gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUNNER=qemu-arm \
     CC_arm_unknown_linux_musleabihf=arm-linux-musleabihf-gcc \
     CXX_arm_unknown_linux_musleabihf=arm-linux-musleabihf-g++ \
+    QEMU_LD_PREFIX=/usr/local/arm-linux-musleabihf \
+    BINDGEN_EXTRA_CLANG_ARGS_ARM_UNKNOWN_LINUX_MUSLEABIHF="--sysroot=/usr/local/arm-linux-musleabihf" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.armv5te-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-gnueabi
@@ -22,4 +22,5 @@ ENV CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_GNUEABI_LINKER=arm-linux-gnueabi-gcc \
     CC_armv5te_unknown_linux_gnueabi=arm-linux-gnueabi-gcc \
     CXX_armv5te_unknown_linux_gnueabi=arm-linux-gnueabi-g++ \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabi \
+    BINDGEN_EXTRA_CLANG_ARGS_ARMV5TE_UNKNOWN_LINUX_GNUEABI="--sysroot=/usr/arm-linux-gnueabi" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.armv5te-unknown-linux-musleabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-musleabi
@@ -24,10 +24,11 @@ RUN /musl.sh \
 RUN ln -sf \
     /usr/local/arm-linux-musleabi/lib/libc.so \
     /usr/local/arm-linux-musleabi/lib/ld-musl-arm.so.1
-ENV QEMU_LD_PREFIX=/usr/local/arm-linux-musleabi
 
 ENV CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_LINKER=arm-linux-musleabi-gcc \
     CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_RUNNER=qemu-arm \
     CC_armv5te_unknown_linux_musleabi=arm-linux-musleabi-gcc \
     CXX_armv5te_unknown_linux_musleabi=arm-linux-musleabi-g++ \
+    QEMU_LD_PREFIX=/usr/local/arm-linux-musleabi \
+    BINDGEN_EXTRA_CLANG_ARGS_ARMV5TE_UNKNOWN_LINUX_MUSLEABI="--sysroot=/usr/arm-linux-musleabi" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.armv7-linux-androideabi
+++ b/docker/Dockerfile.armv7-linux-androideabi
@@ -29,6 +29,7 @@ ENV CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc \
     CC_armv7_linux_androideabi=arm-linux-androideabi-gcc \
     CXX_armv7_linux_androideabi=arm-linux-androideabi-g++ \
     DEP_Z_INCLUDE=/android-ndk/sysroot/usr/include/ \
+    BINDGEN_EXTRA_CLANG_ARGS_ARMV7_LINUX_ANDROIDEABI="--sysroot=/android-ndk/sysroot" \
     RUST_TEST_THREADS=1 \
     HOME=/tmp/ \
     TMPDIR=/tmp/ \

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -30,4 +30,5 @@ ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
     CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
     CXX_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++ \
     QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
+    BINDGEN_EXTRA_CLANG_ARGS_ARMV7_UNKNOWN_LINUX_GNUEABIHF="--sysroot=/usr/arm-linux-gnueabihf" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.armv7-unknown-linux-musleabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-musleabihf
@@ -25,10 +25,11 @@ RUN /musl.sh \
 RUN ln -sf \
     /usr/local/arm-linux-musleabihf/lib/libc.so \
     /usr/local/arm-linux-musleabihf/lib/ld-musl-armhf.so.1
-ENV QEMU_LD_PREFIX=/usr/local/arm-linux-musleabihf
 
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER=arm-linux-musleabihf-gcc \
     CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_RUNNER=qemu-arm \
     CC_armv7_unknown_linux_musleabihf=arm-linux-musleabihf-gcc \
     CXX_armv7_unknown_linux_musleabihf=arm-linux-musleabihf-g++ \
+    QEMU_LD_PREFIX=/usr/local/arm-linux-musleabihf \
+    BINDGEN_EXTRA_CLANG_ARGS_ARMV7_UNKNOWN_LINUX_MUSLEABIHF="--sysroot=/usr/local/arm-linux-musleabihf" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.i586-unknown-linux-musl
+++ b/docker/Dockerfile.i586-unknown-linux-musl
@@ -15,4 +15,5 @@ RUN /musl.sh TARGET=i586-linux-musl
 
 ENV CARGO_TARGET_I586_UNKNOWN_LINUX_MUSL_LINKER=i586-linux-musl-gcc \
     CC_i586_unknown_linux_musl=i586-linux-musl-gcc \
-    CXX_i586_unknown_linux_musl=i586-linux-musl-g++
+    CXX_i586_unknown_linux_musl=i586-linux-musl-g++ \
+    BINDGEN_EXTRA_CLANG_ARGS_I586_UNKNOWN_LINUX_MUSL="--sysroot=/usr/local/i586-linux-musl"

--- a/docker/Dockerfile.i686-linux-android
+++ b/docker/Dockerfile.i686-linux-android
@@ -36,6 +36,7 @@ ENV CARGO_TARGET_I686_LINUX_ANDROID_LINKER=i686-linux-android-gcc \
     CC_i686_linux_android=i686-linux-android-gcc \
     CXX_i686_linux_android=i686-linux-android-g++ \
     DEP_Z_INCLUDE=/android-ndk/sysroot/usr/include/ \
+    BINDGEN_EXTRA_CLANG_ARGS_I686_LINUX_ANDROID="--sysroot=/android-ndk/sysroot" \
     LIBZ_SYS_STATIC=1 \
     RUST_TEST_THREADS=1 \
     HOME=/tmp/ \

--- a/docker/Dockerfile.i686-pc-windows-gnu
+++ b/docker/Dockerfile.i686-pc-windows-gnu
@@ -38,4 +38,5 @@ ENTRYPOINT ["/windows-entry.sh"]
 ENV CARGO_TARGET_I686_PC_WINDOWS_GNU_LINKER=i686-w64-mingw32-gcc \
     CARGO_TARGET_I686_PC_WINDOWS_GNU_RUNNER=wine \
     CC_i686_pc_windows_gnu=i686-w64-mingw32-gcc-posix \
-    CXX_i686_pc_windows_gnu=i686-w64-mingw32-g++-posix
+    CXX_i686_pc_windows_gnu=i686-w64-mingw32-g++-posix \
+    BINDGEN_EXTRA_CLANG_ARGS_I686_PC_WINDOWS_GNU="--sysroot=/usr/i686-w64-mingw32"

--- a/docker/Dockerfile.mips-unknown-linux-gnu
+++ b/docker/Dockerfile.mips-unknown-linux-gnu
@@ -30,4 +30,5 @@ ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc \
     CC_mips_unknown_linux_gnu=mips-linux-gnu-gcc \
     CXX_mips_unknown_linux_gnu=mips-linux-gnu-g++ \
     QEMU_LD_PREFIX=/usr/mips-linux-gnu \
+    BINDGEN_EXTRA_CLANG_ARGS_MIPS_UNKNOWN_LINUX_GNU="--sysroot=/usr/mips-linux-gnu" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.mips-unknown-linux-musl
+++ b/docker/Dockerfile.mips-unknown-linux-musl
@@ -22,11 +22,11 @@ RUN /musl.sh \
 RUN ln -sf \
     /usr/local/mips-linux-muslsf/lib/libc.so \
     /usr/local/mips-linux-muslsf/lib/ld-musl-mips-sf.so.1
-ENV QEMU_LD_PREFIX=/usr/local/mips-linux-muslsf
 
 ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_LINKER=mips-linux-muslsf-gcc \
     CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_RUNNER=qemu-mips \
     CC_mips_unknown_linux_musl=mips-linux-muslsf-gcc \
     CXX_mips_unknown_linux_musl=mips-linux-muslsf-g++ \
-    RUST_TEST_THREADS=1 \
-    QEMU_LD_PREFIX=/usr/local/mips-linux-muslsf
+    QEMU_LD_PREFIX=/usr/local/mips-linux-muslsf \
+    BINDGEN_EXTRA_CLANG_ARGS_MIPS_UNKNOWN_LINUX_MUSL="--sysroot=/usr/local/mips-linux-muslsf" \
+    RUST_TEST_THREADS=1

--- a/docker/Dockerfile.mips64-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-gnuabi64
@@ -21,4 +21,5 @@ ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_LINKER=mips64-linux-gnuabi64-gcc 
     CC_mips64_unknown_linux_gnuabi64=mips64-linux-gnuabi64-gcc \
     CXX_mips64_unknown_linux_gnuabi64=mips64-linux-gnuabi64-g++ \
     QEMU_LD_PREFIX=/usr/mips64-linux-gnuabi64 \
+    BINDGEN_EXTRA_CLANG_ARGS_MIPS64_UNKNOWN_LINUX_GNUABI64="--sysroot=/usr/mips64-linux-gnuabi64" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.mips64-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-muslabi64
@@ -21,10 +21,11 @@ RUN /musl.sh \
 RUN ln -sf \
     /usr/local/mips64-linux-muslsf/lib/libc.so \
     /usr/local/mips64-linux-muslsf/lib/ld-musl-mips64-sf.so.1
-ENV QEMU_LD_PREFIX=/usr/local/mips64-linux-muslsf
 
 ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_LINKER=mips64-linux-muslsf-gcc \
     CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_RUNNER=qemu-mips64 \
     CC_mips64_unknown_linux_muslabi64=mips64-linux-muslsf-gcc \
     CXX_mips64_unknown_linux_muslabi64=mips64-linux-muslsf-g++ \
+    QEMU_LD_PREFIX=/usr/local/mips64-linux-muslsf \
+    BINDGEN_EXTRA_CLANG_ARGS_MIPS64_UNKNOWN_LINUX_MUSLABI64="--sysroot=/usr/local/mips64-linux-muslsf" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
@@ -30,4 +30,5 @@ ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_LINKER=mips64el-linux-gnuabi64-
     CC_mips64el_unknown_linux_gnuabi64=mips64el-linux-gnuabi64-gcc \
     CXX_mips64el_unknown_linux_gnuabi64=mips64el-linux-gnuabi64-g++ \
     QEMU_LD_PREFIX=/usr/mips64el-linux-gnuabi64 \
+    BINDGEN_EXTRA_CLANG_ARGS_MIPS64EL_UNKNOWN_LINUX_GNUABI64="--sysroot=/usr/mips64el-linux-gnuabi64" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.mips64el-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-muslabi64
@@ -21,10 +21,11 @@ RUN /musl.sh \
 RUN ln -sf \
     /usr/local/mips64el-linux-muslsf/lib/libc.so \
     /usr/local/mips64el-linux-muslsf/lib/ld-musl-mips64el-sf.so.1
-ENV QEMU_LD_PREFIX=/usr/local/mips64el-linux-muslsf
 
 ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_LINKER=mips64el-linux-muslsf-gcc \
     CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_RUNNER=qemu-mips64el \
     CC_mips64el_unknown_linux_muslabi64=mips64el-linux-muslsf-gcc \
     CXX_mips64el_unknown_linux_muslabi64=mips64el-linux-muslsf-g++ \
+    EMU_LD_PREFIX=/usr/local/mips64el-linux-muslsf \
+    BINDGEN_EXTRA_CLANG_ARGS_MIPS64EL_UNKNOWN_LINUX_MUSLABI64="--sysroot=/usr/local/mips64el-linux-muslsf" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.mipsel-unknown-linux-gnu
+++ b/docker/Dockerfile.mipsel-unknown-linux-gnu
@@ -30,4 +30,5 @@ ENV CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER=mipsel-linux-gnu-gcc \
     CC_mipsel_unknown_linux_gnu=mipsel-linux-gnu-gcc \
     CXX_mipsel_unknown_linux_gnu=mipsel-linux-gnu-g++ \
     QEMU_LD_PREFIX=/usr/mipsel-linux-gnu \
+    BINDGEN_EXTRA_CLANG_ARGS_MIPSEL_UNKNOWN_LINUX_GNU="--sysroot=/usr/mipsel-linux-gnu" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.mipsel-unknown-linux-musl
+++ b/docker/Dockerfile.mipsel-unknown-linux-musl
@@ -22,10 +22,11 @@ RUN /musl.sh \
 RUN ln -sf \
     /usr/local/mipsel-linux-muslsf/lib/libc.so \
     /usr/local/mipsel-linux-muslsf/lib/ld-musl-mipsel-sf.so.1
-ENV QEMU_LD_PREFIX=/usr/local/mipsel-linux-muslsf
 
 ENV CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_LINKER=mipsel-linux-muslsf-gcc \
     CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_RUNNER=qemu-mipsel \
     CC_mipsel_unknown_linux_musl=mipsel-linux-muslsf-gcc \
     CXX_mipsel_unknown_linux_musl=mipsel-linux-muslsf-g++ \
+    QEMU_LD_PREFIX=/usr/local/mipsel-linux-muslsf \
+    BINDGEN_EXTRA_CLANG_ARGS_MIPSEL_UNKNOWN_LINUX_MUSL="--sysroot=/usr/local/mipsel-linux-muslsf" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.powerpc-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc-unknown-linux-gnu
@@ -30,4 +30,5 @@ ENV CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER=powerpc-linux-gnu-gcc \
     CC_powerpc_unknown_linux_gnu=powerpc-linux-gnu-gcc \
     CXX_powerpc_unknown_linux_gnu=powerpc-linux-gnu-g++ \
     QEMU_LD_PREFIX=/usr/powerpc-linux-gnu \
+    BINDGEN_EXTRA_CLANG_ARGS_POWERPC_UNKNOWN_LINUX_GNU="--sysroot=/usr/powerpc-linux-gnu" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.powerpc64-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64-unknown-linux-gnu
@@ -30,4 +30,5 @@ ENV CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER=powerpc64-linux-gnu-gcc \
     CC_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-gcc \
     CXX_powerpc64_unknown_linux_gnu=powerpc64-linux-gnu-g++ \
     QEMU_LD_PREFIX=/usr/powerpc64-linux-gnu \
+    BINDGEN_EXTRA_CLANG_ARGS_POWERPC64_UNKNOWN_LINUX_GNU="--sysroot=/usr/powerpc64-linux-gnu" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.powerpc64le-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64le-unknown-linux-gnu
@@ -30,4 +30,5 @@ ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-linux-gnu-gcc 
     CC_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-gcc \
     CXX_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-g++ \
     QEMU_LD_PREFIX=/usr/powerpc64le-linux-gnu \
+    BINDGEN_EXTRA_CLANG_ARGS_POWERPC64LE_UNKNOWN_LINUX_GNU="--sysroot=/usr/powerpc64le-linux-gnu" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.riscv64gc-unknown-linux-gnu
+++ b/docker/Dockerfile.riscv64gc-unknown-linux-gnu
@@ -24,4 +24,5 @@ ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc \
     CC_riscv64gc_unknown_linux_gnu=riscv64-linux-gnu-gcc \
     CXX_riscv64gc_unknown_linux_gnu=riscv64-linux-gnu-g++ \
     QEMU_LD_PREFIX=/usr/riscv64-linux-gnu \
+    BINDGEN_EXTRA_CLANG_ARGS_RISCV64GC_UNKNOWN_LINUX_GNU="--sysroot=/usr/riscv64-linux-gnu" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.s390x-unknown-linux-gnu
+++ b/docker/Dockerfile.s390x-unknown-linux-gnu
@@ -30,4 +30,5 @@ ENV CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc \
     CC_s390x_unknown_linux_gnu=s390x-linux-gnu-gcc \
     CXX_s390x_unknown_linux_gnu=s390x-linux-gnu-g++ \
     QEMU_LD_PREFIX=/usr/s390x-linux-gnu \
+    BINDGEN_EXTRA_CLANG_ARGS_S390X_UNKNOWN_LINUX_GNU="--sysroot=/usr/s390x-linux-gnu" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.sparc64-unknown-linux-gnu
+++ b/docker/Dockerfile.sparc64-unknown-linux-gnu
@@ -30,4 +30,5 @@ ENV CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_LINKER=sparc64-linux-gnu-gcc \
     CC_sparc64_unknown_linux_gnu=sparc64-linux-gnu-gcc \
     CXX_sparc64_unknown_linux_gnu=sparc64-linux-gnu-g++ \
     QEMU_LD_PREFIX=/usr/sparc64-linux-gnu \
+    BINDGEN_EXTRA_CLANG_ARGS_SPARC64_UNKNOWN_LINUX_GNU="--sysroot=/usr/sparc64-linux-gnu" \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.sparcv9-sun-solaris
+++ b/docker/Dockerfile.sparcv9-sun-solaris
@@ -15,4 +15,5 @@ RUN /solaris.sh sparcv9
 
 ENV CARGO_TARGET_SPARCV9_SUN_SOLARIS_LINKER=sparcv9-sun-solaris2.10-gcc \
     CC_sparcv9_sun_solaris=sparcv9-sun-solaris2.10-gcc \
-    CXX_sparcv9_sun_solaris=sparcv9-sun-solaris2.10-g++
+    CXX_sparcv9_sun_solaris=sparcv9-sun-solaris2.10-g++ \
+    BINDGEN_EXTRA_CLANG_ARG_SPARCV9_SUN_SOLARIS="--sysroot=/usr/local/sparcv9-sun-solaris2.10"

--- a/docker/Dockerfile.x86_64-linux-android
+++ b/docker/Dockerfile.x86_64-linux-android
@@ -30,6 +30,7 @@ ENV CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android-gcc \
     CC_x86_64_linux_android=x86_64-linux-android-gcc \
     CXX_x86_64_linux_android=x86_64-linux-android-g++ \
     DEP_Z_INCLUDE=/android-ndk/sysroot/usr/include/ \
+    BINDGEN_EXTRA_CLANG_ARGS_X86_64_LINUX_ANDROID="--sysroot=/android-ndk/sysroot" \
     RUST_TEST_THREADS=1 \
     HOME=/tmp/ \
     TMPDIR=/tmp/ \

--- a/docker/Dockerfile.x86_64-pc-windows-gnu
+++ b/docker/Dockerfile.x86_64-pc-windows-gnu
@@ -36,4 +36,5 @@ ENTRYPOINT ["/windows-entry.sh"]
 ENV CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc \
     CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER=wine \
     CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc-posix \
-    CXX_x86_64_pc_windows_gnu=x86_64-w64-mingw32-g++-posix
+    CXX_x86_64_pc_windows_gnu=x86_64-w64-mingw32-g++-posix \
+    BINDGEN_EXTRA_CLANG_ARGS_X86_64_PC_WINDOWS_GNU="--sysroot=/usr/x86_64-w64-mingw32"

--- a/docker/Dockerfile.x86_64-sun-solaris
+++ b/docker/Dockerfile.x86_64-sun-solaris
@@ -15,4 +15,5 @@ RUN /solaris.sh x86_64
 
 ENV CARGO_TARGET_X86_64_SUN_SOLARIS_LINKER=x86_64-sun-solaris2.10-gcc \
     CC_x86_64_sun_solaris=x86_64-sun-solaris2.10-gcc \
-    CXX_x86_64_sun_solaris=x86_64-sun-solaris2.10-g++
+    CXX_x86_64_sun_solaris=x86_64-sun-solaris2.10-g++ \
+    BINDGEN_EXTRA_CLANG_ARG_X86_64_SUN_SOLARIS="--sysroot=/usr/local/x86_64-sun-solaris2.10"

--- a/docker/Dockerfile.x86_64-unknown-freebsd
+++ b/docker/Dockerfile.x86_64-unknown-freebsd
@@ -19,4 +19,5 @@ RUN /freebsd-extras.sh x86_64
 ENV CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER=x86_64-unknown-freebsd12-gcc \
     CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd12-gcc \
     CXX_x86_64_unknown_freebsd=x86_64-unknown-freebsd12-g++ \
+    BINDGEN_EXTRA_CLANG_ARGS_X86_64_UNKNOWN_FREEBSD="--sysroot=/usr/local/x86_64-unknown-freebsd12" \
     X86_64_UNKNOWN_FREEBSD_OPENSSL_DIR=/usr/local/x86_64-unknown-freebsd12/

--- a/docker/Dockerfile.x86_64-unknown-linux-musl
+++ b/docker/Dockerfile.x86_64-unknown-linux-musl
@@ -15,4 +15,5 @@ RUN /musl.sh TARGET=x86_64-linux-musl
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc \
     CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc \
-    CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++
+    CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++ \
+    BINDGEN_EXTRA_CLANG_ARGS_X86_64_UNKNOWN_LINUX_MUSL="--sysroot=/usr/local/x86_64-linux-musl"

--- a/docker/Dockerfile.x86_64-unknown-netbsd
+++ b/docker/Dockerfile.x86_64-unknown-netbsd
@@ -15,4 +15,5 @@ RUN /netbsd.sh
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_NETBSD_LINKER=x86_64-unknown-netbsd-gcc \
     CC_x86_64_unknown_netbsd=x86_64-unknown-netbsd-gcc \
-    CXX_x86_64_unknown_netbsd=x86_64-unknown-netbsd-g++
+    CXX_x86_64_unknown_netbsd=x86_64-unknown-netbsd-g++ \
+    BINDGEN_EXTRA_CLANG_ARGS_X86_64_UNKNOWN_NETBSD="--sysroot=/usr/local/x86_64-unknown-netbsd"

--- a/docker/disabled/Dockerfile.x86_64-unknown-dragonfly
+++ b/docker/disabled/Dockerfile.x86_64-unknown-dragonfly
@@ -15,4 +15,5 @@ RUN /dragonfly.sh
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_DRAGONFLY_LINKER=x86_64-unknown-dragonfly-gcc \
     CC_x86_64_unknown_dragonfly=x86_64-unknown-dragonfly-gcc \
-    CXX_x86_64_unknown_dragonfly=x86_64-unknown-dragonfly-g++
+    CXX_x86_64_unknown_dragonfly=x86_64-unknown-dragonfly-g++ \
+    BINDGEN_EXTRA_CLANG_ARGS_X86_64_UNKNOWN_DRAGONFLY="--sysroot=/usr/local/x86_64-unknown-dragonfly"


### PR DESCRIPTION
This allows projects using [`rust-bindgen`](https://github.com/rust-lang/rust-bindgen) to build properly.