### PR TITLE
Add a cache dir tag when creating a target directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- #836 - write a `CACHEDIR.TAG` when creating the target directory, similar to `cargo`.
 - #804 - allow usage of env `CARGO_BUILD_TARGET` as an alias for `CROSS_BUILD_TARGET`
 - #792 - fixed container-in-container support when using podman.
 - #781 - ensure `target.$(...)` config options override `build` ones.


### PR DESCRIPTION
Ensure `cross` is similar in functionality to `cargo`, and this minimizes network traffic by applications that may copy the project but do not wish to copy compiled code.

Closes #835.