### PR TITLE
Enable usage of other toolchains in images

### DIFF
--- a/.changes/817.json
+++ b/.changes/817.json
@@ -1,10 +1,16 @@
 [
   {
     "description": "Images can now specify a certain toolchain via `target.{target}.image.toolchain`",
-    "type": "changed"
+    "breaking": true,
+    "type": "added"
   },
   {
     "description": "made `cross +channel` parsing more compliant to parsing a toolchain",
     "type": "fixed"
+  },
+  {
+    "description": "`pre-build` and `dockerfile` now uses buildx/buildkit",
+    "breaking": true,
+    "type": "changed"
   }
 ]

--- a/.changes/817.json
+++ b/.changes/817.json
@@ -1,0 +1,10 @@
+[
+  {
+    "description": "Images can now specify a certain toolchain via `target.{target}.image.toolchain`",
+    "type": "changed"
+  },
+  {
+    "description": "made `cross +channel` parsing more compliant to parsing a toolchain",
+    "type": "fixed"
+  }
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
 
       - name: LLVM instrument coverage
-        id: remote-cov
         uses: ./.github/actions/cargo-llvm-cov
         with:
           name: integration-remote
@@ -361,7 +360,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
 
       - name: LLVM instrument coverage
-        id: bisect-cov
         uses: ./.github/actions/cargo-llvm-cov
         with:
           name: integration-bisect
@@ -370,6 +368,23 @@ jobs:
         env:
           TARGET: aarch64-unknown-linux-gnu
         run: ./ci/test-bisect.sh
+        shell: bash
+
+  foreign:
+    needs: [shellcheck, test, check]
+    runs-on: ubuntu-latest
+    if: github.actor == 'bors[bot]'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-rust
+
+      - name: LLVM instrument coverage
+        uses: ./.github/actions/cargo-llvm-cov
+        with:
+          name: integration-bisect
+
+      - name: Run Foreign toolchain test
+        run: ./ci/test-foreign-toolchain.sh
         shell: bash
 
   docker-in-docker:
@@ -381,7 +396,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
 
       - name: LLVM instrument coverage
-        id: docker-in-docker-cov
         uses: ./.github/actions/cargo-llvm-cov
         with:
           name: integration-docker-in-docker
@@ -405,7 +419,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   conclusion:
-    needs: [shellcheck, fmt, clippy, test, generate-matrix, build, publish, check, remote, bisect, docker-in-docker]
+    needs: [shellcheck, fmt, clippy, test, generate-matrix, build, publish, check, remote, bisect, docker-in-docker, foreign]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
 
   # we should always have an artifact from a previous build.
   remote:
-    needs: [shellcheck, test, check]
+    needs: [test, check]
     runs-on: ubuntu-latest
     if: github.actor == 'bors[bot]'
     steps:
@@ -352,7 +352,7 @@ jobs:
         shell: bash
 
   bisect:
-    needs: [shellcheck, test, check]
+    needs: [test, check]
     runs-on: ubuntu-latest
     if: github.actor == 'bors[bot]'
     steps:
@@ -371,7 +371,7 @@ jobs:
         shell: bash
 
   foreign:
-    needs: [shellcheck, test, check]
+    needs: [test, check]
     runs-on: ubuntu-latest
     if: github.actor == 'bors[bot]'
     steps:
@@ -382,13 +382,21 @@ jobs:
         uses: ./.github/actions/cargo-llvm-cov
         with:
           name: integration-bisect
-
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+        with:
+          install: true
       - name: Run Foreign toolchain test
         run: ./ci/test-foreign-toolchain.sh
         shell: bash
 
   docker-in-docker:
-    needs: [shellcheck, test, check]
+    needs: [test, check]
     runs-on: ubuntu-latest
     if: github.actor == 'bors[bot]'
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,6 @@ version = "0.2.4"
 edition = "2021"
 include = [
   "src/**/*",
-  "docker/Dockerfile.*",
-  "docker/*.sh",
   "docs/*.md",
   "Cargo.toml",
   "Cargo.lock",

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ One of these container engines is required. If both are installed, `cross` will
 default to `docker`.
 
 - [Docker]. Note that on Linux non-sudo users need to be in the `docker` group.
-  Read the official [post-installation steps][post]. Requires version 1.24 or later.
+  Read the official [post-installation steps][post]. Requires version 20.10 (API 1.40) or later.
 
 [post]: https://docs.docker.com/install/linux/linux-postinstall/
 
-- [Podman]. Requires version 1.6.3 or later.
+- [Podman]. Requires version 3.4.0 or later.
 
 ## Installation
 

--- a/ci/shared.sh
+++ b/ci/shared.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+ci_dir=$(dirname "${BASH_SOURCE[0]}")
+ci_dir=$(realpath "${ci_dir}")
+PROJECT_HOME=$(dirname "${ci_dir}")
+export PROJECT_HOME
+CARGO_TMP_DIR="${PROJECT_HOME}/target/tmp"
+export CARGO_TMP_DIR
+
+if [[ -n "${CROSS_CONTAINER_ENGINE}" ]]; then
+  CROSS_ENGINE="${CROSS_CONTAINER_ENGINE}"
+elif command -v docker >/dev/null 2>&1; then
+  CROSS_ENGINE=docker
+else
+  CROSS_ENGINE=podman
+fi
+export CROSS_ENGINE
+
 function retry {
   local tries="${TRIES-5}"
   local timeout="${TIMEOUT-1}"
@@ -20,4 +36,15 @@ function retry {
   done
 
   return ${exit_code}
+}
+
+function mkcargotemp {
+  local td=
+  td="$CARGO_TMP_DIR"/$(mktemp -u "${@}" | xargs basename)
+  mkdir -p "$td"
+  echo '# Cargo.toml
+  [workspace]
+  members = ["'"$(basename "$td")"'"]
+   ' > "$CARGO_TMP_DIR"/Cargo.toml
+  echo "$td"
 }

--- a/ci/test-bisect.sh
+++ b/ci/test-bisect.sh
@@ -13,7 +13,7 @@ fi
 ci_dir=$(dirname "${BASH_SOURCE[0]}")
 ci_dir=$(realpath "${ci_dir}")
 . "${ci_dir}"/shared.sh
-project_home=$(dirname "${ci_dir}")
+
 
 main() {
     local td=
@@ -22,7 +22,7 @@ main() {
     retry cargo fetch
     cargo build
     cargo install cargo-bisect-rustc --debug
-    export CROSS="${project_home}/target/debug/cross"
+    export CROSS="${PROJECT_HOME}/target/debug/cross"
 
     td="$(mktemp -d)"
     git clone --depth 1 https://github.com/cross-rs/rust-cpp-hello-word "${td}"

--- a/ci/test-cross-image.sh
+++ b/ci/test-cross-image.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2086
+# shellcheck disable=SC2086,SC1091,SC1090
 
 set -x
 set -eo pipefail
@@ -20,6 +20,9 @@ if [[ -z "${CROSS_TARGET_CROSS_IMAGE}" ]]; then
     CROSS_TARGET_CROSS_IMAGE="ghcr.io/cross-rs/cross:main"
 fi
 
+ci_dir=$(dirname "${BASH_SOURCE[0]}")
+ci_dir=$(realpath "${ci_dir}")
+. "${ci_dir}"/shared.sh
 
 main() {
 

--- a/ci/test-docker-in-docker.sh
+++ b/ci/test-docker-in-docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC1004
+# shellcheck disable=SC1004,SC1091,SC1090
 
 # test to see that running docker-in-docker works
 
@@ -18,17 +18,17 @@ if [[ "${IMAGE}" ]]; then
     export "CROSS_TARGET_${TARGET_UPPER//-/_}_IMAGE"="${IMAGE}"
 fi
 
-source=$(dirname "${BASH_SOURCE[0]}")
-source=$(realpath "${source}")
-home=$(dirname "${source}")
+ci_dir=$(dirname "${BASH_SOURCE[0]}")
+ci_dir=$(realpath "${ci_dir}")
+. "${ci_dir}"/shared.sh
 
 main() {
-    docker run -v "${home}":"${home}" -w "${home}" \
+    docker run -v "${PROJECT_HOME}":"${PROJECT_HOME}" -w "${PROJECT_HOME}" \
         --rm -e TARGET -e RUSTFLAGS -e RUST_TEST_THREADS \
         -e LLVM_PROFILE_FILE -e CARGO_INCREMENTAL \
         -e "CROSS_TARGET_${TARGET_UPPER//-/_}_IMAGE" \
         -v /var/run/docker.sock:/var/run/docker.sock \
-        docker:18.09-dind sh -c '
+        docker:20.10-dind sh -c '
 #!/usr/bin/env sh
 set -x
 set -euo pipefail

--- a/ci/test-foreign-toolchain.sh
+++ b/ci/test-foreign-toolchain.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091,SC1090
+
+# test to see that foreign toolchains work
+
+set -x
+set -eo pipefail
+
+ci_dir=$(dirname "${BASH_SOURCE[0]}")
+ci_dir=$(realpath "${ci_dir}")
+. "${ci_dir}"/shared.sh
+
+main() {
+    local td=
+
+    retry cargo fetch
+    cargo build
+    export CROSS="${PROJECT_HOME}/target/debug/cross"
+
+    td="$(mkcargotemp -d)"
+
+    pushd "${td}"
+    cargo init --bin --name foreign_toolchain
+    # shellcheck disable=SC2016
+    echo '# Cross.toml
+[build]
+default-target = "x86_64-unknown-linux-musl"
+
+[target."x86_64-unknown-linux-musl"]
+image.name = "alpine:edge"
+image.toolchain = ["x86_64-unknown-linux-musl"]
+pre-build = ["apk add --no-cache gcc musl-dev"]' >"${CARGO_TMP_DIR}"/Cross.toml
+
+    "$CROSS" run -v
+
+    local tmp_basename
+    tmp_basename=$(basename "${CARGO_TMP_DIR}")
+    "${CROSS_ENGINE}" images --format '{{.Repository}}:{{.Tag}}' --filter 'label=org.cross-rs.for-cross-target' | grep "cross-custom-${tmp_basename}" | xargs -t "${CROSS_ENGINE}" rmi
+
+    echo '# Cross.toml
+[build]
+default-target = "x86_64-unknown-linux-gnu"
+
+[target.x86_64-unknown-linux-gnu]
+pre-build = [
+    "apt-get update && apt-get install -y libc6 g++-x86-64-linux-gnu libc6-dev-amd64-cross",
+]
+
+[target.x86_64-unknown-linux-gnu.env]
+passthrough = [
+    "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc",
+    "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER=/qemu-runner x86_64",
+    "CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc",
+    "CXX_x86_64_unknown_linux_gnu=x86_64-linux-gnu-g++",
+]
+
+[target.x86_64-unknown-linux-gnu.image]
+name = "ubuntu:20.04"
+toolchain = ["aarch64-unknown-linux-gnu"]
+    ' >"${CARGO_TMP_DIR}"/Cross.toml
+
+    "$CROSS" build -v
+
+    "${CROSS_ENGINE}" images --format '{{.Repository}}:{{.Tag}}' --filter 'label=org.cross-rs.for-cross-target' | grep "cross-custom-${tmp_basename}" | xargs "${CROSS_ENGINE}" rmi
+
+    popd
+
+    rm -rf "${td}"
+}
+
+main

--- a/ci/test-remote.sh
+++ b/ci/test-remote.sh
@@ -14,15 +14,14 @@ fi
 ci_dir=$(dirname "${BASH_SOURCE[0]}")
 ci_dir=$(realpath "${ci_dir}")
 . "${ci_dir}"/shared.sh
-project_home=$(dirname "${ci_dir}")
 
 main() {
     local err=
 
     retry cargo fetch
     cargo build
-    export CROSS="${project_home}/target/debug/cross"
-    export CROSS_UTIL="${project_home}/target/debug/cross-util"
+    export CROSS="${PROJECT_HOME}/target/debug/cross"
+    export CROSS_UTIL="${PROJECT_HOME}/target/debug/cross-util"
 
     # if the create volume fails, ensure it exists.
     if ! err=$("${CROSS_UTIL}" volumes create 2>&1 >/dev/null); then
@@ -40,7 +39,7 @@ main() {
 
 cross_test_cpp() {
     local td=
-    td="$(mktemp -d)"
+    td="$(mkcargotemp -d)"
 
     git clone --depth 1 https://github.com/cross-rs/rust-cpp-hello-word "${td}"
 

--- a/docs/cross_toml.md
+++ b/docs/cross_toml.md
@@ -56,6 +56,16 @@ $ cat ./scripts/my-script.sh
 apt-get install libssl-dev -y
 ```
 
+# `target.TARGET.image`
+
+The `image` key can also take the toolchains/platforms supported by the image.
+
+```toml
+[target.aarch64-unknown-linux-gnu]
+image.name = "alpine:edge"
+image.toolchain = ["x86_64-unknown-linux-musl", "linux/arm64=aarch64-unknown-linux-musl"] # Defaults to `x86_64-unknown-linux-gnu`
+```
+
 # `target.TARGET.env`
 
 The `target` key allows you to specify environment variables that should be used for a specific compilation target.

--- a/src/bin/cross-util.rs
+++ b/src/bin/cross-util.rs
@@ -1,8 +1,8 @@
 #![deny(missing_debug_implementations, rust_2018_idioms)]
 
 use clap::{CommandFactory, Parser, Subcommand};
-use cross::docker;
 use cross::shell::MessageInfo;
+use cross::{docker, rustc::Toolchain};
 
 mod commands;
 
@@ -11,7 +11,7 @@ mod commands;
 struct Cli {
     /// Toolchain name/version to use (such as stable or 1.59.0).
     #[clap(value_parser = is_toolchain)]
-    toolchain: Option<String>,
+    toolchain: Option<Toolchain>,
     #[clap(subcommand)]
     command: Commands,
 }
@@ -88,7 +88,7 @@ pub fn main() -> cross::Result<()> {
         Commands::Volumes(args) => {
             let mut msg_info = get_msg_info!(args)?;
             let engine = get_engine!(args, args.docker_in_docker(), msg_info)?;
-            args.run(engine, cli.toolchain.as_deref(), &mut msg_info)?;
+            args.run(engine, cli.toolchain.as_ref(), &mut msg_info)?;
         }
         Commands::Containers(args) => {
             let mut msg_info = get_msg_info!(args)?;

--- a/src/bin/cross.rs
+++ b/src/bin/cross.rs
@@ -1,10 +1,48 @@
 #![deny(missing_debug_implementations, rust_2018_idioms)]
 
+use std::{
+    env,
+    io::{self, Write},
+};
+
+use cross::{
+    cargo, cli, rustc,
+    shell::{self, Verbosity},
+    OutputExt, Subcommand,
+};
+
 pub fn main() -> cross::Result<()> {
     cross::install_panic_hook()?;
     cross::install_termination_hook()?;
 
-    let status = cross::run()?;
+    let target_list = rustc::target_list(&mut Verbosity::Quiet.into())?;
+    let args = cli::parse(&target_list)?;
+    let subcommand = args.subcommand;
+    let mut msg_info = shell::MessageInfo::create(args.verbose, args.quiet, args.color.as_deref())?;
+    let status = match cross::run(args, target_list, &mut msg_info)? {
+        Some(status) => status,
+        None => {
+            // if we fallback to the host cargo, use the same invocation that was made to cross
+            let argv: Vec<String> = env::args().skip(1).collect();
+            msg_info.note("Falling back to `cargo` on the host.")?;
+            match subcommand {
+                Some(Subcommand::List) => {
+                    // this won't print in order if we have both stdout and stderr.
+                    let out = cargo::run_and_get_output(&argv, &mut msg_info)?;
+                    let stdout = out.stdout()?;
+                    if out.status.success() && cli::is_subcommand_list(&stdout) {
+                        cli::fmt_subcommands(&stdout, &mut msg_info)?;
+                    } else {
+                        // Not a list subcommand, which can happen with weird edge-cases.
+                        print!("{}", stdout);
+                        io::stdout().flush().expect("could not flush");
+                    }
+                    out.status
+                }
+                _ => cargo::run(&argv, &mut msg_info)?,
+            }
+        }
+    };
     let code = status
         .code()
         .ok_or_else(|| eyre::Report::msg("Cargo process terminated by signal"))?;

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::error::Error;
 use std::fs::File;
-use std::io::{self, Write};
+use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -22,11 +22,6 @@ fn main() {
     File::create(out_dir.join("commit-info.txt"))
         .unwrap()
         .write_all(commit_info().as_bytes())
-        .unwrap();
-
-    File::create(out_dir.join("docker-images.rs"))
-        .unwrap()
-        .write_all(docker_images().as_bytes())
         .unwrap();
 }
 
@@ -59,27 +54,4 @@ fn commit_date() -> Result<String, Some> {
     } else {
         Err(Some {})
     }
-}
-
-fn docker_images() -> String {
-    let mut images = String::from("[");
-    let mut dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
-    dir.push("docker");
-
-    let dir = dir.read_dir().unwrap();
-    let mut paths = dir.collect::<io::Result<Vec<_>>>().unwrap();
-    paths.sort_by_key(|e| e.path());
-
-    for entry in paths {
-        let path = entry.path();
-        let file_name = path.file_name().unwrap().to_str().unwrap();
-        if file_name.starts_with("Dockerfile.") {
-            images.push('"');
-            images.push_str(&file_name.replacen("Dockerfile.", "", 1));
-            images.push_str("\", ");
-        }
-    }
-
-    images.push(']');
-    images
 }

--- a/src/docker/engine.rs
+++ b/src/docker/engine.rs
@@ -3,9 +3,11 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::config::bool_from_envvar;
-use crate::errors::*;
 use crate::extensions::CommandExt;
 use crate::shell::MessageInfo;
+use crate::{errors::*, OutputExt};
+
+use super::{Architecture, ContainerOs};
 
 pub const DOCKER: &str = "docker";
 pub const PODMAN: &str = "podman";
@@ -23,6 +25,8 @@ pub struct Engine {
     pub kind: EngineType,
     pub path: PathBuf,
     pub in_docker: bool,
+    pub arch: Option<Architecture>,
+    pub os: Option<ContainerOs>,
     pub is_remote: bool,
 }
 
@@ -45,16 +49,18 @@ impl Engine {
         is_remote: Option<bool>,
         msg_info: &mut MessageInfo,
     ) -> Result<Engine> {
-        let kind = get_engine_type(&path, msg_info)?;
         let in_docker = match in_docker {
             Some(v) => v,
             None => Self::in_docker(msg_info)?,
         };
+        let (kind, arch, os) = get_engine_info(&path, msg_info)?;
         let is_remote = is_remote.unwrap_or_else(Self::is_remote);
         Ok(Engine {
             path,
             kind,
             in_docker,
+            arch,
+            os,
             is_remote,
         })
     }
@@ -92,21 +98,101 @@ impl Engine {
 
 // determine if the container engine is docker. this fixes issues with
 // any aliases (#530), and doesn't fail if an executable suffix exists.
-fn get_engine_type(ce: &Path, msg_info: &mut MessageInfo) -> Result<EngineType> {
-    let stdout = Command::new(ce)
+fn get_engine_info(
+    ce: &Path,
+    msg_info: &mut MessageInfo,
+) -> Result<(EngineType, Option<Architecture>, Option<ContainerOs>)> {
+    let stdout_help = Command::new(ce)
         .arg("--help")
         .run_and_get_stdout(msg_info)?
         .to_lowercase();
 
-    if stdout.contains("podman-remote") {
-        Ok(EngineType::PodmanRemote)
-    } else if stdout.contains("podman") {
-        Ok(EngineType::Podman)
-    } else if stdout.contains("docker") && !stdout.contains("emulate") {
-        Ok(EngineType::Docker)
+    let kind = if stdout_help.contains("podman-remote") {
+        EngineType::PodmanRemote
+    } else if stdout_help.contains("podman") {
+        EngineType::Podman
+    } else if stdout_help.contains("docker") && !stdout_help.contains("emulate") {
+        EngineType::Docker
     } else {
-        Ok(EngineType::Other)
-    }
+        EngineType::Other
+    };
+
+    let mut cmd = Command::new(ce);
+    cmd.args(&["version", "-f", "{{ .Server.Os }},,,{{ .Server.Arch }}"]);
+
+    let out = cmd.run_and_get_output(msg_info)?;
+
+    let stdout = out.stdout()?.to_lowercase();
+
+    let osarch = stdout
+        .trim()
+        .split_once(",,,")
+        .map(|(os, arch)| -> Result<_> { Ok((ContainerOs::new(os)?, Architecture::new(arch)?)) })
+        .transpose();
+
+    let osarch = match (kind, osarch) {
+        (_, Ok(Some(osarch))) => Some(osarch),
+        (EngineType::PodmanRemote | EngineType::Podman, Ok(None)) => get_podman_info(ce, msg_info)?,
+        (_, Err(e)) => {
+            return Err(e.wrap_err(format!(
+                "command `{}` returned unexpected data",
+                cmd.command_pretty(msg_info, |_| false)
+            )));
+        }
+        (EngineType::Docker | EngineType::Other, Ok(None)) => None,
+    };
+
+    let osarch = if osarch.is_some() {
+        osarch
+    } else if !out.status.success() {
+        get_custom_info(ce, msg_info).with_error(|| {
+            cmd.status_result(msg_info, out.status, Some(&out))
+                .expect_err("status_result should error")
+        })?
+    } else {
+        get_custom_info(ce, msg_info)?
+    };
+
+    let (os, arch) = osarch.map_or(<_>::default(), |(os, arch)| (Some(os), Some(arch)));
+    Ok((kind, arch, os))
+}
+
+fn get_podman_info(
+    ce: &Path,
+    msg_info: &mut MessageInfo,
+) -> Result<Option<(ContainerOs, Architecture)>> {
+    let mut cmd = Command::new(ce);
+    cmd.args(&["info", "-f", "{{ .Version.OsArch }}"]);
+    cmd.run_and_get_stdout(msg_info)
+        .map(|s| {
+            s.to_lowercase()
+                .trim()
+                .split_once('/')
+                .map(|(os, arch)| -> Result<_> {
+                    Ok((ContainerOs::new(os)?, Architecture::new(arch)?))
+                })
+        })
+        .wrap_err("could not determine os and architecture of vm")?
+        .transpose()
+}
+
+fn get_custom_info(
+    ce: &Path,
+    msg_info: &mut MessageInfo,
+) -> Result<Option<(ContainerOs, Architecture)>> {
+    let mut cmd = Command::new(ce);
+    cmd.args(&["info", "-f", "{{ .Client.Os }},,,{{ .Client.Arch }}"]);
+    cmd.run_and_get_stdout(msg_info)
+        .map(|s| {
+            s.to_lowercase()
+                .trim()
+                .split_once(",,,")
+                .map(|(os, arch)| -> Result<_> {
+                    Ok((ContainerOs::new(os)?, Architecture::new(arch)?))
+                })
+        })
+        .unwrap_or_default()
+        .transpose()
 }
 
 pub fn get_container_engine() -> Result<PathBuf, which::Error> {

--- a/src/docker/image.rs
+++ b/src/docker/image.rs
@@ -1,0 +1,422 @@
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{errors::*, shell::MessageInfo, TargetTriple};
+
+use super::Engine;
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct Image {
+    pub name: String,
+    // The toolchain triple the image is built for
+    pub platform: ImagePlatform,
+}
+
+impl std::fmt::Display for Image {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.name)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct PossibleImage {
+    pub name: String,
+    // The toolchain triple the image is built for
+    pub toolchain: Vec<ImagePlatform>,
+}
+
+impl PossibleImage {
+    pub(crate) fn to_definite_with(&self, engine: &Engine, msg_info: &mut MessageInfo) -> Image {
+        if self.toolchain.is_empty() {
+            Image {
+                name: self.name.clone(),
+                platform: ImagePlatform::DEFAULT,
+            }
+        } else {
+            let platform = if self.toolchain.len() == 1 {
+                self.toolchain.get(0).expect("should contain at least one")
+            } else {
+                let same_arch = self
+                    .toolchain
+                    .iter()
+                    .filter(|platform| {
+                        &platform.architecture
+                            == engine.arch.as_ref().unwrap_or(&Architecture::Amd64)
+                    })
+                    .collect::<Vec<_>>();
+
+                if same_arch.len() == 1 {
+                    // pick the platform with the same architecture
+                    same_arch.get(0).expect("should contain one element")
+                } else if let Some(platform) = same_arch
+                    .iter()
+                    .find(|platform| &platform.os == engine.os.as_ref().unwrap_or(&Os::Linux))
+                {
+                    *platform
+                } else if let Some(platform) =
+                    same_arch.iter().find(|platform| platform.os == Os::Linux)
+                {
+                    // container engine should be fine with linux
+                    platform
+                } else {
+                    let platform = self
+                        .toolchain
+                        .get(0)
+                        .expect("should be at least one platform");
+                    // FIXME: Don't throw away
+                    msg_info.warn(
+                        format_args!("could not determine what toolchain to use for image, defaulting to `{}`", platform.target),
+                    ).ok();
+                    platform
+                }
+            };
+            Image {
+                platform: platform.clone(),
+                name: self.name.clone(),
+            }
+        }
+    }
+}
+
+impl<T: AsRef<str>> From<T> for PossibleImage {
+    fn from(s: T) -> Self {
+        PossibleImage {
+            name: s.as_ref().to_owned(),
+            toolchain: vec![],
+        }
+    }
+}
+
+impl FromStr for PossibleImage {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(s.into())
+    }
+}
+
+impl std::fmt::Display for PossibleImage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.name)
+    }
+}
+/// The architecture/platform to use in the image
+///
+/// https://github.com/containerd/containerd/blob/release/1.6/platforms/platforms.go#L63
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "&str")]
+pub struct ImagePlatform {
+    /// CPU architecture, x86_64, aarch64 etc
+    pub architecture: Architecture,
+    /// The OS, i.e linux, windows, darwin
+    pub os: Os,
+    /// The platform variant, i.e v8, v7, v6 etc
+    pub variant: Option<String>,
+    pub target: TargetTriple,
+}
+
+impl ImagePlatform {
+    pub const DEFAULT: Self = ImagePlatform::from_const_target(TargetTriple::DEFAULT);
+    pub const X86_64_UNKNOWN_LINUX_GNU: Self =
+        ImagePlatform::from_const_target(TargetTriple::X86_64UnknownLinuxGnu);
+    pub const AARCH64_UNKNOWN_LINUX_GNU: Self =
+        ImagePlatform::from_const_target(TargetTriple::Aarch64UnknownLinuxGnu);
+
+    /// Get a representative version of this platform specifier for usage in `--platform`
+    ///
+    /// Prefer using [`ImagePlatform::specify_platform`] which will supply the flag if needed
+    pub fn docker_platform(&self) -> String {
+        if let Some(variant) = &self.variant {
+            format!("{}/{}/{variant}", self.os, self.architecture)
+        } else {
+            format!("{}/{}", self.os, self.architecture)
+        }
+    }
+}
+
+impl TryFrom<&str> for ImagePlatform {
+    type Error = <Self as std::str::FromStr>::Err;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl std::str::FromStr for ImagePlatform {
+    type Err = eyre::Report;
+    // [os/arch[/variant]=]toolchain
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use serde::de::{
+            value::{Error as SerdeError, StrDeserializer},
+            IntoDeserializer,
+        };
+        if let Some((platform, toolchain)) = s.split_once('=') {
+            let image_toolchain = toolchain.into();
+            let (os, arch, variant) = if let Some((os, rest)) = platform.split_once('/') {
+                let os: StrDeserializer<'_, SerdeError> = os.into_deserializer();
+                let (arch, variant) = if let Some((arch, variant)) = rest.split_once('/') {
+                    let arch: StrDeserializer<'_, SerdeError> = arch.into_deserializer();
+                    (arch, Some(variant))
+                } else {
+                    let arch: StrDeserializer<'_, SerdeError> = rest.into_deserializer();
+                    (arch, None)
+                };
+                (os, arch, variant)
+            } else {
+                eyre::bail!("invalid platform specified")
+            };
+            Ok(ImagePlatform {
+                architecture: Architecture::deserialize(arch)?,
+                os: Os::deserialize(os)?,
+                variant: variant.map(ToOwned::to_owned),
+                target: image_toolchain,
+            })
+        } else {
+            Ok(ImagePlatform::from_target(s.into())
+                .wrap_err_with(|| format!("could not map `{s}` to a platform"))?)
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Architecture {
+    I386,
+    #[serde(alias = "x86_64")]
+    Amd64,
+    #[serde(alias = "armv7")]
+    Arm,
+    #[serde(alias = "aarch64")]
+    Arm64,
+    Mips,
+    Mips64,
+    Mips64Le,
+    MipsLe,
+    Ppc64,
+    Ppc64Le,
+    #[serde(alias = "riscv64gc")]
+    Riscv64,
+    S390x,
+    Wasm,
+}
+
+impl Architecture {
+    pub fn from_target(target: &TargetTriple) -> Result<Self> {
+        let arch = target
+            .triple()
+            .split_once('-')
+            .ok_or_else(|| eyre::eyre!("malformed target"))?
+            .0;
+        Self::new(arch)
+    }
+
+    pub fn new(s: &str) -> Result<Self> {
+        use serde::de::IntoDeserializer;
+
+        Self::deserialize(<&str as IntoDeserializer>::into_deserializer(s))
+            .wrap_err_with(|| format!("architecture {s} is not supported"))
+    }
+}
+
+impl std::fmt::Display for Architecture {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.serialize(f)
+    }
+}
+
+// Supported Oses are on
+// https://rust-lang.github.io/rustup-components-history/aarch64-unknown-linux-gnu.html
+// where rust, rustc and cargo is available (e.g rustup toolchain add works)
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Os {
+    Android,
+    #[serde(alias = "macos")]
+    Darwin,
+    Freebsd,
+    Illumos,
+    Linux,
+    Netbsd,
+    Solaris,
+    Windows,
+    // Aix
+    // Dragonfly
+    // Ios
+    // Js
+    // Openbsd
+    // Plan9
+}
+
+impl Os {
+    pub fn from_target(target: &TargetTriple) -> Result<Self> {
+        let mut iter = target.triple().rsplit('-');
+        Ok(
+            match (
+                iter.next().ok_or_else(|| eyre::eyre!("malformed target"))?,
+                iter.next().ok_or_else(|| eyre::eyre!("malformed target"))?,
+            ) {
+                ("darwin", _) => Os::Darwin,
+                ("freebsd", _) => Os::Freebsd,
+                ("netbsd", _) => Os::Netbsd,
+                ("illumos", _) => Os::Illumos,
+                ("solaris", _) => Os::Solaris,
+                // android targets also set linux, so must occur first
+                ("android", _) => Os::Android,
+                (_, "linux") => Os::Linux,
+                (_, "windows") => Os::Windows,
+                (abi, system) => {
+                    eyre::bail!("unsupported os in target, abi: {abi:?}, system: {system:?} ")
+                }
+            },
+        )
+    }
+
+    pub fn new(s: &str) -> Result<Self> {
+        use serde::de::IntoDeserializer;
+
+        Self::deserialize(<&str as IntoDeserializer>::into_deserializer(s))
+            .wrap_err_with(|| format!("architecture {s} is not supported"))
+    }
+}
+
+impl std::fmt::Display for Os {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.serialize(f)
+    }
+}
+
+impl ImagePlatform {
+    pub fn from_target(target: TargetTriple) -> Result<Self> {
+        match target {
+            target @ TargetTriple::Other(_) => {
+                let os = Os::from_target(&target)
+                    .wrap_err("could not determine os in target triplet")?;
+                let architecture = Architecture::from_target(&target)
+                    .wrap_err("could not determine architecture in target triplet")?;
+                let variant = match target.triple() {
+                    // v7 is default for arm architecture, we still specify it for clarity
+                    armv7 if armv7.starts_with("armv7-") => Some("v7".to_owned()),
+                    arm if arm.starts_with("arm-") => Some("v6".to_owned()),
+                    _ => None,
+                };
+                Ok(ImagePlatform {
+                    architecture,
+                    os,
+                    variant,
+                    target,
+                })
+            }
+            target => Ok(Self::from_const_target(target)),
+        }
+    }
+    #[track_caller]
+    pub const fn from_const_target(target: TargetTriple) -> Self {
+        match target {
+            TargetTriple::Other(_) => {
+                unimplemented!()
+            }
+            TargetTriple::X86_64AppleDarwin => ImagePlatform {
+                architecture: Architecture::Amd64,
+                os: Os::Darwin,
+                variant: None,
+                target,
+            },
+            TargetTriple::Aarch64AppleDarwin => ImagePlatform {
+                architecture: Architecture::Arm64,
+                os: Os::Linux,
+                variant: None,
+                target,
+            },
+            TargetTriple::X86_64UnknownLinuxGnu => ImagePlatform {
+                architecture: Architecture::Amd64,
+                os: Os::Linux,
+                variant: None,
+                target,
+            },
+            TargetTriple::Aarch64UnknownLinuxGnu => ImagePlatform {
+                architecture: Architecture::Arm64,
+                os: Os::Linux,
+                variant: None,
+                target,
+            },
+            TargetTriple::X86_64UnknownLinuxMusl => ImagePlatform {
+                architecture: Architecture::Amd64,
+                os: Os::Linux,
+                variant: None,
+                target,
+            },
+            TargetTriple::Aarch64UnknownLinuxMusl => ImagePlatform {
+                architecture: Architecture::Arm,
+                os: Os::Linux,
+                variant: None,
+                target,
+            },
+            TargetTriple::X86_64PcWindowsMsvc => ImagePlatform {
+                architecture: Architecture::Amd64,
+                os: Os::Windows,
+                variant: None,
+                target,
+            },
+        }
+    }
+
+    pub fn specify_platform(&self, engine: &Engine, cmd: &mut std::process::Command) {
+        if self.variant.is_none()
+            && Some(&self.architecture) == engine.arch.as_ref()
+            && Some(&self.os) == engine.os.as_ref()
+        {
+        } else {
+            cmd.args(&["--platform", &self.docker_platform()]);
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    macro_rules! t {
+        ($t:literal) => {
+            TargetTriple::from($t)
+        };
+    }
+
+    macro_rules! arch {
+        ($t:literal) => {
+            Architecture::from_target(&TargetTriple::from($t))
+        };
+    }
+
+    #[test]
+    fn architecture_from_target() -> Result<()> {
+        assert_eq!(arch!("x86_64-apple-darwin")?, Architecture::Amd64);
+        assert_eq!(arch!("arm-unknown-linux-gnueabihf")?, Architecture::Arm);
+        assert_eq!(arch!("armv7-unknown-linux-gnueabihf")?, Architecture::Arm);
+        assert_eq!(arch!("aarch64-unknown-linux-gnu")?, Architecture::Arm64);
+        assert_eq!(arch!("mips-unknown-linux-gnu")?, Architecture::Mips);
+        assert_eq!(
+            arch!("mips64-unknown-linux-gnuabi64")?,
+            Architecture::Mips64
+        );
+        assert_eq!(
+            arch!("mips64le-unknown-linux-gnuabi64")?,
+            Architecture::Mips64Le
+        );
+        assert_eq!(arch!("mipsle-unknown-linux-gnu")?, Architecture::MipsLe);
+        Ok(())
+    }
+
+    #[test]
+    fn os_from_target() -> Result<()> {
+        assert_eq!(Os::from_target(&t!("x86_64-apple-darwin"))?, Os::Darwin);
+        assert_eq!(Os::from_target(&t!("x86_64-unknown-freebsd"))?, Os::Freebsd);
+        assert_eq!(Os::from_target(&t!("x86_64-unknown-netbsd"))?, Os::Netbsd);
+        assert_eq!(Os::from_target(&t!("sparcv9-sun-solaris"))?, Os::Solaris);
+        assert_eq!(Os::from_target(&t!("sparcv9-sun-illumos"))?, Os::Illumos);
+        assert_eq!(Os::from_target(&t!("aarch64-linux-android"))?, Os::Android);
+        assert_eq!(Os::from_target(&t!("x86_64-unknown-linux-gnu"))?, Os::Linux);
+        assert_eq!(Os::from_target(&t!("x86_64-pc-windows-msvc"))?, Os::Windows);
+        Ok(())
+    }
+}

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -1,16 +1,43 @@
 pub mod custom;
 mod engine;
+mod image;
 mod local;
+mod provided_images;
 pub mod remote;
 mod shared;
 
 pub use self::engine::*;
+pub use self::provided_images::PROVIDED_IMAGES;
 pub use self::shared::*;
+
+pub use image::{Architecture, Image, ImagePlatform, Os as ContainerOs, PossibleImage};
 
 use std::process::ExitStatus;
 
 use crate::errors::*;
 use crate::shell::MessageInfo;
+
+#[derive(Debug)]
+pub struct ProvidedImage {
+    /// The `name` of the image, usually the target triplet
+    pub name: &'static str,
+    pub platforms: &'static [ImagePlatform],
+    pub sub: Option<&'static str>,
+}
+
+impl ProvidedImage {
+    pub fn image_name(&self, repository: &str, tag: &str) -> String {
+        image_name(self.name, self.sub, repository, tag)
+    }
+}
+
+pub fn image_name(target: &str, sub: Option<&str>, repository: &str, tag: &str) -> String {
+    if let Some(sub) = sub {
+        format!("{repository}/{target}:{tag}-{sub}")
+    } else {
+        format!("{repository}/{target}:{tag}")
+    }
+}
 
 pub fn run(
     options: DockerOptions,

--- a/src/docker/provided_images.rs
+++ b/src/docker/provided_images.rs
@@ -1,0 +1,276 @@
+#![doc = "*** AUTO-GENERATED, do not touch. Run `cargo xtask codegen` to update ***"]
+use super::{ImagePlatform, ProvidedImage};
+
+#[rustfmt::skip]
+pub static PROVIDED_IMAGES: &[ProvidedImage] = &[
+        ProvidedImage {
+            name: "x86_64-unknown-linux-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "x86_64-unknown-linux-musl",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "x86_64-unknown-linux-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: Some("centos")
+        },
+        ProvidedImage {
+            name: "aarch64-unknown-linux-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "arm-unknown-linux-gnueabi",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "arm-unknown-linux-gnueabihf",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "armv7-unknown-linux-gnueabi",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "armv7-unknown-linux-gnueabihf",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "thumbv7neon-unknown-linux-gnueabihf",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "i586-unknown-linux-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "i686-unknown-linux-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "mips-unknown-linux-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "mipsel-unknown-linux-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "mips64-unknown-linux-gnuabi64",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "mips64el-unknown-linux-gnuabi64",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "mips64-unknown-linux-muslabi64",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "mips64el-unknown-linux-muslabi64",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "powerpc-unknown-linux-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "powerpc64-unknown-linux-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "powerpc64le-unknown-linux-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "riscv64gc-unknown-linux-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "s390x-unknown-linux-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "sparc64-unknown-linux-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "aarch64-unknown-linux-musl",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "arm-unknown-linux-musleabihf",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "arm-unknown-linux-musleabi",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "armv5te-unknown-linux-gnueabi",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "armv5te-unknown-linux-musleabi",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "armv7-unknown-linux-musleabi",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "armv7-unknown-linux-musleabihf",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "i586-unknown-linux-musl",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "i686-unknown-linux-musl",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "mips-unknown-linux-musl",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "mipsel-unknown-linux-musl",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "aarch64-linux-android",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "arm-linux-androideabi",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "armv7-linux-androideabi",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "thumbv7neon-linux-androideabi",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "i686-linux-android",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "x86_64-linux-android",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "x86_64-pc-windows-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "i686-pc-windows-gnu",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "wasm32-unknown-emscripten",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "x86_64-unknown-dragonfly",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "i686-unknown-freebsd",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "x86_64-unknown-freebsd",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "x86_64-unknown-netbsd",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "sparcv9-sun-solaris",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "x86_64-sun-solaris",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "x86_64-unknown-illumos",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "thumbv6m-none-eabi",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "thumbv7em-none-eabi",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "thumbv7em-none-eabihf",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+        ProvidedImage {
+            name: "thumbv7m-none-eabi",
+            platforms: &[ImagePlatform::DEFAULT],
+            sub: None
+        },
+];

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -612,7 +612,7 @@ pub(crate) fn docker_seccomp(
 ) -> Result<()> {
     // docker uses seccomp now on all installations
     if target.needs_docker_seccomp() {
-        let seccomp = if engine_type == EngineType::Docker && cfg!(target_os = "windows") {
+        let seccomp = if engine_type.is_docker() && cfg!(target_os = "windows") {
             // docker on windows fails due to a bug in reading the profile
             // https://github.com/docker/for-win/issues/12760
             "unconfined".to_owned()

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -5,13 +5,16 @@ use std::{env, fs};
 
 use super::custom::{Dockerfile, PreBuild};
 use super::engine::*;
+use super::image::PossibleImage;
+use super::Image;
+use super::PROVIDED_IMAGES;
 use crate::cargo::{cargo_metadata_with_args, CargoMetadata};
 use crate::config::{bool_from_envvar, Config};
 use crate::errors::*;
 use crate::extensions::{CommandExt, SafeCommand};
 use crate::file::{self, write_file, ToUtf8};
 use crate::id;
-use crate::rustc::{self, VersionMetaExt};
+use crate::rustc::QualifiedToolchain;
 use crate::shell::{MessageInfo, Verbosity};
 use crate::Target;
 
@@ -23,7 +26,6 @@ pub use super::custom::CROSS_CUSTOM_DOCKERFILE_IMAGE_PREFIX;
 pub const CROSS_IMAGE: &str = "ghcr.io/cross-rs";
 // note: this is the most common base image for our images
 pub const UBUNTU_BASE: &str = "ubuntu:16.04";
-const DOCKER_IMAGES: &[&str] = &include!(concat!(env!("OUT_DIR"), "/docker-images.rs"));
 
 // secured profile based off the docker documentation for denied syscalls:
 // https://docs.docker.com/engine/security/seccomp/#significant-syscalls-blocked-by-the-default-profile
@@ -36,15 +38,23 @@ pub struct DockerOptions {
     pub engine: Engine,
     pub target: Target,
     pub config: Config,
+    pub image: Image,
     pub uses_xargo: bool,
 }
 
 impl DockerOptions {
-    pub fn new(engine: Engine, target: Target, config: Config, uses_xargo: bool) -> DockerOptions {
+    pub fn new(
+        engine: Engine,
+        target: Target,
+        config: Config,
+        image: Image,
+        uses_xargo: bool,
+    ) -> DockerOptions {
         DockerOptions {
             engine,
             target,
             config,
+            image,
             uses_xargo,
         }
     }
@@ -77,19 +87,25 @@ impl DockerOptions {
         paths: &DockerPaths,
         msg_info: &mut MessageInfo,
     ) -> Result<String> {
-        let mut image = self.image_name()?;
+        let mut image = self.image.clone();
 
         if let Some(path) = self.config.dockerfile(&self.target)? {
             let context = self.config.dockerfile_context(&self.target)?;
-            let name = self.config.image(&self.target)?;
+
+            let is_custom_image = self.config.image(&self.target)?.is_some();
 
             let build = Dockerfile::File {
                 path: &path,
                 context: context.as_deref(),
-                name: name.as_deref(),
+                name: if is_custom_image {
+                    Some(&image.name)
+                } else {
+                    None
+                },
+                runs_with: &image.platform,
             };
 
-            image = build
+            image.name = build
                 .build(
                     self,
                     paths,
@@ -122,9 +138,10 @@ impl DockerOptions {
                 RUN chmod +x /pre-build-script
                 RUN ./pre-build-script $CROSS_TARGET"#
                         ),
+                        runs_with: &image.platform,
                     };
 
-                    image = custom
+                    image.name = custom
                         .build(
                             self,
                             paths,
@@ -152,8 +169,9 @@ impl DockerOptions {
                 ARG CROSS_CMD
                 RUN eval "${{CROSS_CMD}}""#
                             ),
+                            runs_with: &image.platform,
                         };
-                        image = custom
+                        image.name = custom
                             .build(
                                 self,
                                 paths,
@@ -166,11 +184,7 @@ impl DockerOptions {
                 }
             }
         }
-        Ok(image)
-    }
-
-    pub(crate) fn image_name(&self) -> Result<String> {
-        image_name(&self.config, &self.target)
+        Ok(image.name.clone())
     }
 }
 
@@ -179,7 +193,6 @@ pub struct DockerPaths {
     pub mount_finder: MountFinder,
     pub metadata: CargoMetadata,
     pub cwd: PathBuf,
-    pub sysroot: PathBuf,
     pub directories: Directories,
 }
 
@@ -188,17 +201,20 @@ impl DockerPaths {
         engine: &Engine,
         metadata: CargoMetadata,
         cwd: PathBuf,
-        sysroot: PathBuf,
+        toolchain: QualifiedToolchain,
     ) -> Result<Self> {
         let mount_finder = MountFinder::create(engine)?;
-        let directories = Directories::create(&mount_finder, &metadata, &cwd, &sysroot)?;
+        let directories = Directories::create(&mount_finder, &metadata, &cwd, toolchain)?;
         Ok(Self {
             mount_finder,
             metadata,
             cwd,
-            sysroot,
             directories,
         })
+    }
+
+    pub fn get_sysroot(&self) -> &Path {
+        self.directories.get_sysroot()
     }
 
     pub fn workspace_root(&self) -> &Path {
@@ -239,7 +255,7 @@ pub struct Directories {
     // both mount fields are WSL paths on windows: they already are POSIX paths
     pub mount_root: String,
     pub mount_cwd: String,
-    pub sysroot: PathBuf,
+    pub toolchain: QualifiedToolchain,
 }
 
 impl Directories {
@@ -247,7 +263,7 @@ impl Directories {
         mount_finder: &MountFinder,
         metadata: &CargoMetadata,
         cwd: &Path,
-        sysroot: &Path,
+        mut toolchain: QualifiedToolchain,
     ) -> Result<Self> {
         let home_dir =
             home::home_dir().ok_or_else(|| eyre::eyre!("could not find home directory"))?;
@@ -289,7 +305,8 @@ impl Directories {
             mount_root = host_root.to_utf8()?.to_owned();
         }
         let mount_cwd = mount_finder.find_path(cwd, false)?;
-        let sysroot = mount_finder.find_mount_path(sysroot);
+
+        toolchain.set_sysroot(|p| mount_finder.find_mount_path(p));
 
         Ok(Directories {
             cargo,
@@ -299,8 +316,12 @@ impl Directories {
             host_root,
             mount_root,
             mount_cwd,
-            sysroot,
+            toolchain,
         })
+    }
+
+    pub fn get_sysroot(&self) -> &Path {
+        self.toolchain.get_sysroot()
     }
 }
 
@@ -339,23 +360,16 @@ pub fn subcommand(engine: &Engine, cmd: &str) -> Command {
 
 pub fn get_package_info(
     engine: &Engine,
-    target: &str,
-    channel: Option<&str>,
+    toolchain: QualifiedToolchain,
     msg_info: &mut MessageInfo,
-) -> Result<(Target, CargoMetadata, Directories)> {
-    let target_list = msg_info.as_quiet(rustc::target_list)?;
-    let target = Target::from(target, &target_list);
+) -> Result<(CargoMetadata, Directories)> {
     let metadata = cargo_metadata_with_args(None, None, msg_info)?
         .ok_or(eyre::eyre!("unable to get project metadata"))?;
-    let cwd = std::env::current_dir()?;
-    let host_meta = rustc::version_meta()?;
-    let host = host_meta.host();
-
-    let sysroot = rustc::get_sysroot(&host, &target, channel, msg_info)?.1;
     let mount_finder = MountFinder::create(engine)?;
-    let dirs = Directories::create(&mount_finder, &metadata, &cwd, &sysroot)?;
+    let cwd = std::env::current_dir()?;
+    let dirs = Directories::create(&mount_finder, &metadata, &cwd, toolchain)?;
 
-    Ok((target, metadata, dirs))
+    Ok((metadata, dirs))
 }
 
 /// Register binfmt interpreters
@@ -626,12 +640,47 @@ pub(crate) fn docker_seccomp(
     Ok(())
 }
 
-pub(crate) fn image_name(config: &Config, target: &Target) -> Result<String> {
+/// Simpler version of [get_image]
+pub fn get_image_name(config: &Config, target: &Target) -> Result<String> {
+    if let Some(image) = config.image(target)? {
+        return Ok(image.name);
+    }
+
+    let compatible = PROVIDED_IMAGES
+        .iter()
+        .filter(|p| p.name == target.triple())
+        .collect::<Vec<_>>();
+
+    if compatible.is_empty() {
+        eyre::bail!(
+            "`cross` does not provide a Docker image for target {target}, \
+                   specify a custom image in `Cross.toml`."
+        );
+    }
+
+    let version = if include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt")).is_empty() {
+        env!("CARGO_PKG_VERSION")
+    } else {
+        "main"
+    };
+
+    Ok(compatible
+        .get(0)
+        .expect("should not be empty")
+        .image_name(CROSS_IMAGE, version))
+}
+
+pub(crate) fn get_image(config: &Config, target: &Target) -> Result<PossibleImage> {
     if let Some(image) = config.image(target)? {
         return Ok(image);
     }
 
-    if !DOCKER_IMAGES.contains(&target.triple()) {
+    let compatible = PROVIDED_IMAGES
+        .iter()
+        .filter(|p| p.name == target.triple())
+        .collect::<Vec<_>>();
+
+    if compatible.is_empty() {
         eyre::bail!(
             "`cross` does not provide a Docker image for target {target}, \
                specify a custom image in `Cross.toml`."
@@ -644,7 +693,47 @@ pub(crate) fn image_name(config: &Config, target: &Target) -> Result<String> {
         "main"
     };
 
-    Ok(format!("{CROSS_IMAGE}/{target}:{version}"))
+    let pick = if compatible.len() == 1 {
+        // If only one match, use that
+        compatible.get(0).expect("should not be empty")
+    } else if compatible
+        .iter()
+        .filter(|provided| provided.sub.is_none())
+        .count()
+        == 1
+    {
+        // if multiple matches, but only one is not a sub-target, pick that one
+        compatible
+            .iter()
+            .find(|provided| provided.sub.is_none())
+            .expect("should exists at least one non-sub image in list")
+    } else {
+        // if there's multiple targets and no option can be chosen, bail
+        return Err(eyre::eyre!(
+            "`cross` provides multiple images for target {target}, \
+               specify toolchain in `Cross.toml`."
+        )
+        .with_note(|| {
+            format!(
+                "candidates: {}",
+                compatible
+                    .iter()
+                    .map(|provided| format!("\"{}\"", provided.image_name(CROSS_IMAGE, version)))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        }));
+    };
+
+    let mut image: PossibleImage = pick.image_name(CROSS_IMAGE, version).into();
+
+    eyre::ensure!(
+        !pick.platforms.is_empty(),
+        "platforms for provided image `{image}` are not specified, this is a bug in cross"
+    );
+
+    image.toolchain = pick.platforms.to_vec();
+    Ok(image)
 }
 
 fn docker_read_mount_paths(engine: &Engine) -> Result<Vec<MountDetail>> {
@@ -930,11 +1019,17 @@ mod tests {
             Ok(path)
         }
 
-        fn get_sysroot() -> Result<PathBuf> {
-            Ok(home()?
+        fn get_toolchain() -> Result<QualifiedToolchain> {
+            let sysroot = home()?
                 .join(".rustup")
                 .join("toolchains")
-                .join("stable-x86_64-unknown-linux-gnu"))
+                .join("stable-x86_64-unknown-linux-gnu");
+            Ok(QualifiedToolchain::new(
+                "stable",
+                &None,
+                &crate::docker::ImagePlatform::X86_64_UNKNOWN_LINUX_GNU,
+                &sysroot,
+            ))
         }
 
         fn get_directories(
@@ -942,8 +1037,8 @@ mod tests {
             mount_finder: &MountFinder,
         ) -> Result<Directories> {
             let cwd = get_cwd()?;
-            let sysroot = get_sysroot()?;
-            Directories::create(mount_finder, metadata, &cwd, &sysroot)
+            let toolchain = get_toolchain()?;
+            Directories::create(mount_finder, metadata, &cwd, toolchain)
         }
 
         fn path_to_posix(path: &Path) -> Result<String> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,7 +8,7 @@ use std::{
 use once_cell::sync::OnceCell;
 use rustc_version::VersionMeta;
 
-use crate::ToUtf8;
+use crate::{docker::ImagePlatform, rustc::QualifiedToolchain, TargetTriple, ToUtf8};
 
 static WORKSPACE: OnceCell<PathBuf> = OnceCell::new();
 
@@ -81,7 +81,12 @@ release: {version}
             expected,
             warn_host_version_mismatch(
                 &host_meta,
-                "xxxx",
+                &QualifiedToolchain::new(
+                    "xxxx",
+                    &None,
+                    &ImagePlatform::from_const_target(TargetTriple::X86_64UnknownLinuxGnu),
+                    Path::new("/toolchains/xxxx-x86_64-unknown-linux-gnu"),
+                ),
                 &target_meta.0,
                 &target_meta.1,
                 &mut msg_info,

--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use crate::util::{cargo_metadata, gha_error, gha_output, gha_print};
 use clap::Args;
+use cross::docker::ImagePlatform;
 use cross::shell::MessageInfo;
 use cross::{docker, CommandExt, ToUtf8};
 
@@ -66,6 +67,9 @@ pub struct BuildDockerImage {
     /// Additional build arguments to pass to Docker.
     #[clap(long)]
     pub build_arg: Vec<String>,
+    // [os/arch[/variant]=]toolchain
+    #[clap(long, short = 'a', action = clap::builder::ArgAction::Append)]
+    pub platform: Vec<ImagePlatform>,
     /// Targets to build for
     #[clap()]
     pub targets: Vec<crate::ImageTarget>,
@@ -106,6 +110,7 @@ pub fn build_docker_image(
         no_fastfail,
         from_ci,
         build_arg,
+        platform,
         mut targets,
         ..
     }: BuildDockerImage,
@@ -154,14 +159,27 @@ pub fn build_docker_image(
         .map(|t| locate_dockerfile(t, &docker_root, &cross_toolchains_root))
         .collect::<cross::Result<Vec<_>>>()?;
 
+    let platforms = if platform.is_empty() {
+        vec![ImagePlatform::DEFAULT]
+    } else {
+        platform
+    };
+
     let mut results = vec![];
-    for (target, dockerfile) in &targets {
+    for (platform, (target, dockerfile)) in targets
+        .iter()
+        .flat_map(|t| platforms.iter().map(move |p| (p, t)))
+    {
         if gha && targets.len() > 1 {
             gha_print("::group::Build {target}");
+        } else {
+            msg_info.note(format_args!("Build {target} for {}", platform.target))?;
         }
         let mut docker_build = docker::command(engine);
         docker_build.args(&["buildx", "build"]);
         docker_build.current_dir(&docker_root);
+
+        docker_build.args(&["--platform", &platform.docker_platform()]);
 
         if push {
             docker_build.arg("--push");
@@ -226,7 +244,19 @@ pub fn build_docker_image(
 
         docker_build.args([
             "--label",
-            &format!("{}.for-cross-target={target}", cross::CROSS_LABEL_DOMAIN),
+            &format!(
+                "{}.for-cross-target={}",
+                cross::CROSS_LABEL_DOMAIN,
+                target.name
+            ),
+        ]);
+        docker_build.args([
+            "--label",
+            &format!(
+                "{}.runs-with={}",
+                cross::CROSS_LABEL_DOMAIN,
+                platform.target
+            ),
         ]);
 
         docker_build.args(&["-f", dockerfile]);

--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -183,7 +183,7 @@ pub fn build_docker_image(
 
         if push {
             docker_build.arg("--push");
-        } else if no_output {
+        } else if engine.kind.is_docker() && no_output {
             docker_build.args(&["--output", "type=tar,dest=/dev/null"]);
         } else {
             docker_build.arg("--load");

--- a/xtask/src/codegen.rs
+++ b/xtask/src/codegen.rs
@@ -1,0 +1,77 @@
+use clap::Args;
+use eyre::Context;
+use std::fmt::Write;
+
+use crate::util::{get_cargo_workspace, get_matrix};
+
+#[derive(Args, Debug)]
+pub struct Codegen {
+    /// Provide verbose diagnostic output.
+    #[clap(short, long)]
+    verbose: bool,
+}
+
+pub fn codegen(Codegen { .. }: Codegen) -> cross::Result<()> {
+    let path = get_cargo_workspace().join("src/docker/provided_images.rs");
+    std::fs::write(path, docker_images()).wrap_err("when writing src/docker/provided_images.rs")?;
+    Ok(())
+}
+
+pub fn docker_images() -> String {
+    let mut images = String::from(
+        r##"#![doc = "*** AUTO-GENERATED, do not touch. Run `cargo xtask codegen` to update ***"]
+use super::{ImagePlatform, ProvidedImage};
+
+#[rustfmt::skip]
+pub static PROVIDED_IMAGES: &[ProvidedImage] = &["##,
+    );
+
+    for image_target in get_matrix()
+        .iter()
+        .filter(|i| i.to_image_target().is_standard_target_image())
+    {
+        write!(
+            &mut images,
+            r#"
+        ProvidedImage {{
+            name: "{}",
+            platforms: &[{}],
+            sub: {}
+        }},"#,
+            image_target.target.clone(),
+            if let Some(platforms) = &image_target.platforms {
+                platforms
+                    .iter()
+                    .map(|p| {
+                        format!(
+                            "ImagePlatform::{}",
+                            p.replace('-', "_").to_ascii_uppercase()
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .as_slice()
+                    .join(", ")
+            } else {
+                "ImagePlatform::DEFAULT".to_string()
+            },
+            if let Some(sub) = &image_target.sub {
+                format!(r#"Some("{}")"#, sub)
+            } else {
+                "None".to_string()
+            }
+        )
+        .expect("writing to string should not fail")
+    }
+
+    images.push_str("\n];\n");
+    images
+}
+
+#[cfg(test)]
+#[test]
+pub fn ensure_correct_codegen() -> cross::Result<()> {
+    let provided_images = crate::util::get_cargo_workspace().join("src/docker/provided_images.rs");
+    let content = cross::file::read(provided_images)?;
+    assert_eq!(content.replace("\r\n", "\n"), docker_images());
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,6 +3,7 @@
 pub mod build_docker_image;
 pub mod changelog;
 pub mod ci;
+pub mod codegen;
 pub mod crosstool;
 pub mod hooks;
 pub mod install_git_hooks;
@@ -11,6 +12,7 @@ pub mod util;
 
 use ci::CiJob;
 use clap::{CommandFactory, Parser, Subcommand};
+use codegen::Codegen;
 use cross::docker;
 use cross::shell::{MessageInfo, Verbosity};
 use util::{cargo_metadata, ImageTarget};
@@ -61,6 +63,8 @@ enum Commands {
     /// Validate changelog entries.
     #[clap(hide = true)]
     ValidateChangelog(ValidateChangelog),
+    /// Code generation
+    Codegen(Codegen),
 }
 
 fn is_toolchain(toolchain: &str) -> cross::Result<String> {
@@ -126,6 +130,7 @@ pub fn main() -> cross::Result<()> {
             let mut msg_info = get_msg_info!(args, args.verbose)?;
             changelog::validate_changelog(args, &mut msg_info)?;
         }
+        Commands::Codegen(args) => codegen::codegen(args)?,
     }
 
     Ok(())

--- a/xtask/src/target_info.rs
+++ b/xtask/src/target_info.rs
@@ -51,7 +51,7 @@ fn image_info(
     let mut command = docker::command(engine);
     command.arg("run");
     command.arg("--rm");
-    command.args(&["-e", &format!("TARGET={}", target.triplet)]);
+    command.args(&["-e", &format!("TARGET={}", target.name)]);
     if msg_info.is_verbose() {
         command.args(&["-e", "VERBOSE=1"]);
     }


### PR DESCRIPTION
Makes the following work

```toml
# Cross.toml
[build]
default-target = "x86_64-unknown-linux-musl"

[target."x86_64-unknown-linux-musl"]
image.name = "alpine:edge"
image.toolchain = ["x86_64-unknown-linux-musl"]
pre-build = ["apk add --no-cache gcc musl-dev"]
```


```rust
// src/main.rs
fn main() {
    println!("Hello, world!");
}
```

```
> cross run
[..snip]
    Finished dev [unoptimized + debuginfo] target(s) in 0.24s
     Running `/target/x86_64-unknown-linux-musl/debug/cross-minimal`
Hello, world!
```

and also 

```toml
[target.x86_64-unknown-linux-gnu]
pre-build = [
    "apt-get update && apt-get install -y libc6 g++-x86-64-linux-gnu libc6-dev-amd64-cross",
]

[target.x86_64-unknown-linux-gnu.env]
passthrough = [
    "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc",
    "CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc",
    "CXX_x86_64_unknown_linux_gnu=x86_64-linux-gnu-g++",
]

[target.x86_64-unknown-linux-gnu.image]
name = "ubuntu:20.04"
toolchain = ["aarch64-unknown-linux-gnu"]
```


```
cross build --target x86_64-unknown-linux-gnu -v
+ cargo metadata --format-version 1 --filter-platform x86_64-unknown-linux-gnu
+ rustc --print sysroot
+ /usr/local/bin/docker
+ /usr/local/bin/docker version '-f "{{ .Server.Os }},{{ .Server.Arch }}"'
+ rustup --verbose toolchain list
+ rustup --verbose target list --toolchain stable-aarch64-unknown-linux-gnu
+ rustup --verbose component list --toolchain stable-aarch64-unknown-linux-gnu
+ "/Users/emil/workspace/cross-tests/basic" /usr/local/bin/docker build --platform linux/arm64 --label 'org.cross-rs.for-cross-target=x86_64-unknown-linux-gnu' --label 'org.cross-rs.runs-with=aarch64-unknown-linux-gnu' --label 'org.cross-rs.workspace_root=/Users/emil/workspace/cross-tests/basic' --tag cross-custom-basic:x86_64-unknown-linux-gnu-50dfa-pre-build --build-arg 'CROSS_CMD=apt-get update && apt-get install -y libc6 g++-x86-64-linux-gnu libc6-dev-amd64-cross' --build-arg 'CROSS_DEB_ARCH=amd64' --file /Users/emil/workspace/cross-tests/basic/target/x86_64-unknown-linux-gnu/Dockerfile.x86_64-unknown-linux-gnu-custom .
[+] Building 10.0s (6/6) FINISHED                                                                               
 => [internal] load build definition from Dockerfile.x86_64-unknown-linux-gnu-custom                       0.0s
 => => transferring dockerfile: 166B                                                                       0.0s
 => [internal] load .dockerignore                                                                          0.0s
 => => transferring context: 2B                                                                            0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                            0.6s
 => CACHED [1/2] FROM docker.io/library/ubuntu:20.04@sha256:fd92c36d3cb9b1d027c4d2a72c6bf0125da82425fc2ca  0.0s
 => [2/2] RUN eval "apt-get update && apt-get install -y libc6 g++-x86-64-linux-gnu libc6-dev-amd64-cross  8.8s
 => exporting to image                                                                                     0.5s 
 => => exporting layers                                                                                    0.5s 
 => => writing image sha256:92f3cf51cc16c7b176c9bc09ce28ef83c029881e9c5017589eb8372bf6fff8d3               0.0s 
 => => naming to docker.io/library/cross-custom-basic:x86_64-unknown-linux-gnu-50dfa-pre-build             0.0s 
+ /usr/local/bin/docker run --userns host --platform linux/arm64 -e 'CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc' -e 'CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc' -e 'CXX_x86_64_unknown_linux_gnu=x86_64-linux-gnu-g++' -e 'PKG_CONFIG_ALLOW_CROSS=1' -e 'XARGO_HOME=/xargo' -e 'CARGO_HOME=/cargo' -e 'CARGO_TARGET_DIR=/target' -e 'CROSS_RUNNER=' -e TERM -e 'USER=emil' --rm --user 501:20 -v /Users/emil/.xargo:/xargo:Z -v /Users/emil/.cargo:/cargo:Z -v /cargo/bin -v /Users/emil/workspace/cross-tests/basic:/project:Z -v /Users/emil/.rustup/toolchains/stable-aarch64-unknown-linux-gnu:/rust:Z,ro -v /Users/emil/workspace/cross-tests/basic/target:/target:Z -w /project -i -t cross-custom-basic:x86_64-unknown-linux-gnu-50dfa-pre-build sh -c 'PATH=$PATH:/rust/bin cargo build --target x86_64-unknown-linux-gnu -v'
       Fresh basic v0.1.0 (/project)
    Finished dev [unoptimized + debuginfo] target(s) in 0.47s

basic on master [?] is 📦 v0.1.0 via 🦀 v1.61.0 took 12s 
❯ file target/x86_64-unknown-linux-gnu/debug/basic
target/x86_64-unknown-linux-gnu/debug/basic: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=5716ca6c6514e255e9a29eeeeac3d9cb4fb43c0a, for GNU/Linux 3.2.0, with debug_info, not stripped

basic on master [?] is 📦 v0.1.0 via 🦀 v1.61.0 
❯ uname -a
Darwin Emils-MacBook-Pro.local 21.5.0 Darwin Kernel Version 21.5.0: Tue Apr 26 21:08:37 PDT 2022; root:xnu-8020.121.3~4/RELEASE_ARM64_T6000 arm64
```

also makes `cross +nightly-2022-01-01` possible.

this is a requirement for #751 