### PR TITLE
Fix tag names for custom docker images.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- #895 - convert filenames in docker tags to ASCII lowercase and ignore invalid characters
 - #885 - handle symlinks when using remote docker.
 - #868 - ignore the `CARGO` environment variable.
 - #867 - fixed parsing of `build.env.passthrough` config values.


### PR DESCRIPTION
Ensures the filenames in custom docker image tags are valid docker tag
characters. This requires the following:
- lowercase ASCII letters
- digits
- a period
- 1-2 underscores
- 1 or more hyphens (dashes)

Closes #894.