### PR TITLE
Avoid using display on paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Internal
 
+- #828 - assume paths are Unicode and provide better error messages for path encoding errors.
 - #787 - add installer for git hooks.
 - #786, #791 - Migrate build script to rust: `cargo build-docker-image $TARGET`
 - #730 - make FreeBSD builds more resilient.

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    { path = "std::path::Path::display", reason = "incorrect handling of non-Unicode paths, use path.to_utf8() or debug (`{path:?}`) instead" },
+]

--- a/src/docker/custom.rs
+++ b/src/docker/custom.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::docker::Engine;
 use crate::{config::Config, docker, CargoMetadata, Target};
-use crate::{errors::*, file, CommandExt};
+use crate::{errors::*, file, CommandExt, ToUtf8};
 
 use super::{image_name, parse_docker_opts};
 
@@ -47,7 +47,7 @@ impl<'a> Dockerfile<'a> {
             &format!(
                 "{}.workspace_root={}",
                 crate::CROSS_LABEL_DOMAIN,
-                metadata.workspace_root.display()
+                metadata.workspace_root.to_utf8()?
             ),
         ]);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ use self::rustc::{TargetList, VersionMetaExt};
 
 pub use self::errors::{install_panic_hook, Result};
 pub use self::extensions::{CommandExt, OutputExt};
+pub use self::file::ToUtf8;
 
 pub const CROSS_LABEL_DOMAIN: &str = "org.cross-rs";
 
@@ -590,11 +591,11 @@ fn toml(metadata: &CargoMetadata) -> Result<Option<CrossToml>> {
     };
 
     if path.exists() {
-        let content = file::read(&path)
-            .wrap_err_with(|| format!("could not read file `{}`", path.display()))?;
+        let content =
+            file::read(&path).wrap_err_with(|| format!("could not read file `{path:?}`"))?;
 
         let (config, _) = CrossToml::parse(&content)
-            .wrap_err_with(|| format!("failed to parse file `{}` as TOML", path.display()))?;
+            .wrap_err_with(|| format!("failed to parse file `{path:?}` as TOML"))?;
 
         Ok(Some(config))
     } else {

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -126,8 +126,8 @@ fn rustc_channel(version: &Version) -> Result<Channel> {
 pub fn rustc_version(toolchain_path: &Path) -> Result<Option<(Version, Channel, String)>> {
     let path = toolchain_path.join("lib/rustlib/multirust-channel-manifest.toml");
     if path.exists() {
-        let contents = std::fs::read(&path)
-            .wrap_err_with(|| format!("couldn't open file `{}`", path.display()))?;
+        let contents =
+            std::fs::read(&path).wrap_err_with(|| format!("couldn't open file `{path:?}`"))?;
         let manifest: toml::value::Table = toml::from_slice(&contents)?;
         if let Some(rust_version) = manifest
             .get("pkg")
@@ -137,9 +137,8 @@ pub fn rustc_version(toolchain_path: &Path) -> Result<Option<(Version, Channel, 
         {
             // Field is `"{version} ({commit} {date})"`
             if let Some((version, meta)) = rust_version.split_once(' ') {
-                let version = Version::parse(version).wrap_err_with(|| {
-                    format!("invalid rust version found in {}", path.display())
-                })?;
+                let version = Version::parse(version)
+                    .wrap_err_with(|| format!("invalid rust version found in {path:?}"))?;
                 let channel = rustc_channel(&version)?;
                 return Ok(Some((version, channel, meta.to_owned())));
             }

--- a/src/tests/toml.rs
+++ b/src/tests/toml.rs
@@ -30,15 +30,15 @@ fn toml_check() -> Result<(), Box<dyn std::error::Error>> {
         if dir_entry.file_type().is_dir() {
             continue;
         }
-        eprintln!("File: {:?}", dir_entry.path().display());
+        eprintln!("File: {:?}", dir_entry.path());
         let mut file = std::fs::File::open(dir_entry.path()).unwrap();
         let mut contents = String::new();
         file.read_to_string(&mut contents).unwrap();
         for matches in TOML_REGEX.captures_iter(&contents) {
             let fence = matches.get(1).unwrap();
             eprintln!(
-                "testing snippet at: {}:{:?}",
-                dir_entry.path().display(),
+                "testing snippet at: {:?}:{:?}",
+                dir_entry.path(),
                 text_line_no(&contents, fence.range().start),
             );
             assert!(crate::cross_toml::CrossToml::parse(fence.as_str())?

--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -2,7 +2,7 @@ use std::{path::Path, process::Command};
 
 use clap::Args;
 use color_eyre::Section;
-use cross::CommandExt;
+use cross::{CommandExt, ToUtf8};
 use std::fmt::Write;
 
 #[derive(Args, Debug)]
@@ -72,7 +72,7 @@ fn locate_dockerfile(
     } else {
         eyre::bail!("unable to find dockerfile for target \"{target}\"");
     };
-    let dockerfile = dockerfile_root.join(dockerfile_name).display().to_string();
+    let dockerfile = dockerfile_root.join(dockerfile_name).to_utf8()?.to_string();
     Ok((target, dockerfile))
 }
 


### PR DESCRIPTION
Adds a helper trait `ToUtf8` which converts the path to UTF-8 if possible, and if not, creates a pretty debugging representation of the path. We can then change `display()` to `to_utf8()?` and be completely correct in all cases.

On POSIX systems, this doesn't matter since paths must be UTF-8 anyway, but on Windows some paths can be WTF-8 (see rust-lang/rust#12056). Either way, this can avoid creating a copy in cases, is always correct, and is more idiomatic about what we're doing. We might not be able to handle non-UTF-8 paths currently (like ISO-8859-1 paths, which are historically very common).

So, this doesn't change ergonomics: the resulting code is as compact and correct. It also requires less copies in most cases, which should be a good thing. But most importantly, if we're mounting data we can't silently fail or produce incorrect data. If something was lossily generated, we probably shouldn't try to mount with a replacement character, and also print more information than there was just an invalid Unicode character.