### PR TITLE
Update external toolchains to support MSVC and Apple targets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ terminate.
 due to a [compiler bug](https://github.com/rust-lang/rust/issues/85821), you will have to build them yourself for now.-->
 
 Additional Dockerfiles for other targets can be found in [cross-toolchains](https://github.com/cross-rs/cross-toolchains).
+These include MSVC targets, which for legal reasons we cannot ship pre-built images of.
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ terminate.
 due to a [compiler bug](https://github.com/rust-lang/rust/issues/85821), you will have to build them yourself for now.-->
 
 Additional Dockerfiles for other targets can be found in [cross-toolchains](https://github.com/cross-rs/cross-toolchains).
-These include MSVC targets, which for legal reasons we cannot ship pre-built images of.
+These include MSVC and Apple Darwin targets, which we cannot ship pre-built images of.
 
 ## Debugging
 


### PR DESCRIPTION
Adds support for building custom MSVC and Apple Darwin targets, and references these images in the README.