### PR TITLE
Add manual overrides for container user namespaces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- #891 - support custom user namespace overrides by setting the `CROSS_CONTAINER_USER_NAMESPACE` environment variable. 
 - #890 - support rootless docker via the `CROSS_ROOTLESS_CONTAINER_ENGINE` environment variable.
 
 ### Changed

--- a/src/docker/local.rs
+++ b/src/docker/local.rs
@@ -31,7 +31,7 @@ pub(crate) fn run(
     cmd.args(args);
 
     let mut docker = subcommand(engine, "run");
-    docker.args(&["--userns", "host"]);
+    docker_userns(&mut docker);
     docker_envvars(&mut docker, config, target, msg_info)?;
 
     let mount_volumes = docker_mount(

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -815,7 +815,7 @@ pub(crate) fn run(
 
     // 3. create our start container command here
     let mut docker = subcommand(engine, "run");
-    docker.args(&["--userns", "host"]);
+    docker_userns(&mut docker);
     docker.args(&["--name", &container]);
     docker.args(&["-v", &format!("{}:{mount_prefix}", volume.as_ref())]);
     docker_envvars(&mut docker, config, target, msg_info)?;


### PR DESCRIPTION
Support manual overrides of the container user namespace via the `CROSS_CONTAINER_USER_NAMESPACE` environment variable. If not set or set to `auto`, it will use the default value for the container engine (`host`). If `none` is provided, no `--userns` flag will be used. If any other value is provided, that will be the value passed to `--userns`.

This is required for using lima/nerdctl, which currently does not support the `--userns` flag.

Related to #888.