### PR TITLE
Fix parsing of config `build.env.passthrough` values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- #867 - fixed parsing of `build.env,passthrough` config values.
+
 ## [v0.2.2] - 2022-06-24
 
 ### Added


### PR DESCRIPTION
Ensure `build.env.passthrough` values are correctly parsed, and do not return `None`, and ensure that they merge as expected with `target.(...).env.passthrough` values.