### PR TITLE
Add --list to known subcommands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - #722 - boolean environment variables are evaluated as truthy or falsey.
 - #721 - add support for running doctests on nightly if `CROSS_UNSTABLE_ENABLE_DOCTESTS=true`.
-- #719 - add android runner to preload `libc++_shared.so`.
+- #720 - add android runner to preload `libc++_shared.so`.
+- #719 - add `--list` to known subcommands.
 - #718 - remove deb subcommand.
 - #714 - use host target directory when falling back to host cargo.
 - #713 - convert relative target directories to absolute paths.

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -17,11 +17,12 @@ pub enum Subcommand {
     Bench,
     Clippy,
     Metadata,
+    List,
 }
 
 impl Subcommand {
     pub fn needs_docker(self) -> bool {
-        !matches!(self, Subcommand::Other)
+        !matches!(self, Subcommand::Other | Subcommand::List)
     }
 
     pub fn needs_interpreter(self) -> bool {
@@ -45,6 +46,7 @@ impl<'a> From<&'a str> for Subcommand {
             "bench" => Subcommand::Bench,
             "clippy" => Subcommand::Clippy,
             "metadata" => Subcommand::Metadata,
+            "--list" => Subcommand::List,
             _ => Subcommand::Other,
         }
     }
@@ -87,4 +89,9 @@ pub fn root() -> Result<Option<Root>> {
 /// Pass-through mode
 pub fn run(args: &[String], verbose: bool) -> Result<ExitStatus> {
     Command::new("cargo").args(args).run_and_get_status(verbose)
+}
+
+/// run cargo and get the output, does not check the exit status
+pub fn run_and_get_output(args: &[String], verbose: bool) -> Result<std::process::Output> {
+    Command::new("cargo").args(args).run_and_get_output(verbose)
 }


### PR DESCRIPTION
`cross --list` should list the subcommands present for cargo in the image, rather on the host. This works because any option provided before a subcommand has priority over the subcommand. For example, `cargo build --help` prints the help menu for `cargo build`, but `cargo --help build` ignores `build` and prints the help for `cargo`. Therefore, the options `--help`, `--version`, and `--list` can be treated as pseudo-subcommands.

Fixes #715.