### PR TITLE
Allow verbose output in ct-ng images.

### DIFF
--- a/docker/Dockerfile.arm-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabihf
@@ -10,6 +10,7 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
+ARG VERBOSE
 COPY crosstool-ng.sh /
 COPY crosstool-config/arm-unknown-linux-gnueabihf.config /
 RUN /crosstool-ng.sh arm-unknown-linux-gnueabihf.config 5

--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -24,8 +24,8 @@ pub struct BuildDockerImage {
     #[clap(long, env = "LABELS")]
     pub labels: Option<String>,
     /// Provide verbose diagnostic output.
-    #[clap(short, long)]
-    pub verbose: bool,
+    #[clap(short, long, action = clap::ArgAction::Count)]
+    pub verbose: u8,
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
@@ -113,7 +113,7 @@ pub fn build_docker_image(
     }: BuildDockerImage,
     engine: &docker::Engine,
 ) -> cross::Result<()> {
-    let msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
+    let msg_info = MessageInfo::create(verbose != 0, quiet, color.as_deref())?;
     let metadata = cargo_metadata(msg_info)?;
     let version = metadata
         .get_package("cross")
@@ -235,6 +235,9 @@ pub fn build_docker_image(
         }
         for arg in &build_arg {
             docker_build.args(&["--build-arg", arg]);
+        }
+        if verbose > 1 {
+            docker_build.args(&["--build-arg", "VERBOSE=1"]);
         }
 
         docker_build.arg(".");

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -75,7 +75,8 @@ pub fn main() -> cross::Result<()> {
             target_info::target_info(args, &engine)?;
         }
         Commands::BuildDockerImage(args) => {
-            let msg_info = MessageInfo::create(args.verbose, args.quiet, args.color.as_deref())?;
+            let msg_info =
+                MessageInfo::create(args.verbose != 0, args.quiet, args.color.as_deref())?;
             let engine = get_container_engine(args.engine.as_deref(), msg_info)?;
             build_docker_image::build_docker_image(args, &engine)?;
         }


### PR DESCRIPTION
Defaulting to verbose output pollutes the build logs during CI, which can be obscure any errors or status results. However, silencing output on local builds can make it difficult to debug issues. This checks for verbose output and the build script is running on a TTY, so we only get spinner output in those cases (IE, where the spinners actually work and are able to delete the current output line).