### PR TITLE
Minor xtask restructuring.

### DIFF
--- a/xtask/src/target_info.rs
+++ b/xtask/src/target_info.rs
@@ -4,6 +4,7 @@ use std::{
     process::{Command, Stdio},
 };
 
+use crate::util::{format_repo, pull_image};
 use clap::Args;
 use cross::CommandExt;
 
@@ -32,30 +33,6 @@ pub struct TargetInfo {
     pub engine: Option<String>,
 }
 
-fn format_repo(registry: &str, repository: &str) -> String {
-    let mut output = String::new();
-    if !repository.is_empty() {
-        output = repository.to_string();
-    }
-    if !registry.is_empty() {
-        output = format!("{registry}/{output}");
-    }
-
-    output
-}
-
-fn pull_image(engine: &Path, image: &str, verbose: bool) -> cross::Result<()> {
-    let mut command = Command::new(engine);
-    command.arg("pull");
-    command.arg(image);
-    if !verbose {
-        // capture output to avoid polluting table
-        command.stdout(Stdio::null());
-        command.stderr(Stdio::null());
-    }
-    command.run(verbose, false).map_err(Into::into)
-}
-
 fn image_info(
     engine: &Path,
     target: &crate::ImageTarget,
@@ -70,7 +47,6 @@ fn image_info(
 
     let mut command = Command::new(engine);
     command.arg("run");
-    command.arg("-it");
     command.arg("--rm");
     command.args(&["-e", &format!("TARGET={}", target.triplet)]);
     if has_test {

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -1,3 +1,7 @@
+use std::path::Path;
+use std::process::Command;
+
+use cross::CommandExt;
 use once_cell::sync::OnceCell;
 use serde::Deserialize;
 
@@ -66,6 +70,27 @@ pub fn get_matrix() -> &'static Vec<Matrix> {
             serde_yaml::from_str(matrix).map_err(Into::into)
         })
         .unwrap()
+}
+
+pub fn format_repo(registry: &str, repository: &str) -> String {
+    let mut output = String::new();
+    if !repository.is_empty() {
+        output = repository.to_string();
+    }
+    if !registry.is_empty() {
+        output = format!("{registry}/{output}");
+    }
+
+    output
+}
+
+pub fn pull_image(engine: &Path, image: &str, verbose: bool) -> cross::Result<()> {
+    let mut command = Command::new(engine);
+    command.arg("pull");
+    command.arg(image);
+    let out = command.run_and_get_output(verbose)?;
+    command.status_result(verbose, out.status, Some(&out))?;
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Remove the `-it` flag from `target-info`, which can the command to not complete. Also changes `pull_image` to use `run_and_get_output` rather than `run`, which is how we should capture the output. Finally, it moves `format_repo` and `pull_image` to `util`, so they can be used by other commands.

This applies a few of the changes mentioned in #822.