### PR TITLE
Fixes regression in #828 with absolute path.

### DIFF
--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -242,7 +242,7 @@ pub(crate) fn docker_cwd(
     } else {
         // We do this to avoid clashes with path separators. Windows uses `\` as a path separator on Path::join
         let cwd = &cwd;
-        let working_dir = Path::new("project").join(cwd.strip_prefix(&metadata.workspace_root)?);
+        let working_dir = Path::new("/project").join(cwd.strip_prefix(&metadata.workspace_root)?);
         docker.args(&["-w", &working_dir.as_posix()?]);
     }
 


### PR DESCRIPTION
Prior to #828, we added a '/' separator before component in our makeshift `as_posix`, so the path would always become absolute, even though the actual path was relative. `as_posix` therefore handled this as a relative path, so using `project` and not `/project` as the working directory for the cross command caused commands to fail.