### PR TITLE
Add `CROSS_CONTAINER_OPTS` environment variable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - #775 - forward Cargo exit code to host
+- #772 - added `CROSS_CONTAINER_OPTS` environment variable to replace `DOCKER_OPTS`.
 - #767 - added the `cross-util` and `cross-dev` commands.
 - #745 - added `thumbv7neon-*` targets.
 - #741 - added `armv7-unknown-linux-gnueabi` and `armv7-unknown-linux-musleabi` targets.


### PR DESCRIPTION
Rename `DOCKER_OPTS` to `CROSS_CONTAINER_OPTS`, and currently prefer `CROSS_CONTAINER_OPTS` to `DOCKER_OPTS`, although both are still valid.

Closes #770.