### PR TITLE
Prefer target.env values over build.env config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- #781 - ensure `target.$(...)` config options override `build` ones.
 - #771 - fix parsing of `DOCKER_OPTS`.
 - #727 - add `PKG_CONFIG_PATH` to all `*-linux-gnu` images.
 - #722 - boolean environment variables are evaluated as truthy or falsey.

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,13 +137,13 @@ impl Config {
             (None, None)
         };
 
-        match (env_build, toml_build) {
+        match (env_target, toml_target) {
             (Some(value), _) => return Some(value),
             (None, Some(value)) => return Some(value),
             (None, None) => {}
         };
 
-        match (env_target, toml_target) {
+        match (env_build, toml_build) {
             (Some(value), _) => return Some(value),
             (None, Some(value)) => return Some(value),
             (None, None) => {}
@@ -360,7 +360,7 @@ mod tests {
             map.insert("CROSS_TARGET_AARCH64_UNKNOWN_LINUX_GNU_XARGO", "true");
             let env = Environment::new(Some(map));
             let config = Config::new_with(Some(toml(TOML_BUILD_XARGO_FALSE)?), env);
-            assert!(matches!(config.xargo(&target()), Some(false)));
+            assert!(matches!(config.xargo(&target()), Some(true)));
 
             Ok(())
         }


### PR DESCRIPTION
We currently use `build.env` over `target.$(...).env`, which means we cannot set a default value and then override it for a specific target. Given the following config file:

```toml
[build.env]
xargo = true

[target.aarch64-unknown-linux-gnu.env]
xargo = false
```

We currently would use `xargo` even on `aarch64-unknown-linux-gnu`, when we should not, and only use `xargo` for every other target.

Closes #773.