### PR TITLE
Support rootless docker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- #890 - support rootless docker via the `CROSS_ROOTLESS_CONTAINER_ENGINE` environment variable.
+
 ### Changed
 
 - #869 - ensure cargo configuration environment variable flags are passed to the docker container.


### PR DESCRIPTION
Adds support for rootless docker, and manually overriding rootless/rootful container engines through the `CROSS_ROOTLESS_CONTAINER_ENGINE` environment variable. If not set, it will use the default mode for the container engine (rootful for docker, rootless for everything else).

```bash
# use the defaults
cross run ...
# auto-select if using rootless (the default)
CROSS_ROOTLESS_CONTAINER_ENGINE=auto cross run ...
# always use rootful mode
CROSS_ROOTLESS_CONTAINER_ENGINE=0 cross run ...
# always use rootless mode
CROSS_ROOTLESS_CONTAINER_ENGINE=1 cross run ...
```

Closes #889.