### PR TITLE
Add soft-float ARMv7 targets.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
             - { target: aarch64-unknown-linux-gnu,        os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }
             - { target: arm-unknown-linux-gnueabi,        os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1 }
             - { target: arm-unknown-linux-gnueabihf,      os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1 }
+            - { target: armv7-unknown-linux-gnueabi,    os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }
             - { target: armv7-unknown-linux-gnueabihf,    os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }
             - { target: i586-unknown-linux-gnu,           os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1 }
             - { target: i686-unknown-linux-gnu,           os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: native qemu-user qemu-system }
@@ -142,6 +143,7 @@ jobs:
             - { target: arm-unknown-linux-musleabi,       os: ubuntu-latest,                    std: 1, run: 1 }
             - { target: armv5te-unknown-linux-gnueabi,    os: ubuntu-latest,                    std: 1, run: 1 }
             - { target: armv5te-unknown-linux-musleabi,   os: ubuntu-latest,                    std: 1, run: 1 }
+            - { target: armv7-unknown-linux-musleabi,   os: ubuntu-latest,                    std: 1, run: 1 }
             - { target: armv7-unknown-linux-musleabihf,   os: ubuntu-latest,                    std: 1, run: 1 }
             - { target: i586-unknown-linux-musl,          os: ubuntu-latest,                    std: 1, run: 1 }
             - { target: i686-unknown-linux-musl,          os: ubuntu-latest,                    std: 1, run: 1 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- #741 - added `armv7-unknown-linux-gnueabi` and `armv7-unknown-linux-musleabi` targets.
 - #377 - update WINE versions to 7.0.
 - #734 - patch `arm-unknown-linux-gnueabihf` to build for ARMv6, and add architecture for crosstool-ng-based images.
 - #730 - make FreeBSD builds more resilient.

--- a/README.md
+++ b/README.md
@@ -277,14 +277,16 @@ terminate.
 | `aarch64-unknown-linux-gnu`          | 2.19   | 4.8.2   | ✓   | 5.1.0 |   ✓    |
 | `aarch64-unknown-linux-musl`         | 1.1.20 | 6.3.0   |     | 5.1.0 |   ✓    |
 | `arm-linux-androideabi` [2]          | 9.0.0  | 4.9     | ✓   | 5.1.0 |   ✓    |
-| `arm-unknown-linux-gnueabi`          | 2.19   | 4.8.2   | ✓   | 5.1.0 |   ✓    |
+| `arm-unknown-linux-gnueabi`          | 2.17   | 8.3.0   | ✓   | 5.1.0 |   ✓    |
 | `arm-unknown-linux-gnueabihf`        | 2.27   | 7.3.0   | ✓   | 5.1.0 |   ✓    |
 | `arm-unknown-linux-musleabi`         | 1.1.20 | 6.3.0   |     | 5.1.0 |   ✓    |
 | `arm-unknown-linux-musleabihf`       | 1.1.20 | 6.3.0   |     | 5.1.0 |   ✓    |
 | `armv5te-unknown-linux-gnueabi`      | 2.27   | 7.5.0   | ✓   | 5.1.0 |   ✓    |
 | `armv5te-unknown-linux-musleabi`     | 1.1.20 | 6.3.0   |     | 5.1.0 |   ✓    |
 | `armv7-linux-androideabi` [2]        | 9.0.0  | 4.9     | ✓   | 5.1.0 |   ✓    |
+| `armv7-unknown-linux-gnueabi`        | 2.27   | 7.5.0   | ✓   | 5.1.0 |   ✓    |
 | `armv7-unknown-linux-gnueabihf`      | 2.15   | 4.6.2   | ✓   | 5.1.0 |   ✓    |
+| `armv7-unknown-linux-musleabi`       | 1.1.20 | 6.3.0   |     | 5.1.0 |   ✓    |
 | `armv7-unknown-linux-musleabihf`     | 1.1.20 | 6.3.0   |     | 5.1.0 |   ✓    |
 | `asmjs-unknown-emscripten` [6]       | 1.2.2  | 3.1.10  | ✓   | N/A   |   ✓    |
 | `i586-unknown-linux-gnu`             | 2.23   | 5.3.1   | ✓   | N/A   |   ✓    |

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabi
@@ -1,0 +1,27 @@
+FROM ubuntu:18.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY common.sh lib.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+RUN apt-get install --assume-yes --no-install-recommends \
+    g++-arm-linux-gnueabi \
+    libc6-dev-armel-cross
+
+COPY qemu.sh /
+RUN /qemu.sh arm
+
+ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABI_LINKER=arm-linux-gnueabi-gcc \
+    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABI_RUNNER=qemu-arm \
+    CC_armv7_unknown_linux_gnueabi=arm-linux-gnueabi-gcc \
+    CXX_armv7_unknown_linux_gnueabi=arm-linux-gnueabi-g++ \
+    BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_gnueabi="--sysroot=/usr/arm-linux-gnueabi" \
+    QEMU_LD_PREFIX=/usr/arm-linux-gnueabi \
+    RUST_TEST_THREADS=1 \
+    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabi/pkgconfig/:${PKG_CONFIG_PATH}"

--- a/docker/Dockerfile.armv7-unknown-linux-musleabi
+++ b/docker/Dockerfile.armv7-unknown-linux-musleabi
@@ -1,0 +1,35 @@
+FROM ubuntu:18.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY common.sh lib.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+COPY qemu.sh /
+RUN /qemu.sh arm
+
+COPY musl.sh /
+RUN /musl.sh \
+    TARGET=arm-linux-musleabi \
+    "COMMON_CONFIG += --with-arch=armv7-a \
+                      --with-float=soft \
+                      --with-mode=thumb \
+                      --with-mode=arm"
+
+# Allows qemu run dynamic linked binaries
+RUN ln -sf \
+    /usr/local/arm-linux-musleabi/lib/libc.so \
+    /usr/local/arm-linux-musleabi/lib/ld-musl-arm.so.1
+
+ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABI_LINKER=arm-linux-musleabi-gcc \
+    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABI_RUNNER=qemu-arm \
+    CC_armv7_unknown_linux_musleabi=arm-linux-musleabi-gcc \
+    CXX_armv7_unknown_linux_musleabi=arm-linux-musleabi-g++ \
+    BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_musleabi="--sysroot=/usr/local/arm-linux-musleabi" \
+    QEMU_LD_PREFIX=/usr/local/arm-linux-musleabi \
+    RUST_TEST_THREADS=1

--- a/docker/crosstool-config/arm-unknown-linux-gnueabihf.config
+++ b/docker/crosstool-config/arm-unknown-linux-gnueabihf.config
@@ -2,6 +2,8 @@
 # Automatically generated file; DO NOT EDIT.
 # crosstool-NG  Configuration
 #
+# This file was adapted from:
+#   https://github.com/rust-lang/rust/blob/0595ea1d12cf745e0a672d05341429ecb0917e66/src/ci/docker/host-x86_64/dist-armhf-linux/arm-linux-gnueabihf.config
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
 CT_CONFIGURE_has_wget=y


### PR DESCRIPTION
Added `armv7-unknown-linux-gnueabi` and `armv7-unknown-linux-musleabi` targets, which target soft-float ARMv7-a processors.

Closes #354.