### PR TITLE
Simplify config internals.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
-use std::str::FromStr;
 use std::{env, path::PathBuf};
 
 use crate::cargo::Subcommand;
+use crate::config::bool_from_envvar;
 use crate::errors::Result;
 use crate::rustc::TargetList;
 use crate::Target;
@@ -26,16 +26,6 @@ fn absolute_path(path: PathBuf) -> Result<PathBuf> {
     } else {
         env::current_dir()?.join(path)
     })
-}
-
-fn bool_from_envvar(envvar: &str) -> bool {
-    if let Ok(value) = bool::from_str(envvar) {
-        value
-    } else if let Ok(value) = i32::from_str(envvar) {
-        value != 0
-    } else {
-        !envvar.is_empty()
-    }
 }
 
 pub fn is_subcommand_list(stdout: &str) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,7 @@ pub fn run() -> Result<ExitStatus> {
 
             let available_targets = rustup::available_targets(&toolchain, verbose)?;
             let uses_xargo = config
-                .xargo(&target)?
+                .xargo(&target)
                 .unwrap_or_else(|| !target.is_builtin() || !available_targets.contains(&target));
 
             if !uses_xargo


### PR DESCRIPTION
Simplifies the `config.rs` and `cross_toml.rs` to have more reusable functions, and implement logic in terms of these functions, so we can add more config options in the future. This also simplifies maintenance, since we can use 1-line logic for most config variables now.