### PR TITLE
Limit permissions for Android images.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - #762 - re-enabled `x86_64-unknown-dragonfly` target.
 - #747 - reduced android image sizes.
+- #746 - limit image permissions for android images.
 - #377 - update WINE versions to 7.0.
 - #734 - patch `arm-unknown-linux-gnueabihf` to build for ARMv6, and add architecture for crosstool-ng-based images.
 - #709 - Update Emscripten targets to `emcc` version 3.1.10

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
@@ -34,4 +34,19 @@ fn _canonicalize(path: &Path) -> Result<PathBuf> {
     {
         Path::new(&path).canonicalize().map_err(Into::into)
     }
+}
+
+pub fn write_file(path: impl AsRef<Path>, overwrite: bool) -> Result<File> {
+    let path = path.as_ref();
+    fs::create_dir_all(
+        &path.parent().ok_or_else(|| {
+            eyre::eyre!("could not find parent directory for `{}`", path.display())
+        })?,
+    )
+    .wrap_err_with(|| format!("couldn't create directory `{}`", path.display()))?;
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(!overwrite)
+        .open(&path)
+        .wrap_err(format!("could't write to file `{}`", path.display()))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ impl Target {
         !native && (self.is_linux() || self.is_windows() || self.is_bare_metal())
     }
 
-    fn needs_docker_privileged(&self) -> bool {
+    fn needs_docker_seccomp(&self) -> bool {
         let arch_32bit = self.triple().starts_with("arm")
             || self.triple().starts_with("i586")
             || self.triple().starts_with("i686");

--- a/src/seccomp.json
+++ b/src/seccomp.json
@@ -1,0 +1,166 @@
+{
+    "defaultAction": "SCMP_ACT_ALLOW",
+    "syscalls": [
+        {
+            "names": [
+                "add_key",
+                "get_kernel_syms",
+                "keyctl",
+                "move_pages",
+                "nfsservctl",
+                "perf_event_open",
+                "pivot_root",
+                "query_module",
+                "request_key",
+                "sysfs",
+                "_sysctl",
+                "uselib",
+                "userfaultfd",
+                "ustat"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "errnoRet": 1
+        },
+        {
+            "names": [
+                "acct"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "errnoRet": 1,
+            "excludes": {
+                "caps": [
+                    "CAP_SYS_PACCT"
+                ]
+            }
+        },
+        {
+            "names": [
+                "bpf",
+                "lookup_dcookie",
+                "mount",
+                "quotactl",
+                "quotactl_fd",
+                "setns",
+                "swapon",
+                "swapoff",
+                "umount",
+                "umount2",
+                "unshare",
+                "vm86",
+                "vm86old",
+                "pciconfig_read",
+                "pciconfig_write",
+                "salinfo_log_open",
+                "salinfo_event_open",
+                "sys_cacheflush",
+                "rtas"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "errnoRet": 1,
+            "excludes": {
+                "caps": [
+                    "CAP_SYS_ADMIN"
+                ]
+            }
+        },
+        {
+            "names": [
+                "clock_adjtime",
+                "clock_settime",
+                "settimeofday",
+                "stime"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "errnoRet": 1,
+            "excludes": {
+                "caps": [
+                    "CAP_SYS_TIME"
+                ]
+            }
+        },
+        {
+            "names": [
+                "create_module",
+                "delete_module",
+                "finit_module",
+                "init_module"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "errnoRet": 1,
+            "excludes": {
+                "caps": [
+                    "CAP_SYS_MODULE"
+                ]
+            }
+        },
+        {
+            "names": [
+                "get_mempolicy",
+                "mbind",
+                "set_mempolicy"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "errnoRet": 1,
+            "excludes": {
+                "caps": [
+                    "CAP_SYS_NICE"
+                ]
+            }
+        },
+        {
+            "names": [
+                "ioperm",
+                "iopl"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "errnoRet": 1,
+            "excludes": {
+                "caps": [
+                    "CAP_SYS_RAWIO"
+                ]
+            }
+        },
+        {
+            "names": [
+                "kcmp",
+                "process_vm_readv",
+                "process_vm_writev",
+                "ptrace"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "errnoRet": 1,
+            "excludes": {
+                "caps": [
+                    "CAP_SYS_PTRACE"
+                ]
+            }
+        },
+        {
+            "names": [
+                "kexec_file_load",
+                "kexec_load",
+                "reboot"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "errnoRet": 1,
+            "excludes": {
+                "caps": [
+                    "CAP_SYS_BOOT"
+                ]
+            }
+        },
+        {
+            "names": [
+                "name_to_handle_at",
+                "open_by_handle_at"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "errnoRet": 1,
+            "excludes": {
+                "caps": [
+                    "CAP_DAC_READ_SEARCH"
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Remove the use of the `--privileged` flag for Android images and instead use an seccomp permissions. The provided profile is derived from the docker documentation, with slight modifications to allow `clone` and `clone3`.

The documentation is [docker seccomp](https://docs.docker.com/engine/security/seccomp/#significant-syscalls-blocked-by-the-default-profile), which details the syscalls blocked by docker. The same is true for podman. We merely modified these settings to allow `personality` syscall, which then allows us to use our Android images.