### PR TITLE
Update README for target information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,74 +272,75 @@ terminate.
 
 | Target                               |  libc  |   GCC   | C++ | QEMU  | `test` |
 |--------------------------------------|-------:|--------:|:---:|------:|:------:|
-| `*-apple-ios` [1]                    | N/A    | N/A     | N/A | N/A   |   ✓    |
-| `aarch64-linux-android` [2]          | 9.0.0  | 4.9     | ✓   | 5.1.0 |   ✓    |
-| `aarch64-unknown-linux-gnu`          | 2.19   | 4.8.2   | ✓   | 5.1.0 |   ✓    |
-| `aarch64-unknown-linux-musl`         | 1.1.24 | 6.3.0   |     | 5.1.0 |   ✓    |
-| `arm-linux-androideabi` [2]          | 9.0.0  | 4.9     | ✓   | 5.1.0 |   ✓    |
-| `arm-unknown-linux-gnueabi`          | 2.17   | 8.3.0   | ✓   | 5.1.0 |   ✓    |
-| `arm-unknown-linux-gnueabihf`        | 2.27   | 7.3.0   | ✓   | 5.1.0 |   ✓    |
-| `arm-unknown-linux-musleabi`         | 1.1.24 | 6.3.0   |     | 5.1.0 |   ✓    |
-| `arm-unknown-linux-musleabihf`       | 1.1.24 | 6.3.0   |     | 5.1.0 |   ✓    |
+| `aarch64-linux-android` [1]          | 9.0.8  | 9.0.8   | ✓   | 5.1.0 |   ✓    |
+| `aarch64-unknown-linux-gnu`          | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `aarch64-unknown-linux-musl`         | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
+| `arm-linux-androideabi` [1]          | 9.0.8  | 9.0.8   | ✓   | 5.1.0 |   ✓    |
+| `arm-unknown-linux-gnueabi`          | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `arm-unknown-linux-gnueabihf`        | 2.17   | 8.3.0   | ✓   | 5.1.0 |   ✓    |
+| `arm-unknown-linux-musleabi`         | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
+| `arm-unknown-linux-musleabihf`       | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
 | `armv5te-unknown-linux-gnueabi`      | 2.27   | 7.5.0   | ✓   | 5.1.0 |   ✓    |
-| `armv5te-unknown-linux-musleabi`     | 1.1.24 | 6.3.0   |     | 5.1.0 |   ✓    |
-| `armv7-linux-androideabi` [2]        | 9.0.0  | 4.9     | ✓   | 5.1.0 |   ✓    |
+| `armv5te-unknown-linux-musleabi`     | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
+| `armv7-linux-androideabi` [1]        | 9.0.8  | 9.0.8   | ✓   | 5.1.0 |   ✓    |
 | `armv7-unknown-linux-gnueabi`        | 2.27   | 7.5.0   | ✓   | 5.1.0 |   ✓    |
-| `armv7-unknown-linux-gnueabihf`      | 2.15   | 4.6.2   | ✓   | 5.1.0 |   ✓    |
-| `armv7-unknown-linux-musleabi`       | 1.1.24 | 6.3.0   |     | 5.1.0 |   ✓    |
-| `armv7-unknown-linux-musleabihf`     | 1.1.24 | 6.3.0   |     | 5.1.0 |   ✓    |
-| `asmjs-unknown-emscripten` [6]       | 1.2.2  | 3.1.10  | ✓   | N/A   |   ✓    |
-| `i586-unknown-linux-gnu`             | 2.23   | 5.3.1   | ✓   | N/A   |   ✓    |
-| `i586-unknown-linux-musl`            | 1.1.24 | 6.3.0   |     | N/A   |   ✓    |
-| `i686-unknown-freebsd` [4]           | 12.1   | 6.4.0   |     | N/A   |   ✓    |
-| `i686-linux-android` [2]             | 9.0.0  | 4.9     | ✓   | 5.1.0 |   ✓    |
-| `i686-pc-windows-gnu`                | N/A    | 7.3.0   | ✓   | N/A   |   ✓    |
-| `i686-unknown-linux-gnu`             | 2.15   | 4.6.2   | ✓   | N/A   |   ✓    |
-| `i686-unknown-linux-musl`            | 1.1.24 | 6.3.0   |     | N/A   |   ✓    |
-| `mips-unknown-linux-gnu`             | 2.23   | 5.3.1   | ✓   | 5.1.0 |   ✓    |
-| `mips-unknown-linux-musl`            | 1.1.24 | 6.3.0   | ✓   | 5.1.0 |   ✓    |
-| `mips64-unknown-linux-gnuabi64`      | 2.23   | 5.3.1   | ✓   | 5.1.0 |   ✓    |
-| `mips64el-unknown-linux-gnuabi64`    | 2.23   | 5.3.1   | ✓   | 5.1.0 |   ✓    |
-| `mipsel-unknown-linux-gnu`           | 2.23   | 5.3.1   | ✓   | 5.1.0 |   ✓    |
-| `mipsel-unknown-linux-musl`          | 1.1.24 | 6.3.0   | ✓   | 5.1.0 |   ✓    |
-| `powerpc-unknown-linux-gnu`          | 2.19   | 4.8.2   | ✓   | 5.1.0 |   ✓    |
-| `powerpc64-unknown-linux-gnu`        | 2.31   | 10.2.0  | ✓   | 5.1.0 |   ✓    |
-| `powerpc64le-unknown-linux-gnu`      | 2.19   | 4.8.2   | ✓   | 5.1.0 |   ✓    |
+| `armv7-unknown-linux-gnueabihf`      | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `armv7-unknown-linux-musleabi`       | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
+| `armv7-unknown-linux-musleabihf`     | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
+| `i586-unknown-linux-gnu`             | 2.23   | 5.4.0   | ✓   | N/A   |   ✓    |
+| `i586-unknown-linux-musl`            | 1.1.24  | 9.2.0   | ✓   | N/A   |   ✓    |
+| `i686-unknown-freebsd`               | 1.5    | 6.4.0   | ✓   | N/A   |       |
+| `i686-linux-android` [1]             | 9.0.8  | 9.0.8   | ✓   | 5.1.0 |   ✓    |
+| `i686-pc-windows-gnu`                | N/A    | 7.5     | ✓   | N/A   |   ✓    |
+| `i686-unknown-linux-gnu`             | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `i686-unknown-linux-musl`            | 1.1.24  | 9.2.0   | ✓   | N/A   |   ✓    |
+| `mips-unknown-linux-gnu`             | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `mips-unknown-linux-musl`            | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
+| `mips64-unknown-linux-gnuabi64`      | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `mips64-unknown-linux-muslabi64`     | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
+| `mips64el-unknown-linux-gnuabi64`    | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `mips64el-unknown-linux-muslabi64`   | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
+| `mipsel-unknown-linux-gnu`           | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `mipsel-unknown-linux-musl`          | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
+| `powerpc-unknown-linux-gnu`          | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `powerpc64-unknown-linux-gnu`        | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `powerpc64le-unknown-linux-gnu`      | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
 | `riscv64gc-unknown-linux-gnu`        | 2.27   | 7.5.0   | ✓   | 5.1.0 |   ✓    |
-| `s390x-unknown-linux-gnu`            | 2.23   | 5.3.1   | ✓   | 5.1.0 |        |
-| `sparc64-unknown-linux-gnu`          | 2.31   | 10.2.0  | ✓   | 5.1.0 |   ✓    |
-| `sparcv9-sun-solaris` [4]            | 2.11   | 5.3.0   | ✓   | N/A   |        |
-| `thumbv6m-none-eabi` [5]             | 2.2.0  | 5.3.1   |     | N/A   |        |
-| `thumbv7em-none-eabi` [5]            | 2.2.0  | 5.3.1   |     | N/A   |        |
-| `thumbv7em-none-eabihf` [5]          | 2.2.0  | 5.3.1   |     | N/A   |        |
-| `thumbv7m-none-eabi` [5]             | 2.2.0  | 5.3.1   |     | N/A   |        |
-| `wasm32-unknown-emscripten` [6]      | 1.2.2  | 3.1.10  | ✓   | N/A   |   ✓    |
-| `x86_64-linux-android` [2]           | 9.0.0  | 4.9     | ✓   | 5.1.0 |   ✓    |
-| `x86_64-pc-windows-gnu`              | N/A    | 7.3.0   | ✓   | N/A   |   ✓    |
-| `x86_64-sun-solaris` [4]             | 2.11   | 5.3.0   | ✓   | N/A   |        |
-| `x86_64-unknown-freebsd` [4]         | 12.1   | 6.4.0   |     | N/A   |   ✓    |
-| `x86_64-unknown-dragonfly` [4] [3]   | 4.6.0  | 5.3.0   | ✓   | N/A   |        |
-| `x86_64-unknown-linux-gnu`           | 2.15   | 4.6.2   | ✓   | N/A   |   ✓    |
-| `x86_64-unknown-linux-musl`          | 1.1.24 | 6.3.0   |     | N/A   |   ✓    |
-| `x86_64-unknown-netbsd` [4]          | 7.0    | 5.3.0   | ✓   | N/A   |        |
+| `s390x-unknown-linux-gnu`            | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `sparc64-unknown-linux-gnu`          | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `thumbv6m-none-eabi` [4]             | 2.2.0  | 4.9.3   |     | N/A   |       |
+| `thumbv7em-none-eabi` [4]            | 2.2.0  | 4.9.3   |     | N/A   |       |
+| `thumbv7em-none-eabihf` [4]          | 2.2.0  | 4.9.3   |     | N/A   |       |
+| `thumbv7m-none-eabi` [4]             | 2.2.0  | 4.9.3   |     | N/A   |       |
+| `thumbv7neon-linux-androideabi` [1]  | 9.0.8  | 9.0.8   | ✓   | 5.1.0 |   ✓    |
+| `thumbv7neon-unknown-linux-gnueabihf`| 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
+| `x86_64-linux-android` [1]           | 9.0.8  | 9.0.8   | ✓   | 5.1.0 |   ✓    |
+| `x86_64-pc-windows-gnu`              | N/A    | 7.3     | ✓   | N/A   |   ✓    |
+| `x86_64-unknown-freebsd`             | 1.5    | 6.4.0   | ✓   | N/A   |       |
+| `x86_64-unknown-dragonfly` [2] [3]   | 6.0.1  | 5.3.0   | ✓   | N/A   |       |
+| `x86_64-unknown-linux-gnu`           | 2.17   | 4.8.5   | ✓   | 4.2.1 |   ✓    |
+| `x86_64-unknown-linux-musl`          | 1.1.24  | 9.2.0   | ✓   | N/A   |   ✓    |
+| `x86_64-unknown-netbsd` [3]          | 9.2.0  | 9.4.0   | ✓   | N/A   |       |
+<!--| `asmjs-unknown-emscripten` [5]       | 1.2.2  | 3.1.10  | ✓   | N/A   |   ✓    |-->
+<!--| `wasm32-unknown-emscripten` [5]      | 1.2.2  | 3.1.10  | ✓   | N/A   |   ✓    |-->
+<!--| `sparcv9-sun-solaris` [3]            | 2.11   | 5.3.0   | ✓   | N/A   |        |-->
+<!--| `x86_64-sun-solaris` [3]             | 2.11   | 5.3.0   | ✓   | N/A   |        |-->
 
-[1] iOS cross compilation is supported on macOS hosts.
-
-[2] libc = bionic; Only works with native tests, that is, tests that do not depends on the
+[1] libc = bionic; Only works with native tests, that is, tests that do not depends on the
     Android Runtime. For i686 some tests may fails with the error `assertion
     failed: signal(libc::SIGPIPE, libc::SIG_IGN) != libc::SIG_ERR`, see
     [issue #140](https://github.com/cross-rs/cross/issues/140) for more
     information.
 
-[4] For *BSD and Solaris targets, the libc column indicates the OS release version
+[2] No `std` component available.
+
+[3] For some \*BSD and Solaris targets, the libc column indicates the OS release version
     from which libc was extracted.
 
-[3] No `std` component available as of 2017-01-10
+[4] libc = newlib
 
-[5] libc = newlib
-
-[6] libc = musl, gcc = emcc. The Docker images for these targets are currently not built automatically
-due to a [compiler bug](https://github.com/rust-lang/rust/issues/85821), you will have to build them yourself for now.
+<!--[5] libc = musl, gcc = emcc. The Docker images for these targets are currently not built automatically
+due to a [compiler bug](https://github.com/rust-lang/rust/issues/85821), you will have to build them yourself for now.-->
 
 ## Debugging
 

--- a/cross-dev/target_info.sh
+++ b/cross-dev/target_info.sh
@@ -120,11 +120,7 @@ case "${arch}" in
         qarch="ppc64"
         ;;
     powerpc64le)
-        if [ "${CROSS_RUNNER}" = "qemu-user" ]; then
-            qarch="ppc64le"
-        else
-            qarch="ppc64"
-        fi
+        qarch="ppc64le"
         ;;
     riscv64*)
         qarch="riscv64"
@@ -324,5 +320,10 @@ if [ "$qemu" != "" ]; then
     printf " %-5s |" "${qemu}"
 else
     printf " N/A   |"
+fi
+if [ "${HAS_TEST}" != "" ]; then
+    printf "   ✓    |"
+else
+    printf "       |"
 fi
 printf "\n"


### PR DESCRIPTION
Updated target information using the `target-info` command from `cross-dev`. Also added test detection for `cross-dev`, and fixed a bug with `powerpc64le-unknown-linux-gnu` using the wrong qemu architecture. I also removed targets for which we don't provide images, these are commented out below the table, so if we re-enable them they aren't gone entirely.