### PR TITLE
Add `thumbv7neon-*` targets.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
             - { target: arm-unknown-linux-gnueabihf,      os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1 }
             - { target: armv7-unknown-linux-gnueabi,    os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }
             - { target: armv7-unknown-linux-gnueabihf,    os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }
+            - { target: thumbv7neon-unknown-linux-gnueabihf, os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }
             - { target: i586-unknown-linux-gnu,           os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1 }
             - { target: i686-unknown-linux-gnu,           os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: native qemu-user qemu-system }
             - { target: mips-unknown-linux-gnu,           os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }
@@ -167,6 +168,7 @@ jobs:
             - { target: aarch64-linux-android,            os: ubuntu-latest,  cpp: 1,           std: 1, run: 1, runners: qemu-user }
             - { target: arm-linux-androideabi,            os: ubuntu-latest,  cpp: 1,           std: 1, run: 1, runners: qemu-user }
             - { target: armv7-linux-androideabi,          os: ubuntu-latest,  cpp: 1,           std: 1, run: 1, runners: qemu-user }
+            - { target: thumbv7neon-linux-androideabi,          os: ubuntu-latest,  cpp: 1,           std: 1, run: 1, runners: qemu-user }
             - { target: i686-linux-android,               os: ubuntu-latest,  cpp: 1,           std: 1, run: 1, runners: qemu-user }
             - { target: x86_64-linux-android,             os: ubuntu-latest,  cpp: 1,           std: 1, run: 1, runners: qemu-user }
             - { target: x86_64-pc-windows-gnu,            os: ubuntu-latest,  cpp: 1,           std: 1, run: 1 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - #767 - added the `cross-util` and `cross-dev` commands.
+- #745 - added `thumbv7neon-*` targets.
 - #741 - added `armv7-unknown-linux-gnueabi` and `armv7-unknown-linux-musleabi` targets.
 - #721 - add support for running doctests on nightly if `CROSS_UNSTABLE_ENABLE_DOCTESTS=true`.
 - #719 - add `--list` to known subcommands.

--- a/docker/Dockerfile.thumbv7neon-linux-androideabi
+++ b/docker/Dockerfile.thumbv7neon-linux-androideabi
@@ -1,0 +1,55 @@
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY common.sh lib.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+COPY android-ndk.sh /
+RUN /android-ndk.sh arm 28
+ENV PATH=$PATH:/android-ndk/bin
+
+COPY android-system.sh /
+RUN /android-system.sh arm
+
+COPY qemu.sh /
+RUN /qemu.sh arm
+
+RUN cp /android-ndk/sysroot/usr/lib/arm-linux-androideabi/28/libz.so /system/lib/
+
+COPY android-runner /
+
+# Libz is distributed in the android ndk, but for some unknown reason it is not
+# found in the build process of some crates, so we explicit set the DEP_Z_ROOT
+# likewise, the toolchains expect the prefix `thumbv7neon-linux-androideabi`,
+# which we don't have, so just export every possible variable, such as AR.
+# Also export all target binutils just in case required.
+ENV CARGO_TARGET_THUMBV7NEON_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc \
+    CARGO_TARGET_THUMBV7NEON_LINUX_ANDROIDEABI_RUNNER="/android-runner arm" \
+    AR_thumbv7neon_linux_androideabi=arm-linux-androideabi-ar \
+    AS_thumbv7neon_linux_androideabi=arm-linux-androideabi-as \
+    CC_thumbv7neon_linux_androideabi=arm-linux-androideabi-gcc \
+    CXX_thumbv7neon_linux_androideabi=arm-linux-androideabi-g++ \
+    LD_thumbv7neon_linux_androideabi=arm-linux-androideabi-ld \
+    NM_thumbv7neon_linux_androideabi=arm-linux-androideabi-nm \
+    OBJCOPY_thumbv7neon_linux_androideabi=arm-linux-androideabi-objcopy \
+    OBJDUMP_thumbv7neon_linux_androideabi=arm-linux-androideabi-objdump \
+    RANLIB_thumbv7neon_linux_androideabi=arm-linux-androideabi-ranlib \
+    READELF_thumbv7neon_linux_androideabi=arm-linux-androideabi-readelf \
+    SIZE_thumbv7neon_linux_androideabi=arm-linux-androideabi-size \
+    STRINGS_thumbv7neon_linux_androideabi=arm-linux-androideabi-strings \
+    STRIP_thumbv7neon_linux_androideabi=arm-linux-androideabi-strip \
+    BINDGEN_EXTRA_CLANG_ARGS_thumbv7neon_linux_androideabi="--sysroot=/android-ndk/sysroot" \
+    DEP_Z_INCLUDE=/android-ndk/sysroot/usr/include/ \
+    RUST_TEST_THREADS=1 \
+    HOME=/tmp/ \
+    TMPDIR=/tmp/ \
+    ANDROID_DATA=/ \
+    ANDROID_DNS_MODE=local \
+    ANDROID_ROOT=/system
+

--- a/docker/Dockerfile.thumbv7neon-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.thumbv7neon-unknown-linux-gnueabihf
@@ -1,0 +1,47 @@
+FROM ubuntu:16.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY common.sh lib.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
+    g++-arm-linux-gnueabihf \
+    libc6-dev-armhf-cross
+
+COPY qemu.sh /
+RUN /qemu.sh arm softmmu
+
+COPY dropbear.sh /
+RUN /dropbear.sh
+
+COPY linux-image.sh /
+RUN /linux-image.sh armv7
+
+COPY linux-runner /
+
+# Export all target binutils just in case required.
+ENV CARGO_TARGET_THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+    CARGO_TARGET_THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF_RUNNER="/linux-runner armv7" \
+    AR_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-ar \
+    AS_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-as \
+    CC_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
+    CXX_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++ \
+    LD_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-ld \
+    NM_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-nm \
+    OBJCOPY_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-objcopy \
+    OBJDUMP_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-objdump \
+    RANLIB_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-ranlib \
+    READELF_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-readelf \
+    SIZE_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-size \
+    STRINGS_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-strings \
+    STRIP_thumbv7neon_unknown_linux_gnueabihf=arm-linux-gnueabihf-strip \
+    BINDGEN_EXTRA_CLANG_ARGS_thumbv7neon_unknown_linux_gnueabihf="--sysroot=/usr/arm-linux-gnueabihf" \
+    QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
+    RUST_TEST_THREADS=1 \
+    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabihf/pkgconfig/:${PKG_CONFIG_PATH}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,7 @@ impl Target {
 
     fn needs_docker_privileged(&self) -> bool {
         let arch_32bit = self.triple().starts_with("arm")
+            || self.triple().starts_with("thumb")
             || self.triple().starts_with("i586")
             || self.triple().starts_with("i686");
 


### PR DESCRIPTION
Add the `thumbv7neon-linux-androideabi` and `thumbv7neon-unknown-linux-gnueabihf` targets.
    
Closes #254.