### PR TITLE
Reduce Android image sizes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- #747 - reduced android image sizes.
 - #377 - update WINE versions to 7.0.
 - #734 - patch `arm-unknown-linux-gnueabihf` to build for ARMv6, and add architecture for crosstool-ng-based images.
 - #709 - Update Emscripten targets to `emcc` version 3.1.10

--- a/docker/android-ndk.sh
+++ b/docker/android-ndk.sh
@@ -27,6 +27,30 @@ main() {
       --arch "${arch}" \
       --api "${api}"
 
+    # clean up unused toolchains to reduce image size
+    local triple
+    local triples
+    local triple_arch="${arch}"
+    case "${arch}" in
+      arm64)
+        triple_arch="aarch64"
+        ;;
+      x86)
+        triple_arch="i686"
+        ;;
+    esac
+    triples=(
+      "aarch64-linux-android"
+      "arm-linux-androideabi"
+      "i686-linux-android"
+      "x86_64-linux-android"
+    )
+    for triple in "${triples[@]}"; do
+      if ! [[ "${triple}" =~ ^"${triple_arch}".* ]]; then
+        rm -rf "/android-ndk/sysroot/usr/lib/${triple}"
+      fi
+    done
+
     purge_packages
 
     popd


### PR DESCRIPTION
Delete unused toolchains to save ~600MB in our total image sizes. This is done by removing the toolchains for other targets in `/android-ndk/sysroot/usr/lib/`.

Closes #739.