### PR TITLE
update readme to mention install from git due to outdated crates version

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ default to `docker`.
 ## Installation
 
 ```
-$ cargo install cross
+$ cargo install cross --git https://github.com/cross-rs/cross
 ```
 
 ## Usage


### PR DESCRIPTION
part of https://github.com/cross-rs/cross/issues/758?