### PR TITLE
Update `rustc` and `cargo` commands to use envvars.

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -4,7 +4,7 @@ use std::process::{Command, ExitStatus};
 
 use crate::cli::Args;
 use crate::errors::*;
-use crate::extensions::CommandExt;
+use crate::extensions::{env_program, CommandExt};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Subcommand {
@@ -100,17 +100,17 @@ impl Package {
     }
 }
 
+pub fn cargo_command() -> Command {
+    Command::new(env_program("CARGO", "cargo"))
+}
+
 /// Cargo metadata with specific invocation
 pub fn cargo_metadata_with_args(
     cd: Option<&Path>,
     args: Option<&Args>,
     verbose: bool,
 ) -> Result<Option<CargoMetadata>> {
-    let mut command = std::process::Command::new(
-        std::env::var("CARGO")
-            .ok()
-            .unwrap_or_else(|| "cargo".to_string()),
-    );
+    let mut command = cargo_command();
     command.arg("metadata").args(&["--format-version", "1"]);
     if let Some(cd) = cd {
         command.current_dir(cd);
@@ -148,12 +148,12 @@ pub fn cargo_metadata_with_args(
 
 /// Pass-through mode
 pub fn run(args: &[String], verbose: bool) -> Result<ExitStatus, CommandError> {
-    Command::new("cargo")
+    cargo_command()
         .args(args)
         .run_and_get_status(verbose, false)
 }
 
 /// run cargo and get the output, does not check the exit status
 pub fn run_and_get_output(args: &[String], verbose: bool) -> Result<std::process::Output> {
-    Command::new("cargo").args(args).run_and_get_output(verbose)
+    cargo_command().args(args).run_and_get_output(verbose)
 }

--- a/src/docker/local.rs
+++ b/src/docker/local.rs
@@ -25,7 +25,7 @@ pub(crate) fn run(
     let engine = Engine::new(verbose)?;
     let dirs = Directories::create(&engine, metadata, cwd, sysroot, docker_in_docker, verbose)?;
 
-    let mut cmd = cargo_cmd(uses_xargo);
+    let mut cmd = cargo_safe_command(uses_xargo);
     cmd.args(args);
 
     let mut docker = subcommand(&engine, "run");

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -162,7 +162,7 @@ pub fn parse_docker_opts(value: &str) -> Result<Vec<String>> {
     shell_words::split(value).wrap_err_with(|| format!("could not parse docker opts of {}", value))
 }
 
-pub(crate) fn cargo_cmd(uses_xargo: bool) -> SafeCommand {
+pub(crate) fn cargo_safe_command(uses_xargo: bool) -> SafeCommand {
     if uses_xargo {
         SafeCommand::new("xargo")
     } else {

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -207,3 +207,9 @@ impl From<SafeCommand> for Command {
         cmd
     }
 }
+
+pub(crate) fn env_program(envvar: &str, program: &str) -> String {
+    std::env::var(envvar)
+        .ok()
+        .unwrap_or_else(|| program.to_string())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ use config::Config;
 use rustc_version::Channel;
 use serde::Deserialize;
 
-pub use self::cargo::{cargo_metadata_with_args, CargoMetadata, Subcommand};
+pub use self::cargo::{cargo_command, cargo_metadata_with_args, CargoMetadata, Subcommand};
 use self::cross_toml::CrossToml;
 use self::errors::Context;
 use self::rustc::{TargetList, VersionMetaExt};

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use rustc_version::{Version, VersionMeta};
 
 use crate::errors::*;
-use crate::extensions::CommandExt;
+use crate::extensions::{env_program, CommandExt};
 use crate::{Host, Target};
 
 #[derive(Debug)]
@@ -33,8 +33,12 @@ impl VersionMetaExt for VersionMeta {
     }
 }
 
+pub fn rustc_command() -> Command {
+    Command::new(env_program("RUSTC", "rustc"))
+}
+
 pub fn target_list(verbose: bool) -> Result<TargetList> {
-    Command::new("rustc")
+    rustc_command()
         .args(&["--print", "target-list"])
         .run_and_get_stdout(verbose)
         .map(|s| TargetList {
@@ -43,7 +47,7 @@ pub fn target_list(verbose: bool) -> Result<TargetList> {
 }
 
 pub fn sysroot(host: &Host, target: &Target, verbose: bool) -> Result<PathBuf> {
-    let mut stdout = Command::new("rustc")
+    let mut stdout = rustc_command()
         .args(&["--print", "sysroot"])
         .run_and_get_stdout(verbose)?
         .trim()

--- a/xtask/src/hooks.rs
+++ b/xtask/src/hooks.rs
@@ -26,7 +26,7 @@ pub struct Test {
 }
 
 fn has_nightly(verbose: bool) -> cross::Result<bool> {
-    Command::new("cargo")
+    cross::cargo_command()
         .arg("+nightly")
         .run_and_get_output(verbose)
         .map(|o| o.status.success())
@@ -47,7 +47,7 @@ fn get_channel_prefer_nightly(
 }
 
 fn cargo(channel: Option<&str>) -> Command {
-    let mut command = Command::new("cargo");
+    let mut command = cross::cargo_command();
     if let Some(channel) = channel {
         command.arg(&format!("+{channel}"));
     }


### PR DESCRIPTION
`rustc` and `cargo` will now use `RUSTC` and `CARGO` environment variables, respectively, if present.