### PR TITLE
Enable copying symlinks when using remote docker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- #885 - handle symlinks when using remote docker.
 - #868 - ignore the `CARGO` environment variable.
 - #867 - fixed parsing of `build.env.passthrough` config values.
 


### PR DESCRIPTION
This handles the reads the link dst from the symlink when using temporary directories, and creates a softlink to the path (keeping relative and absolute symlinks valid) in the temporary directory, which is then copied with the same permissions over the dst filesystem. This should not keep the same metadata, but since we fingerprint source files, this should not matter.

If symlinks are created, it issues a warning that there might be bugs that the file pointed to by the symlink is not mounted and the build may fail in that case.