### PR TITLE
Add cargo-style output diagnostics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - #869 - ensure cargo configuration environment variable flags are passed to the docker container.
+- #859 - added color diagnostic output and error messages.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "libc",
  "nix",
  "once_cell",
+ "owo-colors",
  "regex",
  "rustc_version",
  "serde",
@@ -313,6 +314,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +395,9 @@ name = "owo-colors"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
+dependencies = [
+ "supports-color",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -597,6 +607,16 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "supports-color"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872ced36b91d47bae8a214a683fe54e7078875b399dfa251df346c9b547d1f9"
+dependencies = [
+ "atty",
+ "is_ci",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ ctrlc = { version = "3.2.2", features = ["termination"] }
 directories = "4.0.1"
 walkdir = { version = "2", optional = true }
 tempfile = "3.3.0"
+owo-colors = { version = "3.4.0", features = ["supports-colors"] }
 
 [target.'cfg(not(windows))'.dependencies]
 nix = { version = "0.24", default-features = false, features = ["user"] }

--- a/deny.toml
+++ b/deny.toml
@@ -24,11 +24,22 @@ unknown-git = "deny"
 allow-git = []
 
 [licenses]
+# need this since to suppress errors in case we add crates with these allowed licenses
+unused-allowed-license = "allow"
 unlicensed = "deny"
 allow-osi-fsf-free = "neither"
 copyleft = "deny"
 confidence-threshold = 0.93
-allow = ["Apache-2.0", "MIT", "CC0-1.0"]
+allow = [
+  "Apache-2.0",
+  "MIT",
+  "CC0-1.0",
+  "ISC",
+  "0BSD",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "Unlicense"
+]
 
 [licenses.private]
 ignore = true

--- a/src/bin/cross-util.rs
+++ b/src/bin/cross-util.rs
@@ -2,6 +2,7 @@
 
 use clap::{CommandFactory, Parser, Subcommand};
 use cross::docker;
+use cross::shell::MessageInfo;
 
 mod commands;
 
@@ -46,13 +47,16 @@ fn is_toolchain(toolchain: &str) -> cross::Result<String> {
     }
 }
 
-fn get_container_engine(engine: Option<&str>, verbose: bool) -> cross::Result<docker::Engine> {
+fn get_container_engine(
+    engine: Option<&str>,
+    msg_info: MessageInfo,
+) -> cross::Result<docker::Engine> {
     let engine = if let Some(ce) = engine {
         which::which(ce)?
     } else {
         docker::get_container_engine()?
     };
-    docker::Engine::from_path(engine, None, verbose)
+    docker::Engine::from_path(engine, None, msg_info)
 }
 
 pub fn main() -> cross::Result<()> {
@@ -60,19 +64,23 @@ pub fn main() -> cross::Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Commands::Images(args) => {
-            let engine = get_container_engine(args.engine(), args.verbose())?;
+            let msg_info = MessageInfo::create(args.verbose(), args.quiet(), args.color())?;
+            let engine = get_container_engine(args.engine(), msg_info)?;
             args.run(engine)?;
         }
         Commands::Volumes(args) => {
-            let engine = get_container_engine(args.engine(), args.verbose())?;
+            let msg_info = MessageInfo::create(args.verbose(), args.quiet(), args.color())?;
+            let engine = get_container_engine(args.engine(), msg_info)?;
             args.run(engine, cli.toolchain.as_deref())?;
         }
         Commands::Containers(args) => {
-            let engine = get_container_engine(args.engine(), args.verbose())?;
+            let msg_info = MessageInfo::create(args.verbose(), args.quiet(), args.color())?;
+            let engine = get_container_engine(args.engine(), msg_info)?;
             args.run(engine)?;
         }
         Commands::Clean(args) => {
-            let engine = get_container_engine(args.engine.as_deref(), args.verbose)?;
+            let msg_info = MessageInfo::create(args.verbose, args.quiet, args.color.as_deref())?;
+            let engine = get_container_engine(args.engine.as_deref(), msg_info)?;
             args.run(engine)?;
         }
     }

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -5,6 +5,7 @@ use std::process::{Command, ExitStatus};
 use crate::cli::Args;
 use crate::errors::*;
 use crate::extensions::CommandExt;
+use crate::shell::MessageInfo;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Subcommand {
@@ -119,7 +120,7 @@ pub fn cargo_command() -> Command {
 pub fn cargo_metadata_with_args(
     cd: Option<&Path>,
     args: Option<&Args>,
-    verbose: bool,
+    msg_info: MessageInfo,
 ) -> Result<Option<CargoMetadata>> {
     let mut command = cargo_command();
     command.arg("metadata").args(&["--format-version", "1"]);
@@ -139,7 +140,7 @@ pub fn cargo_metadata_with_args(
     if let Some(features) = args.map(|a| &a.features).filter(|v| !v.is_empty()) {
         command.args([String::from("--features"), features.join(",")]);
     }
-    let output = command.run_and_get_output(verbose)?;
+    let output = command.run_and_get_output(msg_info)?;
     if !output.status.success() {
         // TODO: logging
         return Ok(None);
@@ -158,13 +159,13 @@ pub fn cargo_metadata_with_args(
 }
 
 /// Pass-through mode
-pub fn run(args: &[String], verbose: bool) -> Result<ExitStatus, CommandError> {
+pub fn run(args: &[String], msg_info: MessageInfo) -> Result<ExitStatus> {
     cargo_command()
         .args(args)
-        .run_and_get_status(verbose, false)
+        .run_and_get_status(msg_info, false)
 }
 
 /// run cargo and get the output, does not check the exit status
-pub fn run_and_get_output(args: &[String], verbose: bool) -> Result<std::process::Output> {
-    cargo_command().args(args).run_and_get_output(verbose)
+pub fn run_and_get_output(args: &[String], msg_info: MessageInfo) -> Result<std::process::Output> {
+    cargo_command().args(args).run_and_get_output(msg_info)
 }

--- a/src/docker/custom.rs
+++ b/src/docker/custom.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use crate::docker::Engine;
+use crate::shell::MessageInfo;
 use crate::{config::Config, docker, CargoMetadata, Target};
 use crate::{errors::*, file, CommandExt, ToUtf8};
 
@@ -31,7 +32,7 @@ impl<'a> Dockerfile<'a> {
         host_root: &Path,
         build_args: impl IntoIterator<Item = (impl AsRef<str>, impl AsRef<str>)>,
         target_triple: &Target,
-        verbose: bool,
+        msg_info: MessageInfo,
     ) -> Result<String> {
         let mut docker_build = docker::subcommand(engine, "build");
         docker_build.current_dir(host_root);
@@ -100,7 +101,7 @@ impl<'a> Dockerfile<'a> {
             docker_build.arg(".");
         }
 
-        docker_build.run(verbose, true)?;
+        docker_build.run(msg_info, true)?;
         Ok(image_name)
     }
 

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -12,6 +12,7 @@ use std::process::ExitStatus;
 
 use crate::cargo::CargoMetadata;
 use crate::errors::*;
+use crate::shell::MessageInfo;
 use crate::{Config, Target};
 
 #[allow(clippy::too_many_arguments)] // TODO: refactor
@@ -23,7 +24,7 @@ pub fn run(
     config: &Config,
     uses_xargo: bool,
     sysroot: &Path,
-    verbose: bool,
+    msg_info: MessageInfo,
     docker_in_docker: bool,
     cwd: &Path,
 ) -> Result<ExitStatus> {
@@ -36,7 +37,7 @@ pub fn run(
             config,
             uses_xargo,
             sysroot,
-            verbose,
+            msg_info,
             docker_in_docker,
             cwd,
         )
@@ -49,7 +50,7 @@ pub fn run(
             config,
             uses_xargo,
             sysroot,
-            verbose,
+            msg_info,
             docker_in_docker,
             cwd,
         )

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -5,6 +5,7 @@ use rustc_version::{Version, VersionMeta};
 
 use crate::errors::*;
 use crate::extensions::{env_program, CommandExt};
+use crate::shell::MessageInfo;
 use crate::{Host, Target};
 
 #[derive(Debug)]
@@ -80,19 +81,19 @@ pub fn rustc_command() -> Command {
     Command::new(env_program("RUSTC", "rustc"))
 }
 
-pub fn target_list(verbose: bool) -> Result<TargetList> {
+pub fn target_list(msg_info: MessageInfo) -> Result<TargetList> {
     rustc_command()
         .args(&["--print", "target-list"])
-        .run_and_get_stdout(verbose)
+        .run_and_get_stdout(msg_info)
         .map(|s| TargetList {
             triples: s.lines().map(|l| l.to_owned()).collect(),
         })
 }
 
-pub fn sysroot(host: &Host, target: &Target, verbose: bool) -> Result<PathBuf> {
+pub fn sysroot(host: &Host, target: &Target, msg_info: MessageInfo) -> Result<PathBuf> {
     let mut stdout = rustc_command()
         .args(&["--print", "sysroot"])
-        .run_and_get_stdout(verbose)?
+        .run_and_get_stdout(msg_info)?
         .trim()
         .to_owned();
 
@@ -108,9 +109,9 @@ pub fn get_sysroot(
     host: &Host,
     target: &Target,
     channel: Option<&str>,
-    verbose: bool,
+    msg_info: MessageInfo,
 ) -> Result<(String, PathBuf)> {
-    let mut sysroot = sysroot(host, target, verbose)?;
+    let mut sysroot = sysroot(host, target, msg_info)?;
     let default_toolchain = sysroot
         .file_name()
         .and_then(|file_name| file_name.to_str())

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,0 +1,310 @@
+// This file was adapted from:
+//   https://github.com/rust-lang/cargo/blob/ca4edabb28fc96fdf2a1d56fe3851831ac166f8a/src/cargo/core/shell.rs
+
+use std::fmt;
+use std::io::{self, Write};
+
+use crate::errors::Result;
+use owo_colors::{self, OwoColorize};
+
+/// the requested verbosity of output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verbosity {
+    Quiet,
+    Normal,
+    Verbose,
+}
+
+impl Verbosity {
+    pub fn verbose(self) -> bool {
+        match self {
+            Self::Verbose => true,
+            Self::Normal | Self::Quiet => false,
+        }
+    }
+}
+
+/// Whether messages should use color output
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorChoice {
+    /// force color output
+    Always,
+    /// force disable color output
+    Never,
+    /// intelligently guess whether to use color output
+    Auto,
+}
+
+// Should simplify the APIs a lot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MessageInfo {
+    pub color_choice: ColorChoice,
+    pub verbosity: Verbosity,
+}
+
+impl MessageInfo {
+    pub fn create(verbose: bool, quiet: bool, color: Option<&str>) -> Result<MessageInfo> {
+        let color_choice = get_color_choice(color)?;
+        let verbosity = get_verbosity(color_choice, verbose, quiet)?;
+
+        Ok(MessageInfo {
+            color_choice,
+            verbosity,
+        })
+    }
+
+    pub fn verbose(self) -> bool {
+        self.verbosity.verbose()
+    }
+}
+
+impl Default for MessageInfo {
+    fn default() -> MessageInfo {
+        MessageInfo {
+            color_choice: ColorChoice::Auto,
+            verbosity: Verbosity::Normal,
+        }
+    }
+}
+
+impl From<ColorChoice> for MessageInfo {
+    fn from(color_choice: ColorChoice) -> MessageInfo {
+        MessageInfo {
+            color_choice,
+            verbosity: Verbosity::Normal,
+        }
+    }
+}
+
+impl From<Verbosity> for MessageInfo {
+    fn from(verbosity: Verbosity) -> MessageInfo {
+        MessageInfo {
+            color_choice: ColorChoice::Auto,
+            verbosity,
+        }
+    }
+}
+
+impl From<(ColorChoice, Verbosity)> for MessageInfo {
+    fn from(info: (ColorChoice, Verbosity)) -> MessageInfo {
+        MessageInfo {
+            color_choice: info.0,
+            verbosity: info.1,
+        }
+    }
+}
+
+// get the prefix for stderr messages
+macro_rules! cross_prefix {
+    ($s:literal) => {
+        concat!("[cross]", " ", $s)
+    };
+}
+
+// generate the color style
+macro_rules! write_style {
+    ($stream:ident, $msg_info:expr, $message:expr $(, $style:ident)* $(,)?) => {{
+        match $msg_info.color_choice {
+            ColorChoice::Always => write!($stream, "{}", $message $(.$style())*),
+            ColorChoice::Never => write!($stream, "{}", $message),
+            ColorChoice::Auto => write!(
+                $stream,
+                "{}",
+                $message $(.if_supports_color($stream.owo(), |text| text.$style()))*
+            ),
+        }?;
+    }};
+}
+
+// low-level interface for printing colorized messages
+macro_rules! message {
+    // write a status message, which has the following format:
+    //  "{status}: {message}"
+    // both status and ':' are bold.
+    (@status $stream:ident, $status:expr, $message:expr, $color:ident, $msg_info:expr $(,)?) => {{
+        write_style!($stream, $msg_info, $status, bold, $color);
+        write_style!($stream, $msg_info, ":", bold);
+        match $message {
+            Some(message) => writeln!($stream, " {}", message)?,
+            None => write!($stream, " ")?,
+        }
+
+        Ok(())
+    }};
+
+    (@status @name $name:ident, $status:expr, $message:expr, $color:ident, $msg_info:expr $(,)?) => {{
+        let mut stream = io::$name();
+        message!(@status stream, $status, $message, $color, $msg_info)
+    }};
+}
+
+// high-level interface to message
+macro_rules! status {
+    (@stderr $status:expr, $message:expr, $color:ident, $msg_info:expr $(,)?) => {{
+        message!(@status @name stderr, $status, $message, $color, $msg_info)
+    }};
+
+    (@stdout $status:expr, $message:expr, $color:ident, $msg_info:expr  $(,)?) => {{
+        message!(@status @name stdout, $status, $message, $color, $msg_info)
+    }};
+}
+
+/// prints a red 'error' message and terminates.
+pub fn fatal<T: fmt::Display>(message: T, msg_info: MessageInfo, code: i32) -> ! {
+    error(message, msg_info).unwrap();
+    std::process::exit(code);
+}
+
+/// prints a red 'error' message.
+pub fn error<T: fmt::Display>(message: T, msg_info: MessageInfo) -> Result<()> {
+    status!(@stderr cross_prefix!("error"), Some(&message), red, msg_info)
+}
+
+/// prints an amber 'warning' message.
+pub fn warn<T: fmt::Display>(message: T, msg_info: MessageInfo) -> Result<()> {
+    match msg_info.verbosity {
+        Verbosity::Quiet => Ok(()),
+        _ => status!(@stderr
+            cross_prefix!("warning"),
+            Some(&message),
+            yellow,
+            msg_info,
+        ),
+    }
+}
+
+/// prints a cyan 'note' message.
+pub fn note<T: fmt::Display>(message: T, msg_info: MessageInfo) -> Result<()> {
+    match msg_info.verbosity {
+        Verbosity::Quiet => Ok(()),
+        _ => status!(@stderr cross_prefix!("note"), Some(&message), cyan, msg_info),
+    }
+}
+
+pub fn status<T: fmt::Display>(message: T, msg_info: MessageInfo) -> Result<()> {
+    match msg_info.verbosity {
+        Verbosity::Quiet => Ok(()),
+        _ => {
+            eprintln!("{}", message);
+            Ok(())
+        }
+    }
+}
+
+/// prints a high-priority message to stdout.
+pub fn print<T: fmt::Display>(message: T, _: MessageInfo) -> Result<()> {
+    println!("{}", message);
+    Ok(())
+}
+
+/// prints a normal message to stdout.
+pub fn info<T: fmt::Display>(message: T, msg_info: MessageInfo) -> Result<()> {
+    match msg_info.verbosity {
+        Verbosity::Quiet => Ok(()),
+        _ => {
+            println!("{}", message);
+            Ok(())
+        }
+    }
+}
+
+/// prints a debugging message to stdout.
+pub fn debug<T: fmt::Display>(message: T, msg_info: MessageInfo) -> Result<()> {
+    match msg_info.verbosity {
+        Verbosity::Quiet | Verbosity::Normal => Ok(()),
+        _ => {
+            println!("{}", message);
+            Ok(())
+        }
+    }
+}
+
+pub fn fatal_usage<T: fmt::Display>(arg: T, msg_info: MessageInfo, code: i32) -> ! {
+    error_usage(arg, msg_info).unwrap();
+    std::process::exit(code);
+}
+
+fn error_usage<T: fmt::Display>(arg: T, msg_info: MessageInfo) -> Result<()> {
+    let mut stream = io::stderr();
+    write_style!(stream, msg_info, cross_prefix!("error"), bold, red);
+    write_style!(stream, msg_info, ":", bold);
+    write_style!(stream, msg_info, " The argument '");
+    write_style!(stream, msg_info, arg, yellow);
+    write_style!(
+        stream,
+        msg_info,
+        "' requires a value but none was supplied\n"
+    );
+    write_style!(stream, msg_info, "Usage:\n");
+    write_style!(
+        stream,
+        msg_info,
+        "    cross [+toolchain] [OPTIONS] [SUBCOMMAND]\n"
+    );
+    write_style!(stream, msg_info, "\n");
+    write_style!(stream, msg_info, "For more information try ");
+    write_style!(stream, msg_info, "--help", green);
+    write_style!(stream, msg_info, "\n");
+
+    stream.flush()?;
+
+    Ok(())
+}
+
+fn get_color_choice(color: Option<&str>) -> Result<ColorChoice> {
+    match color {
+        Some("always") => Ok(ColorChoice::Always),
+        Some("never") => Ok(ColorChoice::Never),
+        Some("auto") | None => Ok(ColorChoice::Auto),
+        Some(arg) => {
+            eyre::bail!("argument for --color must be auto, always, or never, but found `{arg}`")
+        }
+    }
+}
+
+fn get_verbosity(color_choice: ColorChoice, verbose: bool, quiet: bool) -> Result<Verbosity> {
+    match (verbose, quiet) {
+        (true, true) => {
+            let verbosity = Verbosity::Normal;
+            error(
+                "cannot set both --verbose and --quiet",
+                MessageInfo {
+                    color_choice,
+                    verbosity,
+                },
+            )?;
+            std::process::exit(101);
+        }
+        (true, false) => Ok(Verbosity::Verbose),
+        (false, true) => Ok(Verbosity::Quiet),
+        (false, false) => Ok(Verbosity::Normal),
+    }
+}
+
+pub trait Stream {
+    const TTY: atty::Stream;
+    const OWO: owo_colors::Stream;
+
+    fn is_atty() -> bool {
+        atty::is(Self::TTY)
+    }
+
+    fn owo(&self) -> owo_colors::Stream {
+        Self::OWO
+    }
+}
+
+impl Stream for io::Stdin {
+    const TTY: atty::Stream = atty::Stream::Stdin;
+    const OWO: owo_colors::Stream = owo_colors::Stream::Stdin;
+}
+
+impl Stream for io::Stdout {
+    const TTY: atty::Stream = atty::Stream::Stdout;
+    const OWO: owo_colors::Stream = owo_colors::Stream::Stdout;
+}
+
+impl Stream for io::Stderr {
+    const TTY: atty::Stream = atty::Stream::Stderr;
+    const OWO: owo_colors::Stream = owo_colors::Stream::Stderr;
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,10 +14,14 @@ static WORKSPACE: OnceCell<PathBuf> = OnceCell::new();
 pub fn get_cargo_workspace() -> &'static Path {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     WORKSPACE.get_or_init(|| {
-        crate::cargo_metadata_with_args(Some(manifest_dir.as_ref()), None, true)
-            .unwrap()
-            .unwrap()
-            .workspace_root
+        crate::cargo_metadata_with_args(
+            Some(manifest_dir.as_ref()),
+            None,
+            crate::shell::Verbosity::Verbose.into(),
+        )
+        .unwrap()
+        .unwrap()
+        .workspace_root
     })
 }
 
@@ -71,7 +75,14 @@ release: {version}
         let target_meta = dbg!(make_rustc_version(targ));
         assert_eq!(
             expected,
-            warn_host_version_mismatch(&host_meta, "xxxx", &target_meta.0, &target_meta.1).unwrap(),
+            warn_host_version_mismatch(
+                &host_meta,
+                "xxxx",
+                &target_meta.0,
+                &target_meta.1,
+                crate::shell::MessageInfo::default()
+            )
+            .unwrap(),
             "\nhost = {}\ntarg = {}",
             host,
             targ

--- a/src/tests/toml.rs
+++ b/src/tests/toml.rs
@@ -41,11 +41,12 @@ fn toml_check() -> Result<(), Box<dyn std::error::Error>> {
                 dir_entry.path(),
                 text_line_no(&contents, fence.range().start),
             );
-            assert!(
-                crate::cross_toml::CrossToml::parse_from_cross(fence.as_str())?
-                    .1
-                    .is_empty()
-            );
+            assert!(crate::cross_toml::CrossToml::parse_from_cross(
+                fence.as_str(),
+                crate::shell::MessageInfo::default()
+            )?
+            .1
+            .is_empty());
         }
     }
     Ok(())

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -1,4 +1,6 @@
+use crate::util::gha_output;
 use clap::Subcommand;
+use cross::shell::Verbosity;
 use cross::{cargo_command, CargoMetadata, CommandExt};
 
 #[derive(Subcommand, Debug)]
@@ -77,7 +79,7 @@ pub fn ci(args: CiJob, metadata: CargoMetadata) -> cross::Result<()> {
                 let search = cargo_command()
                     .args(&["search", "--limit", "1"])
                     .arg("cross")
-                    .run_and_get_stdout(true)?;
+                    .run_and_get_stdout(Verbosity::Verbose.into())?;
                 let (cross, rest) = search
                     .split_once(" = ")
                     .ok_or_else(|| eyre::eyre!("cargo search failed"))?;
@@ -95,13 +97,4 @@ pub fn ci(args: CiJob, metadata: CargoMetadata) -> cross::Result<()> {
         }
     }
     Ok(())
-}
-
-#[track_caller]
-fn gha_output(tag: &str, content: &str) {
-    if content.contains('\n') {
-        // https://github.com/actions/toolkit/issues/403
-        panic!("output `{tag}` contains newlines, consider serializing with json and deserializing in gha with fromJSON()")
-    }
-    println!("::set-output name={tag}::{}", content)
 }

--- a/xtask/src/install_git_hooks.rs
+++ b/xtask/src/install_git_hooks.rs
@@ -1,17 +1,32 @@
 use crate::util::project_dir;
 use clap::Args;
+use cross::shell::MessageInfo;
 
 #[derive(Args, Debug)]
 pub struct InstallGitHooks {
     /// Provide verbose diagnostic output.
     #[clap(short, long)]
-    verbose: bool,
+    pub verbose: bool,
+    /// Do not print cross log messages.
+    #[clap(short, long)]
+    pub quiet: bool,
+    /// Whether messages should use color output.
+    #[clap(long)]
+    pub color: Option<String>,
 }
 
-pub fn install_git_hooks(InstallGitHooks { verbose }: InstallGitHooks) -> cross::Result<()> {
-    let root = project_dir(verbose)?;
+pub fn install_git_hooks(
+    InstallGitHooks {
+        verbose,
+        quiet,
+        color,
+    }: InstallGitHooks,
+) -> cross::Result<()> {
+    let msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
+    let root = project_dir(msg_info)?;
     let git_hooks = root.join(".git").join("hooks");
     let cross_dev = root.join("xtask").join("src");
+
     std::fs::copy(
         cross_dev.join("pre-commit.sh"),
         git_hooks.join("pre-commit"),


### PR DESCRIPTION
Adds the quiet and color command-line flags, where color supports `auto`, always`, and `never`. These command-line flags are parsed to a verbosity which can be quiet, normal, or verbose.

With these, we then have the stderr message formatters:
- `fatal_usage`: print a fatal error message with the failing argument, and add a help context menu for how to use cross.
- `fatal`: print red 'error' message and exit with an error code
- `error`: print red 'error' message
- `warn`: print amber 'warning' message
- `note`: print cyan 'note' message
- `status`: print an uncolored and unprefixed 'status' message

We have the stdout message formatters:
- `print`: always print the message
- `info`: print the message as long as the verbosity is not quiet
- `debug`: only print the message if the output is not quiet

We also have a few specialized error handlers, and methods to help ensure we can have flexible error reporting in the future:
- `status_stderr`
- `status_stdout`

The command extensions now have, `print`, `info`, and `debug`, which formats the command and sends it to the shell. This allows us to avoid using `print_verbose` where we sometimes manually override the default setting.

A few of these settings aren't currently used (such as `info` and `status`, but they're a very common pattern), so we can ensure we have the necessary utilities to ensure we can properly format messages in the future. A few like `shell::print` are practically identical to `println!`, but this allows us to customize it if need be in the future.

Solves parts of #797.