### PR TITLE
Bug fix for dragonfly and CI tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
             # Disabled for now, see https://github.com/rust-lang/rust/issues/85821
             #- { target: asmjs-unknown-emscripten,         os: ubuntu-latest,  cpp: 1,           std: 1, run: 1 }
             #- { target: wasm32-unknown-emscripten,        os: ubuntu-latest,  cpp: 1,           std: 1, run: 1 }
-            - { target: x86_64-unknown-dragonfly,         os: ubuntu-latest,  cpp: 1, dylib: 1 }
+            - { target: x86_64-unknown-dragonfly,         os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, build-std: 1 }
             - { target: i686-unknown-freebsd,             os: ubuntu-latest,          dylib: 1, std: 1 }
             - { target: x86_64-unknown-freebsd,           os: ubuntu-latest,          dylib: 1, std: 1 }
             - { target: x86_64-unknown-netbsd,            os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1 }
@@ -243,6 +243,7 @@ jobs:
           CPP: ${{ matrix.cpp }}
           DYLIB: ${{ matrix.dylib }}
           STD: ${{ matrix.std }}
+          BUILD_STD: ${{ matrix.build-std }}
           RUN: ${{ matrix.run }}
           RUNNERS: ${{ matrix.runners }}
         shell: bash

--- a/docker/dragonfly.sh
+++ b/docker/dragonfly.sh
@@ -134,6 +134,11 @@ EOF
     make install
     cd ..
 
+    # rust incorrectly adds link args to libgcc_pic, which is no longer
+    # a present target, and it should link to libgcc_s.
+    # https://github.com/rust-lang/rust/blob/60361f2/library/unwind/build.rs#L23-L38
+    ln -s "${destdir}"/lib/libgcc_s.so "${destdir}"/lib/libgcc_pic.so
+
     # clean up
     popd
 


### PR DESCRIPTION
Added `build-std` flag to CI, so for targets that support `std` but are tier 3 targets, we can use the experimental `build-std` support to ensure they build. Also patches linking on dragonfly to ensure we use `libgcc_s` instead of `libgcc_pic`, which no longer exists. We just create a symlink for that purpose.

Necessary to merge #775.