### PR TITLE
Use host target directory when calling host cargo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- #714 - use host target directory when falling back to host cargo.
 - #713 - convert relative target directories to absolute paths.
 - #709 - Update Emscripten targets to `emcc` version 3.1.10
 - #707, #708 - Set `BINDGEN_EXTRA_CLANG_ARGS` environment variable to pass sysroot to `rust-bindgen`

--- a/src/main.rs
+++ b/src/main.rs
@@ -410,7 +410,12 @@ fn run() -> Result<ExitStatus> {
     }
 
     eprintln!("Warning: Falling back to `cargo` on the host.");
-    cargo::run(&args.all, verbose)
+
+    // fix for #619: other subcommands have the wrong target dir here.
+    // in the docker host, the target directory is mounted as /target.
+    // if we fallback to the host cargo, need to use the original path.
+    let argv: Vec<String> = env::args().skip(1).collect();
+    cargo::run(&argv, verbose)
 }
 
 #[derive(PartialEq, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,9 +411,7 @@ fn run() -> Result<ExitStatus> {
 
     eprintln!("Warning: Falling back to `cargo` on the host.");
 
-    // fix for #619: other subcommands have the wrong target dir here.
-    // in the docker host, the target directory is mounted as /target.
-    // if we fallback to the host cargo, need to use the original path.
+    // if we fallback to the host cargo, use the same invocation that was made to cross
     let argv: Vec<String> = env::args().skip(1).collect();
     cargo::run(&argv, verbose)
 }


### PR DESCRIPTION
When using docker, the target directory is mounted at `/target`. However, when falling back to the host cargo, if we provide a custom target directory, we incorrectly pass it as `--target-dir /target`. To rectify this, this PR passes the original command-line arguments to cargo.

Fixes #619.