### PR TITLE
Use create_dir_all for cargo directory.

### DIFF
--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -59,8 +59,10 @@ impl Directories {
 
         // create the directories we are going to mount before we mount them,
         // otherwise `docker` will create them but they will be owned by `root`
-        fs::create_dir(&cargo).ok();
-        fs::create_dir(&xargo).ok();
+        // cargo builds all intermediate directories, but fails
+        // if it has other issues (such as permission errors).
+        fs::create_dir_all(&cargo)?;
+        fs::create_dir_all(&xargo)?;
         create_target_dir(target)?;
 
         let cargo = mount_finder.find_mount_path(cargo);


### PR DESCRIPTION
Use create_dir_all for cargo directory.

Cargo builds all intermediate directories to `CARGO_HOME`, if not present, and hard errors if it cannot. This differs from our behavior, where we silently ignore failures and only attempt to build the current directory (ignores errors if it actually exists). If using a rootful container engine, this means we create the cargo directory and it is owned by root. This only occurs if the package has no dependencies, another fix that using `cargo metadata` solved.

An example of the hard failure shown as the following (some lines are omitted for brevity):

### Cargo

```bash
$ CARGO_HOME=/path/to/my/cargo cargo build
error: failed to get `cc` as a dependency of package `hellopp v0.1.0 (/home/ahuszagh/Desktop/cross/rust-cpp-hello-word)`

Caused by:
  failed to create directory `/path/to/my/cargo/registry/index/github.com-1ecc6299db9ec823`

Caused by:
  Permission denied (os error 13)
```

### Old Cross

**Container Engine Runs as Root**

```bash
$ CARGO_HOME=/path/to/my/cargo cross build -vv
...
+ /usr/bin/docker run --userns host -e 'PKG_CONFIG_ALLOW_CROSS=1' -e 'XARGO_HOME=/xargo' -e 'CARGO_HOME=/cargo' -e 'CARGO_TARGET_DIR=/target' -e 'CROSS_RUNNER=' -e 'USER=ahuszagh' --rm --user 1000:1000 -v /home/ahuszagh/.xargo:/xargo:Z -v /path/to/my/cargo:/cargo:Z -v /cargo/bin -v /home/ahuszagh/Desktop/cross/hello:/project:Z -v /home/ahuszagh/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu:/rust:Z,ro -v /home/ahuszagh/Desktop/cross/hello/target:/target:Z -w /project -i -t ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.2 sh -c 'PATH=$PATH:/rust/bin cargo build -vv --target x86_64-unknown-linux-gnu'
...
$ ls -la /path/to/my/cargo
total 0
drwxr-xr-x. 1 root root  6 Jul  4 10:55 .
drwxr-xr-x. 1 root root 10 Jul  4 10:55 ..
drwxr-xr-x. 1 root root  0 Jul  4 10:55 bin
```

**Rootless Container Engine**

```bash
$ CROSS_CONTAINER_ENGINE=podman CARGO_HOME=/path/to/my/cargo cross build
Error: statfs /path/to/my/cargo: no such file or directory
```

### New Cross

**Container Engine Runs as Root**

```bash
$ CARGO_HOME=/path/to/my/cargo ~/git/cross/target/debug/cross build
[cross] warning: unable to get metadata for package
[cross] note: Falling back to `cargo` on the host.
error: failed to get `cc` as a dependency of package `hellopp v0.1.0 (/home/ahuszagh/Desktop/cross/rust-cpp-hello-word)`

Caused by:
  failed to create directory `/path/to/my/cargo/registry/index/github.com-1ecc6299db9ec823`

Caused by:
  Permission denied (os error 13)
```

**Rootless Container Engine**

```bash
$ CROSS_CONTAINER_ENGINE=podman CARGO_HOME=/path/to/my/cargo ~/git/cross/target/debug/cross build
Error:
   0: could not run container
   1: Permission denied (os error 13)
```