### PR TITLE
Support cross debugging and runners on Android.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- #725 - support `CROSS_DEBUG` and `CROSS_RUNNER` on android images.
 - #722 - boolean environment variables are evaluated as truthy or falsey.
 - #721 - add support for running doctests on nightly if `CROSS_UNSTABLE_ENABLE_DOCTESTS=true`.
 - #720 - add android runner to preload `libc++_shared.so`.

--- a/docker/Dockerfile.armv7-linux-androideabi
+++ b/docker/Dockerfile.armv7-linux-androideabi
@@ -25,7 +25,7 @@ RUN cp /android-ndk/sysroot/usr/lib/arm-linux-androideabi/28/libz.so /system/lib
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 ENV CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc \
-    CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_RUNNER=qemu-arm \
+    CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_RUNNER="/android-runner arm" \
     CC_armv7_linux_androideabi=arm-linux-androideabi-gcc \
     CXX_armv7_linux_androideabi=arm-linux-androideabi-g++ \
     BINDGEN_EXTRA_CLANG_ARGS_armv7_linux_androideabi="--sysroot=/android-ndk/sysroot" \

--- a/docker/Dockerfile.i686-linux-android
+++ b/docker/Dockerfile.i686-linux-android
@@ -34,7 +34,7 @@ COPY android-runner /
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 ENV CARGO_TARGET_I686_LINUX_ANDROID_LINKER=i686-linux-android-gcc \
-    CARGO_TARGET_I686_LINUX_ANDROID_RUNNER="/android-runner i686 -cpu n270" \
+    CARGO_TARGET_I686_LINUX_ANDROID_RUNNER="/android-runner i686" \
     CC_i686_linux_android=i686-linux-android-gcc \
     CXX_i686_linux_android=i686-linux-android-g++ \
     BINDGEN_EXTRA_CLANG_ARGS_i686_linux_android="--sysroot=/android-ndk/sysroot" \

--- a/docker/Dockerfile.x86_64-linux-android
+++ b/docker/Dockerfile.x86_64-linux-android
@@ -28,7 +28,7 @@ COPY android-runner /
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 ENV CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android-gcc \
-    CARGO_TARGET_X86_64_LINUX_ANDROID_RUNNER="/android-runner x86_64 -cpu qemu64,+mmx,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt" \
+    CARGO_TARGET_X86_64_LINUX_ANDROID_RUNNER="/android-runner x86_64" \
     CC_x86_64_linux_android=x86_64-linux-android-gcc \
     CXX_x86_64_linux_android=x86_64-linux-android-g++ \
     BINDGEN_EXTRA_CLANG_ARGS_x86_64_linux_android="--sysroot=/android-ndk/sysroot" \

--- a/docker/android-runner
+++ b/docker/android-runner
@@ -6,6 +6,14 @@ set -e
 arch="${1}"
 shift
 
+if [ -n "${CROSS_DEBUG}" ]; then
+    set -x
+fi
+
+if [ "${CROSS_RUNNER}" = "" ]; then
+    CROSS_RUNNER=qemu-user
+fi
+
 # select android abi, and find the shared libc++ library
 android_abi="${arch}-linux-android"
 qarch="${arch}"
@@ -15,8 +23,25 @@ case "${arch}" in
         ;;
     i686)
         qarch="i386"
+        qemu_args=("-cpu" "n270")
+        ;;
+    x86_64)
+        qemu_args=("-cpu" "qemu64,+mmx,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt")
         ;;
 esac
 libdir="/android-ndk/sysroot/usr/lib/${android_abi}"
 
-LD_PRELOAD="${libdir}/libc++_shared.so" exec qemu-"${qarch}" "${@}"
+export LD_PRELOAD="${libdir}/libc++_shared.so"
+case "${CROSS_RUNNER}" in
+    native)
+        exec "${@}"
+        ;;
+    qemu-user)
+        exec "qemu-${qarch}" "${qemu_args[@]}" "${@}"
+        ;;
+    *)
+        echo "Invalid runner: \"${CROSS_RUNNER}\"";
+        echo "Valid runners are: native and qemu-user"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Support the `CROSS_DEBUG` and `CROSS_RUNNER` environment variables for android runners.

This allows us to both get debugging information for the Android runner (similar to the Linux runner) and also use a native runner for Android (defaults to Qemu). It also fixes a minor bug where the Android runner was not used on `armv7-linux-androideabi`.