### PR TITLE
Evaluate boolean environment variables as truthy or falsey.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- #722 - boolean environment variables are evaluated as truthy or falsey.
 - #718 - remove deb subcommand.
 - #714 - use host target directory when falling back to host cargo.
 - #713 - convert relative target directories to absolute paths.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,16 @@ fn absolute_path(path: PathBuf) -> Result<PathBuf> {
     })
 }
 
+fn bool_from_envvar(envvar: &str) -> bool {
+    if let Ok(value) = bool::from_str(envvar) {
+        value
+    } else if let Ok(value) = i32::from_str(envvar) {
+        value != 0
+    } else {
+        !envvar.is_empty()
+    }
+}
+
 pub fn parse(target_list: &TargetList) -> Result<Args> {
     let mut channel = None;
     let mut target = None;
@@ -73,7 +83,7 @@ pub fn parse(target_list: &TargetList) -> Result<Args> {
     }
 
     let docker_in_docker = env::var("CROSS_DOCKER_IN_DOCKER")
-        .map(|s| bool::from_str(&s).unwrap_or_default())
+        .map(|s| bool_from_envvar(&s))
         .unwrap_or_default();
 
     Ok(Args {


### PR DESCRIPTION
Allow values of 0, 1, so values other than `true` or `false` can be provided. `VAR=0`, `VAR=`, `VAR=-0`, or `VAR=false` will evaluate to false, while the rest will evaluate to true.

Affects #661 and #721.