### PR TITLE
Re-enable x86_64-unknown-dragonfly target.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,8 +174,7 @@ jobs:
             # Disabled for now, see https://github.com/rust-lang/rust/issues/85821
             #- { target: asmjs-unknown-emscripten,         os: ubuntu-latest,  cpp: 1,           std: 1, run: 1 }
             #- { target: wasm32-unknown-emscripten,        os: ubuntu-latest,  cpp: 1,           std: 1, run: 1 }
-            # Disabled, see #396
-            #-{ target: x86_64-unknown-dragonfly,          os: ubuntu-latest,  cpp: 1, dylib: 1 }
+            - { target: x86_64-unknown-dragonfly,         os: ubuntu-latest,  cpp: 1, dylib: 1 }
             - { target: i686-unknown-freebsd,             os: ubuntu-latest,          dylib: 1, std: 1 }
             - { target: x86_64-unknown-freebsd,           os: ubuntu-latest,          dylib: 1, std: 1 }
             - { target: x86_64-unknown-netbsd,            os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- #762 - re-enabled `x86_64-unknown-dragonfly` target.
 - #747 - reduced android image sizes.
 - #377 - update WINE versions to 7.0.
 - #734 - patch `arm-unknown-linux-gnueabihf` to build for ARMv6, and add architecture for crosstool-ng-based images.

--- a/docker/Dockerfile.x86_64-unknown-dragonfly
+++ b/docker/Dockerfile.x86_64-unknown-dragonfly
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 ARG DEBIAN_FRONTEND=noninteractive
 
-COPY common.sh /
+COPY common.sh lib.sh /
 RUN /common.sh
 
 COPY cmake.sh /
@@ -11,7 +11,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 COPY dragonfly.sh /
-RUN /dragonfly.sh
+RUN /dragonfly.sh 5
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_DRAGONFLY_LINKER=x86_64-unknown-dragonfly-gcc \
     CC_x86_64_unknown_dragonfly=x86_64-unknown-dragonfly-gcc \

--- a/docker/dragonfly.sh
+++ b/docker/dragonfly.sh
@@ -7,10 +7,15 @@ set -euo pipefail
 . lib.sh
 
 main() {
-    local binutils=2.25.1 \
-          dragonfly=4.6.1_REL \
+    local nproc=
+    local binutils=2.32 \
+          dragonfly=6.0.1_REL \
           gcc=5.3.0 \
-          target=x86_64-unknown-dragonfly
+          target=x86_64-unknown-dragonfly \
+          url="https://mirror-master.dragonflybsd.org/iso-images"
+    if [[ $# != "0" ]]; then
+        nproc="${1}"
+    fi
 
     install_packages bsdtar \
         bzip2 \
@@ -25,35 +30,34 @@ main() {
     local td
     td="$(mktemp -d)"
 
+    pushd "${td}"
     mkdir "${td}"/{binutils,gcc}{,-build} "${td}/dragonfly"
 
     curl --retry 3 -sSfL "https://ftp.gnu.org/gnu/binutils/binutils-${binutils}.tar.bz2" -O
     tar -C "${td}/binutils" --strip-components=1 -xjf "binutils-${binutils}.tar.bz2"
 
-    curl --retry 3 -sSfL "https://ftp.gnu.org/gnu/gcc/gcc-${gcc}/gcc-${gcc}.tar.bz2" -O
-    tar -C "${td}/gcc" --strip-components=1 -xjf "gcc-${gcc}.tar.bz2"
-
-    pushd "${td}"
+    curl --retry 3 -sSfL "https://ftp.gnu.org/gnu/gcc/gcc-${gcc}/gcc-${gcc}.tar.gz" -O
+    tar -C "${td}/gcc" --strip-components=1 -xf "gcc-${gcc}.tar.gz"
 
     cd gcc
     sed -i -e 's/ftp:/https:/g' ./contrib/download_prerequisites
     ./contrib/download_prerequisites
     patch -p0 <<'EOF'
---- libatomic/configure.tgt.orig	2015-07-09 16:08:55 UTC
+--- libatomic/configure.tgt.orig   2015-07-09 16:08:55 UTC
 +++ libatomic/configure.tgt
 @@ -110,7 +110,7 @@ case "${target}" in
- 	;;
+   ;;
 
    *-*-linux* | *-*-gnu* | *-*-k*bsd*-gnu \
 -  | *-*-netbsd* | *-*-freebsd* | *-*-openbsd* \
 +  | *-*-netbsd* | *-*-freebsd* | *-*-openbsd* | *-*-dragonfly* \
    | *-*-solaris2* | *-*-sysv4* | *-*-irix6* | *-*-osf* | *-*-hpux11* \
    | *-*-darwin* | *-*-aix* | *-*-cygwin*)
- 	# POSIX system.  The OS is supported.
+   # POSIX system.  The OS is supported.
 EOF
 
     patch -p0 <<'EOF'
---- libstdc++-v3/config/os/bsd/dragonfly/os_defines.h.orig	2015-07-09 16:08:54 UTC
+--- libstdc++-v3/config/os/bsd/dragonfly/os_defines.h.orig  2015-07-09 16:08:54 UTC
 +++ libstdc++-v3/config/os/bsd/dragonfly/os_defines.h
 @@ -29,4 +29,9 @@
  // System-specific #define, typedefs, corrections, etc, go here.  This
@@ -68,8 +72,8 @@ EOF
 EOF
 
     patch -p0 <<'EOF'
---- libstdc++-v3/configure.orig	2016-05-26 18:34:47.163132921 +0200
-+++ libstdc++-v3/configure	2016-05-26 18:35:29.594590648 +0200
+--- libstdc++-v3/configure.orig    2016-05-26 18:34:47.163132921 +0200
++++ libstdc++-v3/configure 2016-05-26 18:35:29.594590648 +0200
 @@ -52013,7 +52013,7 @@
 
      ;;
@@ -82,16 +86,17 @@ EOF
 EOF
     cd ..
 
-    curl --retry 3 -sSfL "https://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-${dragonfly}.iso.bz2" -O
+    curl --retry 3 -sSfL "${url}/dfly-x86_64-${dragonfly}.iso.bz2" -O
     bzcat "dfly-x86_64-${dragonfly}.iso.bz2" | bsdtar xf - -C "${td}/dragonfly" ./usr/include ./usr/lib ./lib
 
     cd binutils-build
     ../binutils/configure \
         --target="${target}"
-    make "-j$(nproc)"
+    make "-j${nproc}"
     make install
     cd ..
 
+    # note: shell expansions can't be quoted
     local destdir="/usr/local/${target}"
     cp -r "${td}/dragonfly/usr/include" "${destdir}"/
     cp "${td}/dragonfly/lib/libc.so.8" "${destdir}/lib"
@@ -100,9 +105,9 @@ EOF
     cp "${td}/dragonfly/usr/lib/libexecinfo.so.1" "${destdir}/lib"
     cp "${td}/dragonfly/usr/lib/libpthread.so" "${destdir}/lib/libpthread.so"
     cp "${td}/dragonfly/usr/lib/librt.so.0" "${destdir}/lib"
-    cp "${td}/dragonfly/usr/lib/lib{c,m,util}.a" "${destdir}/lib"
+    cp "${td}"/dragonfly/usr/lib/lib{c,m,util}.a "${destdir}/lib"
     cp "${td}/dragonfly/usr/lib/thread/libthread_xu.so.2" "${destdir}/lib/libpthread.so.0"
-    cp "${td}/dragonfly/usr/lib/{crt1,Scrt1,crti,crtn}.o" "${destdir}/lib"
+    cp "${td}"/dragonfly/usr/lib/{crt1,Scrt1,crti,crtn}.o "${destdir}/lib/"
 
     ln -s libc.so.8 "${destdir}/lib/libc.so"
     ln -s libexecinfo.so.1 "${destdir}/lib/libexecinfo.so"
@@ -125,7 +130,7 @@ EOF
         --disable-nls \
         --enable-languages=c,c++ \
         --target="${target}"
-    make "-j$(nproc)"
+    make "-j${nproc}"
     make install
     cd ..
 


### PR DESCRIPTION
This undoes #396, and updates the dragonfly version from 4.6.1 to 6.0.1.
This also fixes a few minor issues in the image previously:

- Brace expansion isn't quoted, so it properly expands.
- Archive files are downloaded to the temp directory, and deleted with
  the image.