### PR TITLE
Allow variable definitions in env.pasthrough.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- #748 - allow definitions in the environment variable passthrough
 - #741 - added `armv7-unknown-linux-gnueabi` and `armv7-unknown-linux-musleabi` targets.
 - #377 - update WINE versions to 7.0.
 - #734 - patch `arm-unknown-linux-gnueabihf` to build for ARMv6, and add architecture for crosstool-ng-based images.

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -115,9 +115,10 @@ pub fn run(
     let mut docker = docker_command("run")?;
 
     let validate_env_var = |var: &str| -> Result<()> {
-        if var.contains('=') {
-            bail!("environment variable names must not contain the '=' character");
-        }
+        let var = match var.split_once('=') {
+            Some((key, _)) => key,
+            _ => var,
+        };
 
         if var == "CROSS_RUNNER" {
             bail!("CROSS_RUNNER environment variable name is reserved and cannot be pass through");


### PR DESCRIPTION
Allow the following syntax:

```toml
[build.env]
passthrough = ["VAR=VALUE"]
```

Closes #743.