### PR TITLE
Ignore the `CARGO` environment variable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- #867 - fixed parsing of `build.env,passthrough` config values.
+- #868 - ignore the `CARGO` environment variable.
+- #867 - fixed parsing of `build.env.passthrough` config values.
 
 ## [v0.2.2] - 2022-06-24
 

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -4,7 +4,7 @@ use std::process::{Command, ExitStatus};
 
 use crate::cli::Args;
 use crate::errors::*;
-use crate::extensions::{env_program, CommandExt};
+use crate::extensions::CommandExt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Subcommand {
@@ -112,7 +112,7 @@ impl Package {
 }
 
 pub fn cargo_command() -> Command {
-    Command::new(env_program("CARGO", "cargo"))
+    Command::new("cargo")
 }
 
 /// Cargo metadata with specific invocation

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -363,7 +363,7 @@ pub(crate) fn docker_user_id(docker: &mut Command, engine_type: EngineType) {
     }
 }
 
-#[allow(unused_variables, unused_mut)]
+#[allow(unused_variables, unused_mut, clippy::let_and_return)]
 pub(crate) fn docker_seccomp(
     docker: &mut Command,
     engine_type: EngineType,


### PR DESCRIPTION
Provides behavior consistent with `cargo` itself, which also ignores it.

Closes #864.
Supersedes #865.
Partially reverts #808.