### PR TITLE
Add android runner to run android binaries.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,11 +147,11 @@ jobs:
             - { target: i686-unknown-linux-musl,          os: ubuntu-latest,                    std: 1, run: 1 }
             - { target: mips-unknown-linux-musl,          os: ubuntu-latest,  cpp: 1,           std: 1, run: 1 }
             - { target: mipsel-unknown-linux-musl,        os: ubuntu-latest,  cpp: 1,           std: 1, run: 1 }
-            - { target: aarch64-linux-android,            os: ubuntu-latest,  cpp: 1,           std: 1, run: 1 }
-            - { target: arm-linux-androideabi,            os: ubuntu-latest,  cpp: 1,           std: 1, run: 1 }
-            - { target: armv7-linux-androideabi,          os: ubuntu-latest,  cpp: 1,           std: 1, run: 1 }
-            - { target: i686-linux-android,               os: ubuntu-latest,  cpp: 1,           std: 1, run: 1 }
-            - { target: x86_64-linux-android,             os: ubuntu-latest,  cpp: 1,           std: 1, run: 1 }
+            - { target: aarch64-linux-android,            os: ubuntu-latest,  cpp: 1,           std: 1, run: 1, cpp: 1, runners: qemu-user }
+            - { target: arm-linux-androideabi,            os: ubuntu-latest,  cpp: 1,           std: 1, run: 1, cpp: 1, runners: qemu-user }
+            - { target: armv7-linux-androideabi,          os: ubuntu-latest,  cpp: 1,           std: 1, run: 1, cpp: 1, runners: qemu-user }
+            - { target: i686-linux-android,               os: ubuntu-latest,  cpp: 1,           std: 1, run: 1, cpp: 1, runners: qemu-user }
+            - { target: x86_64-linux-android,             os: ubuntu-latest,  cpp: 1,           std: 1, run: 1, cpp: 1, runners: qemu-user }
             - { target: x86_64-pc-windows-gnu,            os: ubuntu-latest,  cpp: 1,           std: 1, run: 1 }
             - { target: i686-pc-windows-gnu,              os: ubuntu-latest,  cpp: 1,           std: 1, run: 1 }
             # Disabled for now, see https://github.com/rust-lang/rust/issues/85821

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - #722 - boolean environment variables are evaluated as truthy or falsey.
 - #721 - add support for running doctests on nightly if `CROSS_UNSTABLE_ENABLE_DOCTESTS=true`.
+- #719 - add android runner to preload `libc++_shared.so`.
 - #718 - remove deb subcommand.
 - #714 - use host target directory when falling back to host cargo.
 - #713 - convert relative target directories to absolute paths.

--- a/docker/Dockerfile.aarch64-linux-android
+++ b/docker/Dockerfile.aarch64-linux-android
@@ -22,10 +22,12 @@ RUN /qemu.sh aarch64
 
 RUN cp /android-ndk/sysroot/usr/lib/aarch64-linux-android/28/libz.so /system/lib/
 
+COPY android-runner /
+
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 ENV CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android-gcc \
-    CARGO_TARGET_AARCH64_LINUX_ANDROID_RUNNER=qemu-aarch64 \
+    CARGO_TARGET_AARCH64_LINUX_ANDROID_RUNNER="/android-runner aarch64" \
     CC_aarch64_linux_android=aarch64-linux-android-gcc \
     CXX_aarch64_linux_android=aarch64-linux-android-g++ \
     BINDGEN_EXTRA_CLANG_ARGS_aarch64_linux_android="--sysroot=/android-ndk/sysroot" \

--- a/docker/Dockerfile.arm-linux-androideabi
+++ b/docker/Dockerfile.arm-linux-androideabi
@@ -22,10 +22,12 @@ RUN /qemu.sh arm
 
 RUN cp /android-ndk/sysroot/usr/lib/arm-linux-androideabi/28/libz.so /system/lib/
 
+COPY android-runner /
+
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 ENV CARGO_TARGET_ARM_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc \
-    CARGO_TARGET_ARM_LINUX_ANDROIDEABI_RUNNER=qemu-arm \
+    CARGO_TARGET_ARM_LINUX_ANDROIDEABI_RUNNER="/android-runner arm" \
     CC_arm_linux_androideabi=arm-linux-androideabi-gcc \
     CXX_arm_linux_androideabi=arm-linux-androideabi-g++ \
     BINDGEN_EXTRA_CLANG_ARGS_arm_linux_androideabi="--sysroot=/android-ndk/sysroot" \

--- a/docker/Dockerfile.i686-linux-android
+++ b/docker/Dockerfile.i686-linux-android
@@ -29,10 +29,12 @@ RUN /qemu.sh i386
 
 RUN cp /android-ndk/sysroot/usr/lib/i686-linux-android/28/libz.so /system/lib/
 
+COPY android-runner /
+
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 ENV CARGO_TARGET_I686_LINUX_ANDROID_LINKER=i686-linux-android-gcc \
-    CARGO_TARGET_I686_LINUX_ANDROID_RUNNER="qemu-i386 -cpu n270" \
+    CARGO_TARGET_I686_LINUX_ANDROID_RUNNER="/android-runner i686 -cpu n270" \
     CC_i686_linux_android=i686-linux-android-gcc \
     CXX_i686_linux_android=i686-linux-android-g++ \
     BINDGEN_EXTRA_CLANG_ARGS_i686_linux_android="--sysroot=/android-ndk/sysroot" \

--- a/docker/Dockerfile.x86_64-linux-android
+++ b/docker/Dockerfile.x86_64-linux-android
@@ -23,10 +23,12 @@ RUN /qemu.sh x86_64
 
 RUN cp /android-ndk/sysroot/usr/lib/x86_64-linux-android/28/libz.so /system/lib/
 
+COPY android-runner /
+
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 ENV CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android-gcc \
-    CARGO_TARGET_X86_64_LINUX_ANDROID_RUNNER="qemu-x86_64 -cpu qemu64,+mmx,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt" \
+    CARGO_TARGET_X86_64_LINUX_ANDROID_RUNNER="/android-runner x86_64 -cpu qemu64,+mmx,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt" \
     CC_x86_64_linux_android=x86_64-linux-android-gcc \
     CXX_x86_64_linux_android=x86_64-linux-android-g++ \
     BINDGEN_EXTRA_CLANG_ARGS_x86_64_linux_android="--sysroot=/android-ndk/sysroot" \

--- a/docker/android-runner
+++ b/docker/android-runner
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+# arch in the rust target
+arch="${1}"
+shift
+
+# select android abi, and find the shared libc++ library
+android_abi="${arch}-linux-android"
+qarch="${arch}"
+case "${arch}" in
+    arm)
+        android_abi="arm-linux-androideabi"
+        ;;
+    i686)
+        qarch="i386"
+        ;;
+esac
+libdir="/android-ndk/sysroot/usr/lib/${android_abi}"
+
+LD_PRELOAD="${libdir}/libc++_shared.so" exec qemu-"${qarch}" "${@}"


### PR DESCRIPTION
Android binaries currently fail to run linking against certain dependencies, because `libc++_shared.so` is not found, so ensure the library is preloaded via `LD_PRELOAD`. This creates a simple `android-runner` file, so any additional changes can be added there.

This merely links to the proper `libc++_shared.so`, so it doesn't fix other issues. The [hello world project](https://github.com/cross-rs/rust-cpp-hello-word) now compiles and runs on `aarch64-linux-android`, but not `i686-linux-android`, which seems to be entirely unrelated (likely a permission error on the cloud Fedora server I'm running).

```text
error getting old personality value: Operation not permitted
libc: error getting old personality value: Operation not permitted
Aborted (core dumped)
```

Linked Issues: #82