### PR TITLE
Update Qemu version to v6.1.0 if possible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- #807 - update Qemu to 6.1.0 on images using Ubuntu 18.04+ with python3.6+.
 - #775 - forward Cargo exit code to host
 - #762 - re-enabled `x86_64-unknown-dragonfly` target.
 - #747 - reduced android image sizes.

--- a/README.md
+++ b/README.md
@@ -302,49 +302,49 @@ terminate.
 
 | Target                               |  libc  |   GCC   | C++ | QEMU  | `test` |
 |--------------------------------------|-------:|--------:|:---:|------:|:------:|
-| `aarch64-linux-android` [1]          | 9.0.8  | 9.0.8   | ✓   | 5.1.0 |   ✓    |
+| `aarch64-linux-android` [1]          | 9.0.8  | 9.0.8   | ✓   | 6.1.0 |   ✓    |
 | `aarch64-unknown-linux-gnu`          | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `aarch64-unknown-linux-musl`         | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
-| `arm-linux-androideabi` [1]          | 9.0.8  | 9.0.8   | ✓   | 5.1.0 |   ✓    |
+| `aarch64-unknown-linux-musl`         | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `arm-linux-androideabi` [1]          | 9.0.8  | 9.0.8   | ✓   | 6.1.0 |   ✓    |
 | `arm-unknown-linux-gnueabi`          | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `arm-unknown-linux-gnueabihf`        | 2.17   | 8.3.0   | ✓   | 5.1.0 |   ✓    |
-| `arm-unknown-linux-musleabi`         | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
-| `arm-unknown-linux-musleabihf`       | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
-| `armv5te-unknown-linux-gnueabi`      | 2.27   | 7.5.0   | ✓   | 5.1.0 |   ✓    |
-| `armv5te-unknown-linux-musleabi`     | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
-| `armv7-linux-androideabi` [1]        | 9.0.8  | 9.0.8   | ✓   | 5.1.0 |   ✓    |
-| `armv7-unknown-linux-gnueabi`        | 2.27   | 7.5.0   | ✓   | 5.1.0 |   ✓    |
+| `arm-unknown-linux-gnueabihf`        | 2.17   | 8.3.0   | ✓   | 6.1.0 |   ✓    |
+| `arm-unknown-linux-musleabi`         | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `arm-unknown-linux-musleabihf`       | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `armv5te-unknown-linux-gnueabi`      | 2.27   | 7.5.0   | ✓   | 6.1.0 |   ✓    |
+| `armv5te-unknown-linux-musleabi`     | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `armv7-linux-androideabi` [1]        | 9.0.8  | 9.0.8   | ✓   | 6.1.0 |   ✓    |
+| `armv7-unknown-linux-gnueabi`        | 2.27   | 7.5.0   | ✓   | 6.1.0 |   ✓    |
 | `armv7-unknown-linux-gnueabihf`      | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `armv7-unknown-linux-musleabi`       | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
-| `armv7-unknown-linux-musleabihf`     | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
+| `armv7-unknown-linux-musleabi`       | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
+| `armv7-unknown-linux-musleabihf`     | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
 | `i586-unknown-linux-gnu`             | 2.23   | 5.4.0   | ✓   | N/A   |   ✓    |
 | `i586-unknown-linux-musl`            | 1.1.24  | 9.2.0   | ✓   | N/A   |   ✓    |
 | `i686-unknown-freebsd`               | 1.5    | 6.4.0   | ✓   | N/A   |       |
-| `i686-linux-android` [1]             | 9.0.8  | 9.0.8   | ✓   | 5.1.0 |   ✓    |
+| `i686-linux-android` [1]             | 9.0.8  | 9.0.8   | ✓   | 6.1.0 |   ✓    |
 | `i686-pc-windows-gnu`                | N/A    | 7.5     | ✓   | N/A   |   ✓    |
 | `i686-unknown-linux-gnu`             | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
 | `i686-unknown-linux-musl`            | 1.1.24  | 9.2.0   | ✓   | N/A   |   ✓    |
 | `mips-unknown-linux-gnu`             | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `mips-unknown-linux-musl`            | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
+| `mips-unknown-linux-musl`            | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
 | `mips64-unknown-linux-gnuabi64`      | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `mips64-unknown-linux-muslabi64`     | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
+| `mips64-unknown-linux-muslabi64`     | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
 | `mips64el-unknown-linux-gnuabi64`    | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `mips64el-unknown-linux-muslabi64`   | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
+| `mips64el-unknown-linux-muslabi64`   | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
 | `mipsel-unknown-linux-gnu`           | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `mipsel-unknown-linux-musl`          | 1.1.24  | 9.2.0   | ✓   | 5.1.0 |   ✓    |
+| `mipsel-unknown-linux-musl`          | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
 | `powerpc-unknown-linux-gnu`          | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
 | `powerpc64-unknown-linux-gnu`        | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
 | `powerpc64le-unknown-linux-gnu`      | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `riscv64gc-unknown-linux-gnu`        | 2.27   | 7.5.0   | ✓   | 5.1.0 |   ✓    |
+| `riscv64gc-unknown-linux-gnu`        | 2.27   | 7.5.0   | ✓   | 6.1.0 |   ✓    |
 | `s390x-unknown-linux-gnu`            | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
 | `sparc64-unknown-linux-gnu`          | 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
 | `thumbv6m-none-eabi` [4]             | 2.2.0  | 4.9.3   |     | N/A   |       |
 | `thumbv7em-none-eabi` [4]            | 2.2.0  | 4.9.3   |     | N/A   |       |
 | `thumbv7em-none-eabihf` [4]          | 2.2.0  | 4.9.3   |     | N/A   |       |
 | `thumbv7m-none-eabi` [4]             | 2.2.0  | 4.9.3   |     | N/A   |       |
-| `thumbv7neon-linux-androideabi` [1]  | 9.0.8  | 9.0.8   | ✓   | 5.1.0 |   ✓    |
+| `thumbv7neon-linux-androideabi` [1]  | 9.0.8  | 9.0.8   | ✓   | 6.1.0 |   ✓    |
 | `thumbv7neon-unknown-linux-gnueabihf`| 2.23   | 5.4.0   | ✓   | 5.1.0 |   ✓    |
-| `x86_64-linux-android` [1]           | 9.0.8  | 9.0.8   | ✓   | 5.1.0 |   ✓    |
+| `x86_64-linux-android` [1]           | 9.0.8  | 9.0.8   | ✓   | 6.1.0 |   ✓    |
 | `x86_64-pc-windows-gnu`              | N/A    | 7.3     | ✓   | N/A   |   ✓    |
 | `x86_64-unknown-freebsd`             | 1.5    | 6.4.0   | ✓   | N/A   |       |
 | `x86_64-unknown-dragonfly` [2] [3]   | 6.0.1  | 5.3.0   | ✓   | N/A   |       |

--- a/docker/qemu.sh
+++ b/docker/qemu.sh
@@ -170,6 +170,15 @@ main() {
         libpixman-1-dev \
         libselinux1-dev \
         zlib1g-dev
+
+    # if we have python3.6+, we can install qemu 6.1.0, which needs ninja-build
+    # ubuntu 16.04 only provides python3.5, so remove when we have a newer qemu.
+    is_ge_python36=$(python3 -c "import sys; print(int(sys.version_info >= (3, 6)))")
+    if [[ "${is_ge_python36}" == "1" ]]; then
+        if_ubuntu version=6.1.0
+        if_ubuntu install_packages ninja-build
+    fi
+
     local td
     td="$(mktemp -d)"
 


### PR DESCRIPTION
The latest Qemu release contains numerous bug fixes, and other improvements, and the existing patches various issues reported in older Qemu versions. The only changes required are incrementing the Qemu version and adding ninja-build as a temporary dependency, since Qemu now uses it for the build system. However, Ubuntu 16.04, the base image for numerous dependencies we use, still ships with Python3.5, and Qemu 6.1.0 requires Python3.6+, as well as the ninja-build system. We therefore add a check to see if we have a compatible Python version, and if we do, build the last Qemu version, so our code can be fully backwards-compatible.

Closes #587.