### PR TITLE
add `CROSS_CUSTOM_TOOLCHAIN` to disable automatic target component downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- #803 - added `CROSS_CUSTOM_TOOLCHAIN` to disable automatic installation of components for use with tools like `cargo-bisect-rustc`
 - #795 - added images for additional toolchains maintained by cross-rs.
 - #792 - added `CROSS_CONTAINER_IN_CONTAINER` environment variable to replace `CROSS_DOCKER_IN_DOCKER`.
 - #782 - added `build-std` config option, which builds the rust standard library from source if enabled.


### PR DESCRIPTION
This adds an environment variable `CROSS_CUSTOM_TOOLCHAIN` to disable some rustup commands.

The way to use this with `cargo-bisect-rustc` is `cargo bisect-rustc --script=./bisect.sh --target powerpc64le-unknown-linux-gnu` and the script is

```sh
#!/usr/bin/env bash

export CROSS_CUSTOM_TOOLCHAIN=1
exec cross run --target powerpc64le-unknown-linux-gnu
```

I've filed https://github.com/rust-lang/cargo-bisect-rustc/pull/159 to avoid the pitfall that was discovered when not specifying `--target`

resolves #699
