### PR TITLE
Remove WSLpath and implement WSL-style path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Internal
 
+- #856 - remove use of external wslpath and create internal helper that properly handles UNC paths.
 - #828 - assume paths are Unicode and provide better error messages for path encoding errors.
 - #787 - add installer for git hooks.
 - #786, #791 - Migrate build script to rust: `cargo build-docker-image $TARGET`

--- a/src/docker/local.rs
+++ b/src/docker/local.rs
@@ -39,8 +39,7 @@ pub(crate) fn run(
         config,
         target,
         cwd,
-        verbose,
-        |docker, val, verbose| mount(docker, val, "", verbose),
+        |docker, val| mount(docker, val, ""),
         |_| {},
     )?;
 
@@ -57,11 +56,7 @@ pub(crate) fn run(
     if mount_volumes {
         docker.args(&[
             "-v",
-            &format!(
-                "{}:{}:Z",
-                dirs.host_root.to_utf8()?,
-                dirs.mount_root.to_utf8()?
-            ),
+            &format!("{}:{}:Z", dirs.host_root.to_utf8()?, dirs.mount_root),
         ]);
     } else {
         docker.args(&["-v", &format!("{}:/project:Z", dirs.host_root.to_utf8()?)]);


### PR DESCRIPTION
Removes the dependency on WSL2, and properly handles DOS-style paths, UNC paths, including those on localhost, even if Docker itself does not support them.

Closes #854.
Related to #665.
Supersedes #852.