### PR TITLE
Remove deb subcommand.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- #718 - remove deb subcommand.
 - #714 - use host target directory when falling back to host cargo.
 - #713 - convert relative target directories to absolute paths.
 - #709 - Update Emscripten targets to `emcc` version 3.1.10

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -15,7 +15,6 @@ pub enum Subcommand {
     Rustc,
     Test,
     Bench,
-    Deb,
     Clippy,
     Metadata,
 }
@@ -44,7 +43,6 @@ impl<'a> From<&'a str> for Subcommand {
             "rustc" => Subcommand::Rustc,
             "t" | "test" => Subcommand::Test,
             "bench" => Subcommand::Bench,
-            "deb" => Subcommand::Deb,
             "clippy" => Subcommand::Clippy,
             "metadata" => Subcommand::Metadata,
             _ => Subcommand::Other,


### PR DESCRIPTION
cargo-deb is not installed in the pre-built images, but `cross deb` runs in docker rather than falling back to the host.

Closes #717.