### PR TITLE
Convert --target-dir to use absolute paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- #713 - convert relative target directories to absolute paths.
 - #709 - Update Emscripten targets to `emcc` version 3.1.10
 - #707, #708 - Set `BINDGEN_EXTRA_CLANG_ARGS` environment variable to pass sysroot to `rust-bindgen`
 - #696 - bump freebsd to 12.3

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,7 +263,7 @@ pub fn main() -> Result<()> {
 
 fn run() -> Result<ExitStatus> {
     let target_list = rustc::target_list(false)?;
-    let args = cli::parse(&target_list);
+    let args = cli::parse(&target_list)?;
 
     if args.all.iter().any(|a| a == "--version" || a == "-V") && args.subcommand.is_none() {
         println!(


### PR DESCRIPTION
Converts relative target directories to absolute paths, to avoid creating the target directory in the sysroot. This keeps the prior behavior if the provided target directory is an absolute path.

Fixes #581.