### PR TITLE
Minor bug fixes for target-info.

### DIFF
--- a/xtask/src/target_info.rs
+++ b/xtask/src/target_info.rs
@@ -75,6 +75,8 @@ fn image_info(
     command.args(&["-e", &format!("TARGET={}", target.triplet)]);
     if has_test {
         command.args(&["-e", "HAS_TEST=1"]);
+    } else {
+        command.args(&["-e", "HAS_TEST="]);
     }
     command.arg(image);
     command.args(&["bash", "-c", TARGET_INFO_SCRIPT]);


### PR DESCRIPTION
These manifest in the `increment_versions` branch, but are more general since they could theoretically happen with version upgrades on the current images.