### PR TITLE
Enable skipping of copying build artifacts back to host.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- #900 - add the option to skip copying build artifacts back to host when using remote cross via `CROSS_REMOTE_SKIP_BUILD_ARTIFACTS`.
 - #891 - support custom user namespace overrides by setting the `CROSS_CONTAINER_USER_NAMESPACE` environment variable. 
 - #890 - support rootless docker via the `CROSS_ROOTLESS_CONTAINER_ENGINE` environment variable.
 

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -1055,7 +1055,10 @@ symlink_recurse \"${{prefix}}\"
 
     // 7. copy data from our target dir back to host
     // this might not exist if we ran `clean`.
-    if container_path_exists(engine, &container, &target_dir, msg_info)? {
+    let skip_artifacts = env::var("CROSS_REMOTE_SKIP_BUILD_ARTIFACTS")
+        .map(|s| bool_from_envvar(&s))
+        .unwrap_or_default();
+    if !skip_artifacts && container_path_exists(engine, &container, &target_dir, msg_info)? {
         subcommand(engine, "cp")
             .arg("-a")
             .arg(&format!("{container}:{}", target_dir.as_posix()?))


### PR DESCRIPTION
If using remote docker but primarily wishing to build or test your builds remotely, without caring about the generated artifacts, the time required to copy the generated artifacts over a network connection can be prohibitive.

Setting `CROSS_REMOTE_SKIP_BUILD_ARTIFACTS=1` will disable copying these build artifacts back to the host, for faster build times with remote container engines.