### PR TITLE
Various bug fixes for cross.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- #904 - ensure `cargo metadata` works by using the same channel.
+- #904 - fixed the path for workspace volumes and passthrough volumes with docker-in-docker.
 - #898 - fix the path to the mount root with docker-in-docker if mounting volumes.
 - #897 - ensure `target.$(...)` config options override `build` ones when parsing strings and vecs.
 - #895 - convert filenames in docker tags to ASCII lowercase and ignore invalid characters

--- a/src/docker/local.rs
+++ b/src/docker/local.rs
@@ -25,7 +25,8 @@ pub(crate) fn run(
     docker_in_docker: bool,
     cwd: &Path,
 ) -> Result<ExitStatus> {
-    let dirs = Directories::create(engine, metadata, cwd, sysroot, docker_in_docker)?;
+    let mount_finder = MountFinder::create(engine, docker_in_docker)?;
+    let dirs = Directories::create(&mount_finder, metadata, cwd, sysroot)?;
 
     let mut cmd = cargo_safe_command(uses_xargo);
     cmd.args(args);
@@ -37,6 +38,7 @@ pub(crate) fn run(
     let mount_volumes = docker_mount(
         &mut docker,
         metadata,
+        &mount_finder,
         config,
         target,
         cwd,

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -12,7 +12,7 @@ use std::process::ExitStatus;
 
 use crate::cargo::CargoMetadata;
 use crate::errors::*;
-use crate::shell::MessageInfo;
+use crate::shell::{self, MessageInfo};
 use crate::{Config, Target};
 
 #[allow(clippy::too_many_arguments)] // TODO: refactor
@@ -28,6 +28,13 @@ pub fn run(
     docker_in_docker: bool,
     cwd: &Path,
 ) -> Result<ExitStatus> {
+    if cfg!(target_os = "windows") && docker_in_docker {
+        shell::fatal(
+            "running cross insider a container running windows is currently unsupported",
+            msg_info,
+            1,
+        );
+    }
     if engine.is_remote {
         remote::run(
             engine,

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -308,3 +308,14 @@ impl Stream for io::Stderr {
     const TTY: atty::Stream = atty::Stream::Stderr;
     const OWO: owo_colors::Stream = owo_colors::Stream::Stderr;
 }
+
+pub fn default_ident() -> usize {
+    cross_prefix!("").len()
+}
+
+pub fn indent(message: &str, spaces: usize) -> String {
+    message
+        .lines()
+        .map(|s| format!("{:spaces$}{s}", ""))
+        .collect()
+}


### PR DESCRIPTION
Fixed `cargo metadata` failing with unstable arguments in rustflags if the default toolchain was not nightly. We also log any warnings that occurred if we cannot get metadata. Also fixed a lack of formatting in messages with remote docker support. The mount paths are also correctly processed if using docker-in-docker for mounted volumes.

Closes #901.
Closes #903.
Required for #873.
