### PR TITLE
Refactor code to use install_packages and purge_packages.

### DIFF
--- a/docker/Dockerfile.x86_64-unknown-linux-gnu
+++ b/docker/Dockerfile.x86_64-unknown-linux-gnu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 ARG DEBIAN_FRONTEND=noninteractive
 
+COPY lib.sh /
 COPY linux-image.sh /
 RUN /linux-image.sh x86_64
 

--- a/docker/android-ndk.sh
+++ b/docker/android-ndk.sh
@@ -3,26 +3,16 @@
 set -x
 set -euo pipefail
 
+# shellcheck disable=SC1091
+. lib.sh
+
 NDK_URL=https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip
 
 main() {
     local arch="${1}" \
           api="${2}"
 
-    local dependencies=(
-        curl
-        unzip
-        python
-    )
-
-    apt-get update
-    local purge_list=()
-    for dep in "${dependencies[@]}"; do
-        if ! dpkg -L "${dep}"; then
-            apt-get install --assume-yes --no-install-recommends "${dep}"
-            purge_list+=( "${dep}" )
-        fi
-    done
+    install_packages curl unzip python
 
     local td
     td="$(mktemp -d)"
@@ -37,9 +27,7 @@ main() {
       --arch "${arch}" \
       --api "${api}"
 
-    if (( ${#purge_list[@]} )); then
-      apt-get purge --assume-yes --auto-remove "${purge_list[@]}"
-    fi
+    purge_packages
 
     popd
     popd

--- a/docker/disabled/dragonfly.sh
+++ b/docker/disabled/dragonfly.sh
@@ -3,32 +3,24 @@
 set -x
 set -euo pipefail
 
+# shellcheck disable=SC1091
+. lib.sh
+
 main() {
     local binutils=2.25.1 \
           dragonfly=4.6.1_REL \
           gcc=5.3.0 \
           target=x86_64-unknown-dragonfly
 
-    local dependencies=(
-        bsdtar
-        bzip2
-        ca-certificates
-        curl
-        g++
-        make
-        patch
-        wget
+    install_packages bsdtar \
+        bzip2 \
+        ca-certificates \
+        curl \
+        g++ \
+        make \
+        patch \
+        wget \
         xz-utils
-    )
-
-    apt-get update
-    local purge_list=()
-    for dep in "${dependencies[@]}"; do
-        if ! dpkg -L "${dep}"; then
-            apt-get install --no-install-recommends --assume-yes "${dep}"
-            purge_list+=( "${dep}" )
-        fi
-    done
 
     local td
     td="$(mktemp -d)"
@@ -140,9 +132,7 @@ EOF
     # clean up
     popd
 
-    if (( ${#purge_list[@]} )); then
-      apt-get purge --assume-yes --auto-remove "${purge_list[@]}"
-    fi
+    purge_packages
 
     rm -rf "${td}"
     rm "${0}"

--- a/docker/emscripten.sh
+++ b/docker/emscripten.sh
@@ -3,23 +3,15 @@
 set -x
 set -euo pipefail
 
-main() {
-    local dependencies=(
-        ca-certificates
-        curl
-        git
-        libxml2
-        python
-    )
+# shellcheck disable=SC1091
+. lib.sh
 
-    apt-get update
-    local purge_list=()
-    for dep in "${dependencies[@]}"; do
-        if ! dpkg -L "${dep}"; then
-            apt-get install --no-install-recommends --assume-yes "${dep}"
-            purge_list+=( "${dep}" )
-        fi
-    done
+main() {
+    install_packages ca-certificates \
+        curl \
+        git \
+        libxml2 \
+        python
 
     cd /
     git clone https://github.com/emscripten-core/emsdk.git /emsdk-portable
@@ -40,9 +32,7 @@ main() {
     # Make emsdk usable by any user
     chmod a+rwX -R "${EMSDK}"
 
-    if (( ${#purge_list[@]} )); then
-      apt-get purge --assume-yes --auto-remove "${purge_list[@]}"
-    fi
+    purge_packages
 
     rm "${0}"
 }

--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 export ARCH="${1}"
 # shellcheck disable=SC1091
 . freebsd-common.sh
+# shellcheck disable=SC1091
+. lib.sh
 
 max_freebsd() {
     local best=
@@ -50,23 +52,12 @@ main() {
           gcc=6.4.0 \
           target="${ARCH}-unknown-freebsd${BSD_MAJOR}"
 
-    local dependencies=(
-        ca-certificates
-        curl
-        g++
-        make
-        wget
+    install_packages ca-certificates \
+        curl \
+        g++ \
+        make \
+        wget \
         xz-utils
-    )
-
-    apt-get update
-    local purge_list=()
-    for dep in "${dependencies[@]}"; do
-        if ! dpkg -L "${dep}"; then
-            apt-get install --no-install-recommends --assume-yes "${dep}"
-            purge_list+=( "${dep}" )
-        fi
-    done
 
     local td
     td="$(mktemp -d)"
@@ -144,9 +135,7 @@ main() {
     # clean up
     popd
 
-    if (( ${#purge_list[@]} )); then
-      apt-get purge --assume-yes --auto-remove "${purge_list[@]}"
-    fi
+    purge_packages
 
     # store the version info for the FreeBSD release
     bsd_revision=$(curl --retry 3 -sSfL "${bsd_http}/REVISION")

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -3,6 +3,9 @@
 set -x
 set -euo pipefail
 
+# shellcheck disable=SC1091
+. lib.sh
+
 main() {
     # arch in the rust target
     local arch="${1}" \
@@ -94,22 +97,11 @@ main() {
             ;;
     esac
 
-    local dependencies=(
-        ca-certificates
-        curl
-        cpio
-        sharutils
+    install_packages ca-certificates \
+        curl \
+        cpio \
+        sharutils \
         gnupg
-    )
-
-    local purge_list=()
-    apt-get update
-    for dep in "${dependencies[@]}"; do
-        if ! dpkg -L "${dep}" >/dev/null 2>/dev/null; then
-            apt-get install --assume-yes --no-install-recommends "${dep}"
-            purge_list+=( "${dep}" )
-        fi
-    done
 
     # Download packages
     mv /etc/apt/sources.list /etc/apt/sources.list.bak
@@ -274,9 +266,7 @@ EOF
     dpkg --remove-architecture "${arch}" || true
     apt-get update
 
-    if (( ${#purge_list[@]} )); then
-      apt-get purge --assume-yes --auto-remove "${purge_list[@]}"
-    fi
+    purge_packages
 
     ls -lh /qemu
 }

--- a/docker/mingw.sh
+++ b/docker/mingw.sh
@@ -3,6 +3,9 @@
 set -x
 set -euo pipefail
 
+# shellcheck disable=SC1091
+. lib.sh
+
 main() {
     # Ubuntu mingw packages for i686 uses sjlj exceptions, but rust target
     # i686-pc-windows-gnu uses dwarf exceptions. So we build mingw packages
@@ -20,13 +23,7 @@ main() {
     while IFS='' read -r dep; do dependencies+=("${dep}"); done < \
       <(apt-cache showsrc gcc-mingw-w64-i686 | grep Build | cut -d: -f2 | tr , '\n' | cut -d' ' -f2 | sort | uniq)
 
-    local purge_list=()
-    for dep in "${dependencies[@]}"; do
-        if ! dpkg -L "${dep}" > /dev/null; then
-            apt-get install --assume-yes --no-install-recommends "${dep}"
-            purge_list+=( "${dep}" )
-        fi
-    done
+    install_packages "${dependencies[@]}"
 
     local td
     td="$(mktemp -d)"
@@ -118,9 +115,7 @@ EOF
     # Replace installed mingw packages with the new ones
     dpkg -i ../g*-mingw-w64-i686*.deb ../gcc-mingw-w64-base*.deb
 
-    if (( ${#purge_list[@]} )); then
-      apt-get purge --assume-yes --auto-remove "${purge_list[@]}"
-    fi
+    purge_packages
 
     popd
     popd

--- a/docker/musl.sh
+++ b/docker/musl.sh
@@ -3,6 +3,9 @@
 set -x
 set -euo pipefail
 
+# shellcheck disable=SC1091
+. lib.sh
+
 hide_output() {
     set +x
     trap "
@@ -21,20 +24,7 @@ hide_output() {
 main() {
     local version=0.9.9
 
-    local dependencies=(
-        ca-certificates
-        curl
-        build-essential
-    )
-
-    apt-get update
-    local purge_list=()
-    for dep in "${dependencies[@]}"; do
-        if ! dpkg -L "${dep}"; then
-            apt-get install --assume-yes --no-install-recommends "${dep}"
-            purge_list+=( "${dep}" )
-        fi
-    done
+    install_packages ca-certificates curl build-essential
 
     local td
     td="$(mktemp -d)"
@@ -55,9 +45,7 @@ main() {
         OUTPUT=/usr/local/ \
         "${@}"
 
-    if (( ${#purge_list[@]} )); then
-      apt-get purge --assume-yes --auto-remove "${purge_list[@]}"
-    fi
+    purge_packages
 
     popd
 

--- a/docker/netbsd.sh
+++ b/docker/netbsd.sh
@@ -3,31 +3,23 @@
 set -x
 set -euo pipefail
 
+# shellcheck disable=SC1091
+. lib.sh
+
 main() {
     local binutils=2.36.1 \
           gcc=9.4.0 \
           target=x86_64-unknown-netbsd
 
-    local dependencies=(
-        bzip2
-        ca-certificates
-        curl
-        g++
-        make
-        patch
-        texinfo
-        wget
+    install_packages bzip2 \
+        ca-certificates \
+        curl \
+        g++ \
+        make \
+        patch \
+        texinfo \
+        wget \
         xz-utils
-    )
-
-    apt-get update
-    local purge_list=()
-    for dep in "${dependencies[@]}"; do
-        if ! dpkg -L "${dep}"; then
-            apt-get install --assume-yes --no-install-recommends "${dep}"
-            purge_list+=( "${dep}" )
-        fi
-    done
 
     local td
     td="$(mktemp -d)"
@@ -117,9 +109,7 @@ main() {
     # clean up
     popd
 
-    if (( ${#purge_list[@]} )); then
-      apt-get purge --assume-yes --auto-remove "${purge_list[@]}"
-    fi
+    purge_packages
 
     rm -rf "${td}"
     rm "${0}"

--- a/docker/solaris.sh
+++ b/docker/solaris.sh
@@ -3,6 +3,9 @@
 set -x
 set -euo pipefail
 
+# shellcheck disable=SC1091
+. lib.sh
+
 main() {
     local arch="${1}"
 
@@ -10,26 +13,15 @@ main() {
           gcc=6.4.0 \
           target="${arch}-sun-solaris2.10"
 
-    local dependencies=(
-        bzip2
-        ca-certificates
-        curl
-        g++
-        make
-        patch
-        software-properties-common
-        wget
+    install_packages bzip2 \
+        ca-certificates \
+        curl \
+        g++ \
+        make \
+        patch \
+        software-properties-common \
+        wget \
         xz-utils
-    )
-
-    apt-get update
-    local purge_list=()
-    for dep in "${dependencies[@]}"; do
-        if ! dpkg -L "${dep}"; then
-            apt-get install --assume-yes --no-install-recommends "${dep}"
-            purge_list+=( "${dep}" )
-        fi
-    done
 
     local td
     td="$(mktemp -d)"
@@ -134,9 +126,7 @@ EOF
     # clean up
     popd
 
-    if (( ${#purge_list[@]} )); then
-      apt-get purge --assume-yes --auto-remove "${purge_list[@]}"
-    fi
+    purge_packages
 
     rm -rf "${td}"
     rm "${0}"


### PR DESCRIPTION
Remove all local use of installing manually via the package manager, using `install_packages` and `purge_packages` rather than use redundant code. Simplifies our shell scripts to build docker images.

Still a draft because I'm currently testing it on all images.