### PR TITLE
Upgrade WINE versions to 7.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- #377 - update WINE versions to 7.0.
 - #734 - patch `arm-unknown-linux-gnueabihf` to build for ARMv6, and add architecture for crosstool-ng-based images.
 - #730 - make FreeBSD builds more resilient.
 - #727 - add `PKG_CONFIG_PATH` to all `*-linux-gnu` images.

--- a/docker/Dockerfile.i686-pc-windows-gnu
+++ b/docker/Dockerfile.i686-pc-windows-gnu
@@ -11,11 +11,10 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 RUN dpkg --add-architecture i386 && apt-get update && \
-    apt-get install --assume-yes --no-install-recommends \
-        wine-stable \
-        wine64 \
-        wine32 \
-        libz-mingw-w64-dev
+    apt-get install --assume-yes --no-install-recommends libz-mingw-w64-dev
+
+COPY wine.sh /
+RUN /wine.sh
 
 # Build mingw tools using dwarf exceptions
 COPY mingw.sh /

--- a/docker/Dockerfile.x86_64-pc-windows-gnu
+++ b/docker/Dockerfile.x86_64-pc-windows-gnu
@@ -11,11 +11,10 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 RUN dpkg --add-architecture i386 && apt-get update && \
-    apt-get install --assume-yes --no-install-recommends \
-        wine-stable \
-        wine64 \
-        wine32 \
-        libz-mingw-w64-dev
+    apt-get install --assume-yes --no-install-recommends libz-mingw-w64-dev
+
+COPY wine.sh /
+RUN /wine.sh
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends g++-mingw-w64-x86-64
 

--- a/docker/wine.sh
+++ b/docker/wine.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -x
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. lib.sh
+
+main() {
+    install_packages wget
+
+    dpkg --add-architecture i386
+
+    # add repository for latest wine version and install from source
+    # hardcode version, since we might want to avoid a version later.
+    wget -nc https://dl.winehq.org/wine-builds/winehq.key
+    mv winehq.key /usr/share/keyrings/winehq-archive.key
+    wget -nc https://dl.winehq.org/wine-builds/ubuntu/dists/bionic/winehq-bionic.sources
+    mv winehq-bionic.sources /etc/apt/sources.list.d/
+    apt-get update
+    apt install --no-install-recommends --assume-yes \
+        "winehq-stable=7.0.0.0~bionic-1"
+
+    purge_packages
+}
+
+main "${@}"


### PR DESCRIPTION
Updates from WINE 3.0 to 7.0 on `*-pc-windows-gnu` images using binary releases provide by WINE HQ.

Closes #390.