### PR TITLE
Add preliminary support for running doctests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - #722 - boolean environment variables are evaluated as truthy or falsey.
+- #721 - add support for running doctests on nightly if `CROSS_UNSTABLE_ENABLE_DOCTESTS=true`.
 - #718 - remove deb subcommand.
 - #714 - use host target directory when falling back to host cargo.
 - #713 - convert relative target directories to absolute paths.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,15 @@ passthrough = [
 ]
 ```
 
+### Unstable Features
+
+Certain unstable features can enable additional functionality useful to 
+cross-compiling. Note that these are unstable, and may be removed at any
+time (particularly if the feature is stabilized or removed), and will
+only be used on a nightly channel.
+
+- `CROSS_UNSTABLE_ENABLE_DOCTESTS=true`: also run doctests.
+
 ### Mounting volumes into the build environment
 
 In addition to passing environment variables, you can also specify environment

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,7 @@ pub struct Args {
     pub target: Option<Target>,
     pub target_dir: Option<PathBuf>,
     pub docker_in_docker: bool,
+    pub enable_doctests: bool,
 }
 
 // Fix for issue #581. target_dir must be absolute.
@@ -85,6 +86,9 @@ pub fn parse(target_list: &TargetList) -> Result<Args> {
     let docker_in_docker = env::var("CROSS_DOCKER_IN_DOCKER")
         .map(|s| bool_from_envvar(&s))
         .unwrap_or_default();
+    let enable_doctests = env::var("CROSS_UNSTABLE_ENABLE_DOCTESTS")
+        .map(|s| bool_from_envvar(&s))
+        .unwrap_or_default();
 
     Ok(Args {
         all,
@@ -93,5 +97,6 @@ pub fn parse(target_list: &TargetList) -> Result<Args> {
         target,
         target_dir,
         docker_in_docker,
+        enable_doctests,
     })
 }


### PR DESCRIPTION
This partially addresses #225.

This only works on nightly, due to the use of the unstable feature [doctest-xcompile](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#doctest-xcompile)

The relevant tracking issues are:
- https://github.com/rust-lang/cargo/issues/7040
- https://github.com/rust-lang/rust/issues/64245

If the subcommand is `test` and the compiler is nightly, we provide the `-Zdoctest-xcompile` flag if `CROSS_UNSTABLE_ENABLE_DOCTESTS=true`.