### PR TITLE
Forward Cargo exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- #775 - forward Cargo exit code to host
 - #767 - added the `cross-util` and `cross-dev` commands.
 - #745 - added `thumbv7neon-*` targets.
 - #741 - added `armv7-unknown-linux-gnueabi` and `armv7-unknown-linux-musleabi` targets.

--- a/src/bin/cross.rs
+++ b/src/bin/cross.rs
@@ -2,6 +2,9 @@
 
 pub fn main() -> cross::Result<()> {
     cross::install_panic_hook()?;
-    cross::run()?;
-    Ok(())
+    let status = cross::run()?;
+    let code = status
+        .code()
+        .ok_or_else(|| eyre::Report::msg("Cargo process terminated by signal"))?;
+    std::process::exit(code)
 }


### PR DESCRIPTION
Forward Cargo's exit code. For example, if `cargo test` returns a non-zero exit code due to a failing test, `cross` will also return a non-zero exit code.