### PR TITLE
Fix build/target config file ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- #897 - ensure `target.$(...)` config options override `build` ones when parsing strings and vecs.
 - #895 - convert filenames in docker tags to ASCII lowercase and ignore invalid characters
 - #885 - handle symlinks when using remote docker.
 - #868 - ignore the `CARGO` environment variable.


### PR DESCRIPTION
Fix the order of values for string (as well as the pre-build vec) values when parsing from config files and environment variables.

The old behavior was:
1. Envvar build.
2. Envvar target
3. Config target
4. Config build

The new behavior is:
1. Envvar target
2. Config target
3. Envvar build.
4. Config build

Some functions were also made more general.