### PR TITLE
Structify more of the internals to simplify the implementation.

### DIFF
--- a/src/bin/commands/clean.rs
+++ b/src/bin/commands/clean.rs
@@ -31,8 +31,11 @@ pub struct Clean {
 }
 
 impl Clean {
-    pub fn run(self, engine: cross::docker::Engine) -> cross::Result<()> {
-        let mut msg_info = MessageInfo::create(self.verbose, self.quiet, self.color.as_deref())?;
+    pub fn run(
+        self,
+        engine: cross::docker::Engine,
+        msg_info: &mut MessageInfo,
+    ) -> cross::Result<()> {
         let tempdir = cross::temp::dir()?;
         match self.execute {
             true => {
@@ -55,7 +58,7 @@ impl Clean {
             execute: self.execute,
             engine: None,
         };
-        remove_containers.run(engine.clone())?;
+        remove_containers.run(engine.clone(), msg_info)?;
 
         let remove_images = RemoveImages {
             targets: vec![],
@@ -67,7 +70,7 @@ impl Clean {
             execute: self.execute,
             engine: None,
         };
-        remove_images.run(engine.clone())?;
+        remove_images.run(engine.clone(), msg_info)?;
 
         let remove_volumes = RemoveAllVolumes {
             verbose: self.verbose,
@@ -77,7 +80,7 @@ impl Clean {
             execute: self.execute,
             engine: None,
         };
-        remove_volumes.run(engine.clone())?;
+        remove_volumes.run(engine.clone(), msg_info)?;
 
         let prune_volumes = PruneVolumes {
             verbose: self.verbose,
@@ -86,7 +89,7 @@ impl Clean {
             execute: self.execute,
             engine: None,
         };
-        prune_volumes.run(engine)?;
+        prune_volumes.run(engine, msg_info)?;
 
         Ok(())
     }

--- a/src/bin/commands/containers.rs
+++ b/src/bin/commands/containers.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use clap::{Args, Subcommand};
-use cross::shell::{self, MessageInfo, Stream};
+use cross::shell::{MessageInfo, Stream};
 use cross::{docker, CommandExt};
 
 #[derive(Args, Debug)]
@@ -149,6 +149,18 @@ pub enum Volumes {
     Remove(RemoveVolume),
 }
 
+macro_rules! volumes_get_field {
+    ($self:ident, $field:ident $(.$cb:ident)?) => {{
+        match $self {
+            Volumes::List(l) => l.$field$(.$cb())?,
+            Volumes::RemoveAll(l) => l.$field$(.$cb())?,
+            Volumes::Prune(l) => l.$field$(.$cb())?,
+            Volumes::Create(l) => l.$field$(.$cb())?,
+            Volumes::Remove(l) => l.$field$(.$cb())?,
+        }
+    }};
+}
+
 impl Volumes {
     pub fn run(self, engine: docker::Engine, toolchain: Option<&str>) -> cross::Result<()> {
         match self {
@@ -161,43 +173,30 @@ impl Volumes {
     }
 
     pub fn engine(&self) -> Option<&str> {
+        volumes_get_field!(self, engine.as_deref)
+    }
+
+    // FIXME: remove this in v0.3.0.
+    pub fn docker_in_docker(&self) -> bool {
         match self {
-            Volumes::List(l) => l.engine.as_deref(),
-            Volumes::RemoveAll(l) => l.engine.as_deref(),
-            Volumes::Prune(l) => l.engine.as_deref(),
-            Volumes::Create(l) => l.engine.as_deref(),
-            Volumes::Remove(l) => l.engine.as_deref(),
+            Volumes::List(_) => false,
+            Volumes::RemoveAll(_) => false,
+            Volumes::Prune(_) => false,
+            Volumes::Create(l) => l.docker_in_docker,
+            Volumes::Remove(l) => l.docker_in_docker,
         }
     }
 
     pub fn verbose(&self) -> bool {
-        match self {
-            Volumes::List(l) => l.verbose,
-            Volumes::RemoveAll(l) => l.verbose,
-            Volumes::Prune(l) => l.verbose,
-            Volumes::Create(l) => l.verbose,
-            Volumes::Remove(l) => l.verbose,
-        }
+        volumes_get_field!(self, verbose)
     }
 
     pub fn quiet(&self) -> bool {
-        match self {
-            Volumes::List(l) => l.quiet,
-            Volumes::RemoveAll(l) => l.quiet,
-            Volumes::Prune(l) => l.quiet,
-            Volumes::Create(l) => l.quiet,
-            Volumes::Remove(l) => l.quiet,
-        }
+        volumes_get_field!(self, quiet)
     }
 
     pub fn color(&self) -> Option<&str> {
-        match self {
-            Volumes::List(l) => l.color.as_deref(),
-            Volumes::RemoveAll(l) => l.color.as_deref(),
-            Volumes::Prune(l) => l.color.as_deref(),
-            Volumes::Create(l) => l.color.as_deref(),
-            Volumes::Remove(l) => l.color.as_deref(),
-        }
+        volumes_get_field!(self, color.as_deref)
     }
 }
 
@@ -259,6 +258,15 @@ pub enum Containers {
     RemoveAll(RemoveAllContainers),
 }
 
+macro_rules! containers_get_field {
+    ($self:ident, $field:ident $(.$cb:ident)?) => {{
+        match $self {
+            Containers::List(l) => l.$field$(.$cb())?,
+            Containers::RemoveAll(l) => l.$field$(.$cb())?,
+        }
+    }};
+}
+
 impl Containers {
     pub fn run(self, engine: docker::Engine) -> cross::Result<()> {
         match self {
@@ -268,35 +276,26 @@ impl Containers {
     }
 
     pub fn engine(&self) -> Option<&str> {
-        match self {
-            Containers::List(l) => l.engine.as_deref(),
-            Containers::RemoveAll(l) => l.engine.as_deref(),
-        }
+        containers_get_field!(self, engine.as_deref)
     }
 
     pub fn verbose(&self) -> bool {
-        match self {
-            Containers::List(l) => l.verbose,
-            Containers::RemoveAll(l) => l.verbose,
-        }
+        containers_get_field!(self, verbose)
     }
 
     pub fn quiet(&self) -> bool {
-        match self {
-            Containers::List(l) => l.quiet,
-            Containers::RemoveAll(l) => l.quiet,
-        }
+        containers_get_field!(self, quiet)
     }
 
     pub fn color(&self) -> Option<&str> {
-        match self {
-            Containers::List(l) => l.color.as_deref(),
-            Containers::RemoveAll(l) => l.color.as_deref(),
-        }
+        containers_get_field!(self, color.as_deref)
     }
 }
 
-fn get_cross_volumes(engine: &docker::Engine, msg_info: MessageInfo) -> cross::Result<Vec<String>> {
+fn get_cross_volumes(
+    engine: &docker::Engine,
+    msg_info: &mut MessageInfo,
+) -> cross::Result<Vec<String>> {
     let stdout = docker::subcommand(engine, "volume")
         .arg("list")
         .args(&["--format", "{{.Name}}"])
@@ -319,9 +318,9 @@ pub fn list_volumes(
     }: ListVolumes,
     engine: &docker::Engine,
 ) -> cross::Result<()> {
-    let msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
-    for line in get_cross_volumes(engine, msg_info)?.iter() {
-        shell::print(line, msg_info)?;
+    let mut msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
+    for line in get_cross_volumes(engine, &mut msg_info)?.iter() {
+        msg_info.print(line)?;
     }
 
     Ok(())
@@ -338,8 +337,8 @@ pub fn remove_all_volumes(
     }: RemoveAllVolumes,
     engine: &docker::Engine,
 ) -> cross::Result<()> {
-    let msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
-    let volumes = get_cross_volumes(engine, msg_info)?;
+    let mut msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
+    let volumes = get_cross_volumes(engine, &mut msg_info)?;
 
     let mut command = docker::subcommand(engine, "volume");
     command.arg("rm");
@@ -350,13 +349,10 @@ pub fn remove_all_volumes(
     if volumes.is_empty() {
         Ok(())
     } else if execute {
-        command.run(msg_info, false).map_err(Into::into)
+        command.run(&mut msg_info, false).map_err(Into::into)
     } else {
-        shell::note(
-            "this is a dry run. to remove the volumes, pass the `--execute` flag.",
-            msg_info,
-        )?;
-        command.print(msg_info)?;
+        msg_info.note("this is a dry run. to remove the volumes, pass the `--execute` flag.")?;
+        command.print(&mut msg_info)?;
         Ok(())
     }
 }
@@ -371,24 +367,20 @@ pub fn prune_volumes(
     }: PruneVolumes,
     engine: &docker::Engine,
 ) -> cross::Result<()> {
-    let msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
+    let mut msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
     let mut command = docker::subcommand(engine, "volume");
     command.args(&["prune", "--force"]);
     if execute {
-        command.run(msg_info, false).map_err(Into::into)
+        command.run(&mut msg_info, false).map_err(Into::into)
     } else {
-        shell::note(
-            "this is a dry run. to prune the volumes, pass the `--execute` flag.",
-            msg_info,
-        )?;
-        command.print(msg_info)?;
+        msg_info.note("this is a dry run. to prune the volumes, pass the `--execute` flag.")?;
+        command.print(&mut msg_info)?;
         Ok(())
     }
 }
 
 pub fn create_persistent_volume(
     CreateVolume {
-        docker_in_docker,
         copy_registry,
         verbose,
         quiet,
@@ -398,31 +390,31 @@ pub fn create_persistent_volume(
     engine: &docker::Engine,
     channel: Option<&str>,
 ) -> cross::Result<()> {
-    let msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
+    let mut msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
     // we only need a triple that needs docker: the actual target doesn't matter.
     let triple = cross::Host::X86_64UnknownLinuxGnu.triple();
     let (target, metadata, dirs) =
-        docker::get_package_info(engine, triple, channel, docker_in_docker, msg_info)?;
+        docker::get_package_info(engine, triple, channel, &mut msg_info)?;
     let container = docker::remote::unique_container_identifier(&target, &metadata, &dirs)?;
     let volume = docker::remote::unique_toolchain_identifier(&dirs.sysroot)?;
 
-    if docker::remote::volume_exists(engine, &volume, msg_info)? {
+    if docker::remote::volume_exists(engine, &volume, &mut msg_info)? {
         eyre::bail!("Error: volume {volume} already exists.");
     }
 
     docker::subcommand(engine, "volume")
         .args(&["create", &volume])
-        .run_and_get_status(msg_info, false)?;
+        .run_and_get_status(&mut msg_info, false)?;
 
     // stop the container if it's already running
-    let state = docker::remote::container_state(engine, &container, msg_info)?;
+    let state = docker::remote::container_state(engine, &container, &mut msg_info)?;
     if !state.is_stopped() {
-        shell::warn("container {container} was running.", msg_info)?;
-        docker::remote::container_stop(engine, &container, msg_info)?;
+        msg_info.warn("container {container} was running.")?;
+        docker::remote::container_stop(engine, &container, &mut msg_info)?;
     }
     if state.exists() {
-        shell::warn("container {container} was exited.", msg_info)?;
-        docker::remote::container_rm(engine, &container, msg_info)?;
+        msg_info.warn("container {container} was exited.")?;
+        docker::remote::container_rm(engine, &container, &mut msg_info)?;
     }
 
     // create a dummy running container to copy data over
@@ -437,7 +429,7 @@ pub fn create_persistent_volume(
     docker.arg(docker::UBUNTU_BASE);
     // ensure the process never exits until we stop it
     docker.args(&["sh", "-c", "sleep infinity"]);
-    docker.run_and_get_status(msg_info, false)?;
+    docker.run_and_get_status(&mut msg_info, false)?;
 
     docker::remote::copy_volume_container_xargo(
         engine,
@@ -445,7 +437,7 @@ pub fn create_persistent_volume(
         &dirs.xargo,
         &target,
         mount_prefix.as_ref(),
-        msg_info,
+        &mut msg_info,
     )?;
     docker::remote::copy_volume_container_cargo(
         engine,
@@ -453,7 +445,7 @@ pub fn create_persistent_volume(
         &dirs.cargo,
         mount_prefix.as_ref(),
         copy_registry,
-        msg_info,
+        &mut msg_info,
     )?;
     docker::remote::copy_volume_container_rust(
         engine,
@@ -462,18 +454,17 @@ pub fn create_persistent_volume(
         &target,
         mount_prefix.as_ref(),
         true,
-        msg_info,
+        &mut msg_info,
     )?;
 
-    docker::remote::container_stop(engine, &container, msg_info)?;
-    docker::remote::container_rm(engine, &container, msg_info)?;
+    docker::remote::container_stop(engine, &container, &mut msg_info)?;
+    docker::remote::container_rm(engine, &container, &mut msg_info)?;
 
     Ok(())
 }
 
 pub fn remove_persistent_volume(
     RemoveVolume {
-        docker_in_docker,
         verbose,
         quiet,
         color,
@@ -483,24 +474,23 @@ pub fn remove_persistent_volume(
     channel: Option<&str>,
 ) -> cross::Result<()> {
     // we only need a triple that needs docker: the actual target doesn't matter.
-    let msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
+    let mut msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
     let triple = cross::Host::X86_64UnknownLinuxGnu.triple();
-    let (_, _, dirs) =
-        docker::get_package_info(engine, triple, channel, docker_in_docker, msg_info)?;
+    let (_, _, dirs) = docker::get_package_info(engine, triple, channel, &mut msg_info)?;
     let volume = docker::remote::unique_toolchain_identifier(&dirs.sysroot)?;
 
-    if !docker::remote::volume_exists(engine, &volume, msg_info)? {
+    if !docker::remote::volume_exists(engine, &volume, &mut msg_info)? {
         eyre::bail!("Error: volume {volume} does not exist.");
     }
 
-    docker::remote::volume_rm(engine, &volume, msg_info)?;
+    docker::remote::volume_rm(engine, &volume, &mut msg_info)?;
 
     Ok(())
 }
 
 fn get_cross_containers(
     engine: &docker::Engine,
-    msg_info: MessageInfo,
+    msg_info: &mut MessageInfo,
 ) -> cross::Result<Vec<String>> {
     let stdout = docker::subcommand(engine, "ps")
         .arg("-a")
@@ -524,9 +514,9 @@ pub fn list_containers(
     }: ListContainers,
     engine: &docker::Engine,
 ) -> cross::Result<()> {
-    let msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
-    for line in get_cross_containers(engine, msg_info)?.iter() {
-        shell::print(line, msg_info)?;
+    let mut msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
+    for line in get_cross_containers(engine, &mut msg_info)?.iter() {
+        msg_info.print(line)?;
     }
 
     Ok(())
@@ -543,8 +533,8 @@ pub fn remove_all_containers(
     }: RemoveAllContainers,
     engine: &docker::Engine,
 ) -> cross::Result<()> {
-    let msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
-    let containers = get_cross_containers(engine, msg_info)?;
+    let mut msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
+    let containers = get_cross_containers(engine, &mut msg_info)?;
     let mut running = vec![];
     let mut stopped = vec![];
     for container in containers.iter() {
@@ -577,15 +567,12 @@ pub fn remove_all_containers(
     }
     if execute {
         for mut command in commands {
-            command.run(msg_info, false)?;
+            command.run(&mut msg_info, false)?;
         }
     } else {
-        shell::note(
-            "this is a dry run. to remove the containers, pass the `--execute` flag.",
-            msg_info,
-        )?;
+        msg_info.note("this is a dry run. to remove the containers, pass the `--execute` flag.")?;
         for command in commands {
-            command.print(msg_info)?;
+            command.print(&mut msg_info)?;
         }
     }
 

--- a/src/bin/cross-util.rs
+++ b/src/bin/cross-util.rs
@@ -65,9 +65,14 @@ fn get_container_engine(
 }
 
 macro_rules! get_engine {
-    ($args:ident, $docker_in_docker:expr) => {{
-        let mut msg_info = MessageInfo::create($args.verbose(), $args.quiet(), $args.color())?;
-        get_container_engine($args.engine(), $docker_in_docker, &mut msg_info)
+    ($args:ident, $docker_in_docker:expr, $msg_info: ident) => {{
+        get_container_engine($args.engine(), $docker_in_docker, &mut $msg_info)
+    }};
+}
+
+macro_rules! get_msg_info {
+    ($args:ident) => {{
+        MessageInfo::create($args.verbose(), $args.quiet(), $args.color())
     }};
 }
 
@@ -76,20 +81,24 @@ pub fn main() -> cross::Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Commands::Images(args) => {
-            let engine = get_engine!(args, false)?;
-            args.run(engine)?;
+            let mut msg_info = get_msg_info!(args)?;
+            let engine = get_engine!(args, false, msg_info)?;
+            args.run(engine, &mut msg_info)?;
         }
         Commands::Volumes(args) => {
-            let engine = get_engine!(args, args.docker_in_docker())?;
-            args.run(engine, cli.toolchain.as_deref())?;
+            let mut msg_info = get_msg_info!(args)?;
+            let engine = get_engine!(args, args.docker_in_docker(), msg_info)?;
+            args.run(engine, cli.toolchain.as_deref(), &mut msg_info)?;
         }
         Commands::Containers(args) => {
-            let engine = get_engine!(args, false)?;
-            args.run(engine)?;
+            let mut msg_info = get_msg_info!(args)?;
+            let engine = get_engine!(args, false, msg_info)?;
+            args.run(engine, &mut msg_info)?;
         }
         Commands::Clean(args) => {
-            let engine = get_engine!(args, false)?;
-            args.run(engine)?;
+            let mut msg_info = get_msg_info!(args)?;
+            let engine = get_engine!(args, false, msg_info)?;
+            args.run(engine, &mut msg_info)?;
         }
     }
 

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -120,7 +120,7 @@ pub fn cargo_command() -> Command {
 pub fn cargo_metadata_with_args(
     cd: Option<&Path>,
     args: Option<&Args>,
-    msg_info: MessageInfo,
+    msg_info: &mut MessageInfo,
 ) -> Result<Option<CargoMetadata>> {
     let mut command = cargo_command();
     if let Some(channel) = args.and_then(|x| x.channel.as_deref()) {
@@ -145,9 +145,9 @@ pub fn cargo_metadata_with_args(
     }
     let output = command.run_and_get_output(msg_info)?;
     if !output.status.success() {
-        shell::warn("unable to get metadata for package", msg_info)?;
+        msg_info.warn("unable to get metadata for package")?;
         let indented = shell::indent(&String::from_utf8(output.stderr)?, shell::default_ident());
-        shell::debug(indented, msg_info)?;
+        msg_info.debug(indented)?;
         return Ok(None);
     }
     let manifest: Option<CargoMetadata> = serde_json::from_slice(&output.stdout)?;
@@ -164,13 +164,16 @@ pub fn cargo_metadata_with_args(
 }
 
 /// Pass-through mode
-pub fn run(args: &[String], msg_info: MessageInfo) -> Result<ExitStatus> {
+pub fn run(args: &[String], msg_info: &mut MessageInfo) -> Result<ExitStatus> {
     cargo_command()
         .args(args)
         .run_and_get_status(msg_info, false)
 }
 
 /// run cargo and get the output, does not check the exit status
-pub fn run_and_get_output(args: &[String], msg_info: MessageInfo) -> Result<std::process::Output> {
+pub fn run_and_get_output(
+    args: &[String],
+    msg_info: &mut MessageInfo,
+) -> Result<std::process::Output> {
     cargo_command().args(args).run_and_get_output(msg_info)
 }

--- a/src/docker/engine.rs
+++ b/src/docker/engine.rs
@@ -22,33 +22,62 @@ pub enum EngineType {
 pub struct Engine {
     pub kind: EngineType,
     pub path: PathBuf,
+    pub in_docker: bool,
     pub is_remote: bool,
 }
 
 impl Engine {
-    pub fn new(is_remote: Option<bool>, msg_info: MessageInfo) -> Result<Engine> {
+    pub fn new(
+        in_docker: Option<bool>,
+        is_remote: Option<bool>,
+        msg_info: &mut MessageInfo,
+    ) -> Result<Engine> {
         let path = get_container_engine()
             .map_err(|_| eyre::eyre!("no container engine found"))
             .with_suggestion(|| "is docker or podman installed?")?;
-        Self::from_path(path, is_remote, msg_info)
+        Self::from_path(path, in_docker, is_remote, msg_info)
     }
 
     pub fn from_path(
         path: PathBuf,
+        in_docker: Option<bool>,
         is_remote: Option<bool>,
-        msg_info: MessageInfo,
+        msg_info: &mut MessageInfo,
     ) -> Result<Engine> {
         let kind = get_engine_type(&path, msg_info)?;
+        let in_docker = match in_docker {
+            Some(v) => v,
+            None => Self::in_docker(msg_info)?,
+        };
         let is_remote = is_remote.unwrap_or_else(Self::is_remote);
         Ok(Engine {
             path,
             kind,
+            in_docker,
             is_remote,
         })
     }
 
     pub fn needs_remote(&self) -> bool {
         self.is_remote && self.kind == EngineType::Podman
+    }
+
+    pub fn in_docker(msg_info: &mut MessageInfo) -> Result<bool> {
+        Ok(
+            if let Ok(value) = env::var("CROSS_CONTAINER_IN_CONTAINER") {
+                if env::var("CROSS_DOCKER_IN_DOCKER").is_ok() {
+                    msg_info.warn(
+                        "using both `CROSS_CONTAINER_IN_CONTAINER` and `CROSS_DOCKER_IN_DOCKER`.",
+                    )?;
+                }
+                bool_from_envvar(&value)
+            } else if let Ok(value) = env::var("CROSS_DOCKER_IN_DOCKER") {
+                // FIXME: remove this when we deprecate CROSS_DOCKER_IN_DOCKER.
+                bool_from_envvar(&value)
+            } else {
+                false
+            },
+        )
     }
 
     pub fn is_remote() -> bool {
@@ -60,7 +89,7 @@ impl Engine {
 
 // determine if the container engine is docker. this fixes issues with
 // any aliases (#530), and doesn't fail if an executable suffix exists.
-fn get_engine_type(ce: &Path, msg_info: MessageInfo) -> Result<EngineType> {
+fn get_engine_type(ce: &Path, msg_info: &mut MessageInfo) -> Result<EngineType> {
     let stdout = Command::new(ce)
         .arg("--help")
         .run_and_get_stdout(msg_info)?

--- a/src/docker/local.rs
+++ b/src/docker/local.rs
@@ -1,56 +1,46 @@
 use std::io;
-use std::path::Path;
 use std::process::ExitStatus;
 
-use super::engine::*;
 use super::shared::*;
-use crate::cargo::CargoMetadata;
 use crate::errors::Result;
 use crate::extensions::CommandExt;
 use crate::file::{PathExt, ToUtf8};
 use crate::shell::{MessageInfo, Stream};
-use crate::{Config, Target};
 use eyre::Context;
 
-#[allow(clippy::too_many_arguments)] // TODO: refactor
 pub(crate) fn run(
-    engine: &Engine,
-    target: &Target,
+    options: DockerOptions,
+    paths: DockerPaths,
     args: &[String],
-    metadata: &CargoMetadata,
-    config: &Config,
-    uses_xargo: bool,
-    sysroot: &Path,
-    msg_info: MessageInfo,
-    docker_in_docker: bool,
-    cwd: &Path,
+    msg_info: &mut MessageInfo,
 ) -> Result<ExitStatus> {
-    let mount_finder = MountFinder::create(engine, docker_in_docker)?;
-    let dirs = Directories::create(&mount_finder, metadata, cwd, sysroot)?;
+    let dirs = paths.directories();
 
-    let mut cmd = cargo_safe_command(uses_xargo);
+    let mut cmd = cargo_safe_command(options.uses_xargo());
     cmd.args(args);
 
-    let mut docker = subcommand(engine, "run");
+    let mut docker = subcommand(options.engine(), "run");
     docker_userns(&mut docker);
-    docker_envvars(&mut docker, config, target, msg_info)?;
+    docker_envvars(&mut docker, options.config(), options.target(), msg_info)?;
 
     let mount_volumes = docker_mount(
         &mut docker,
-        metadata,
-        &mount_finder,
-        config,
-        target,
-        cwd,
+        &options,
+        &paths,
         |docker, val| mount(docker, val, ""),
         |_| {},
     )?;
 
     docker.arg("--rm");
 
-    docker_seccomp(&mut docker, engine.kind, target, metadata)
-        .wrap_err("when copying seccomp profile")?;
-    docker_user_id(&mut docker, engine.kind);
+    docker_seccomp(
+        &mut docker,
+        options.engine().kind,
+        options.target(),
+        paths.metadata(),
+    )
+    .wrap_err("when copying seccomp profile")?;
+    docker_user_id(&mut docker, options.engine().kind);
 
     docker
         .args(&["-v", &format!("{}:/xargo:Z", dirs.xargo.to_utf8()?)])
@@ -68,7 +58,7 @@ pub(crate) fn run(
     docker
         .args(&["-v", &format!("{}:/rust:Z,ro", dirs.sysroot.to_utf8()?)])
         .args(&["-v", &format!("{}:/target:Z", dirs.target.to_utf8()?)]);
-    docker_cwd(&mut docker, metadata, &dirs, cwd, mount_volumes)?;
+    docker_cwd(&mut docker, &paths, mount_volumes)?;
 
     // When running inside NixOS or using Nix packaging we need to add the Nix
     // Store to the running container so it can load the needed binaries.
@@ -85,9 +75,10 @@ pub(crate) fn run(
             docker.arg("-t");
         }
     }
-    let mut image = image_name(config, target)?;
-    if needs_custom_image(target, config) {
-        image = custom_image_build(target, config, metadata, dirs, engine, msg_info)
+    let mut image = options.image_name()?;
+    if options.needs_custom_image() {
+        image = options
+            .custom_image_build(&paths, msg_info)
             .wrap_err("when building custom image")?
     }
 

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -12,7 +12,7 @@ use crate::extensions::{CommandExt, SafeCommand};
 use crate::file::{self, write_file, PathExt, ToUtf8};
 use crate::id;
 use crate::rustc::{self, VersionMetaExt};
-use crate::shell::{self, MessageInfo, Verbosity};
+use crate::shell::{MessageInfo, Verbosity};
 use crate::Target;
 
 pub use super::custom::CROSS_CUSTOM_DOCKERFILE_IMAGE_PREFIX;
@@ -27,6 +27,217 @@ const DOCKER_IMAGES: &[&str] = &include!(concat!(env!("OUT_DIR"), "/docker-image
 // note that we've allow listed `clone` and `clone3`, which is necessary
 // to fork the process, and which podman allows by default.
 pub(crate) const SECCOMP: &str = include_str!("seccomp.json");
+
+#[derive(Debug)]
+pub struct DockerOptions {
+    engine: Engine,
+    target: Target,
+    config: Config,
+    uses_xargo: bool,
+}
+
+impl DockerOptions {
+    pub fn new(engine: Engine, target: Target, config: Config, uses_xargo: bool) -> DockerOptions {
+        DockerOptions {
+            engine,
+            target,
+            config,
+            uses_xargo,
+        }
+    }
+
+    pub fn in_docker(&self) -> bool {
+        self.engine.in_docker
+    }
+
+    pub fn is_remote(&self) -> bool {
+        self.engine.is_remote
+    }
+
+    pub fn uses_xargo(&self) -> bool {
+        self.uses_xargo
+    }
+
+    pub fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    pub fn target(&self) -> &Target {
+        &self.target
+    }
+
+    pub fn needs_custom_image(&self) -> bool {
+        self.config()
+            .dockerfile(self.target())
+            .unwrap_or_default()
+            .is_some()
+            || !self
+                .config()
+                .pre_build(self.target())
+                .unwrap_or_default()
+                .unwrap_or_default()
+                .is_empty()
+    }
+
+    pub(crate) fn custom_image_build(
+        &self,
+        paths: &DockerPaths,
+        msg_info: &mut MessageInfo,
+    ) -> Result<String> {
+        let mut image = image_name(self.config(), self.target())?;
+
+        if let Some(path) = self.config().dockerfile(self.target())? {
+            let context = self.config().dockerfile_context(self.target())?;
+            let name = self.config().image(self.target())?;
+
+            let build = Dockerfile::File {
+                path: &path,
+                context: context.as_deref(),
+                name: name.as_deref(),
+            };
+
+            image = build
+                .build(
+                    self,
+                    paths,
+                    self.config()
+                        .dockerfile_build_args(self.target())?
+                        .unwrap_or_default(),
+                    msg_info,
+                )
+                .wrap_err("when building dockerfile")?;
+        }
+        let pre_build = self.config().pre_build(self.target())?;
+
+        if let Some(pre_build) = pre_build {
+            if !pre_build.is_empty() {
+                let custom = Dockerfile::Custom {
+                    content: format!(
+                        r#"
+        FROM {image}
+        ARG CROSS_DEB_ARCH=
+        ARG CROSS_CMD
+        RUN eval "${{CROSS_CMD}}""#
+                    ),
+                };
+                custom
+                    .build(
+                        self,
+                        paths,
+                        Some(("CROSS_CMD", pre_build.join("\n"))),
+                        msg_info,
+                    )
+                    .wrap_err("when pre-building")
+                    .with_note(|| format!("CROSS_CMD={}", pre_build.join("\n")))?;
+                image = custom.image_name(self.target(), paths.metadata())?;
+            }
+        }
+        Ok(image)
+    }
+
+    pub(crate) fn image_name(&self) -> Result<String> {
+        if let Some(image) = self.config().image(self.target())? {
+            return Ok(image);
+        }
+
+        if !DOCKER_IMAGES.contains(&self.target().triple()) {
+            eyre::bail!(
+                "`cross` does not provide a Docker image for target {target}, \
+                   specify a custom image in `Cross.toml`.",
+                target = self.target()
+            );
+        }
+
+        let version = if include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt")).is_empty() {
+            env!("CARGO_PKG_VERSION")
+        } else {
+            "main"
+        };
+
+        Ok(format!(
+            "{CROSS_IMAGE}/{target}:{version}",
+            target = self.target()
+        ))
+    }
+}
+
+#[derive(Debug)]
+pub struct DockerPaths {
+    mount_finder: MountFinder,
+    metadata: CargoMetadata,
+    cwd: PathBuf,
+    sysroot: PathBuf,
+    directories: Directories,
+}
+
+impl DockerPaths {
+    pub fn create(
+        engine: &Engine,
+        metadata: CargoMetadata,
+        cwd: PathBuf,
+        sysroot: PathBuf,
+    ) -> Result<Self> {
+        let mount_finder = MountFinder::create(engine)?;
+        let directories = Directories::create(&mount_finder, &metadata, &cwd, &sysroot)?;
+        Ok(Self {
+            mount_finder,
+            metadata,
+            cwd,
+            sysroot,
+            directories,
+        })
+    }
+
+    pub fn mount_finder(&self) -> &MountFinder {
+        &self.mount_finder
+    }
+
+    pub fn metadata(&self) -> &CargoMetadata {
+        &self.metadata
+    }
+
+    pub fn cwd(&self) -> &Path {
+        &self.cwd
+    }
+
+    pub fn sysroot(&self) -> &Path {
+        &self.sysroot
+    }
+
+    pub fn directories(&self) -> &Directories {
+        &self.directories
+    }
+
+    pub fn workspace_root(&self) -> &Path {
+        &self.metadata().workspace_root
+    }
+
+    pub fn workspace_dependencies(&self) -> impl Iterator<Item = &Path> {
+        self.metadata().path_dependencies()
+    }
+
+    pub fn workspace_from_cwd(&self) -> Result<&Path> {
+        self.cwd()
+            .strip_prefix(self.workspace_root())
+            .map_err(Into::into)
+    }
+
+    pub fn in_workspace(&self) -> bool {
+        self.workspace_from_cwd().is_ok()
+    }
+
+    pub fn mount_cwd(&self) -> &str {
+        &self.directories().mount_cwd
+    }
+
+    pub fn host_root(&self) -> &Path {
+        &self.directories().host_root
+    }
+}
 
 #[derive(Debug)]
 pub struct Directories {
@@ -141,10 +352,9 @@ pub fn get_package_info(
     engine: &Engine,
     target: &str,
     channel: Option<&str>,
-    docker_in_docker: bool,
-    msg_info: MessageInfo,
+    msg_info: &mut MessageInfo,
 ) -> Result<(Target, CargoMetadata, Directories)> {
-    let target_list = rustc::target_list((msg_info.color_choice, Verbosity::Quiet).into())?;
+    let target_list = msg_info.as_quiet(rustc::target_list)?;
     let target = Target::from(target, &target_list);
     let metadata = cargo_metadata_with_args(None, None, msg_info)?
         .ok_or(eyre::eyre!("unable to get project metadata"))?;
@@ -153,14 +363,14 @@ pub fn get_package_info(
     let host = host_meta.host();
 
     let sysroot = rustc::get_sysroot(&host, &target, channel, msg_info)?.1;
-    let mount_finder = MountFinder::create(engine, docker_in_docker)?;
+    let mount_finder = MountFinder::create(engine)?;
     let dirs = Directories::create(&mount_finder, &metadata, &cwd, &sysroot)?;
 
     Ok((target, metadata, dirs))
 }
 
 /// Register binfmt interpreters
-pub(crate) fn register(engine: &Engine, target: &Target, msg_info: MessageInfo) -> Result<()> {
+pub(crate) fn register(engine: &Engine, target: &Target, msg_info: &mut MessageInfo) -> Result<()> {
     let cmd = if target.is_windows() {
         // https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html
         "mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc && \
@@ -255,7 +465,7 @@ pub(crate) fn docker_envvars(
     docker: &mut Command,
     config: &Config,
     target: &Target,
-    msg_info: MessageInfo,
+    msg_info: &mut MessageInfo,
 ) -> Result<()> {
     for ref var in config.env_passthrough(target)?.unwrap_or_default() {
         validate_env_var(var)?;
@@ -289,10 +499,7 @@ pub(crate) fn docker_envvars(
 
     if let Ok(value) = env::var("CROSS_CONTAINER_OPTS") {
         if env::var("DOCKER_OPTS").is_ok() {
-            shell::warn(
-                "using both `CROSS_CONTAINER_OPTS` and `DOCKER_OPTS`.",
-                msg_info,
-            )?;
+            msg_info.warn("using both `CROSS_CONTAINER_OPTS` and `DOCKER_OPTS`.")?;
         }
         docker.args(&parse_docker_opts(&value)?);
     } else if let Ok(value) = env::var("DOCKER_OPTS") {
@@ -305,44 +512,41 @@ pub(crate) fn docker_envvars(
 
 pub(crate) fn docker_cwd(
     docker: &mut Command,
-    metadata: &CargoMetadata,
-    dirs: &Directories,
-    cwd: &Path,
+    paths: &DockerPaths,
     mount_volumes: bool,
 ) -> Result<()> {
     if mount_volumes {
-        docker.args(&["-w", &dirs.mount_cwd]);
-    } else if dirs.mount_cwd == metadata.workspace_root.to_utf8()? {
+        docker.args(&["-w", paths.mount_cwd()]);
+    } else if paths.mount_cwd() == paths.workspace_root().to_utf8()? {
         docker.args(&["-w", "/project"]);
     } else {
         // We do this to avoid clashes with path separators. Windows uses `\` as a path separator on Path::join
-        let cwd = &cwd;
-        let working_dir = Path::new("/project").join(cwd.strip_prefix(&metadata.workspace_root)?);
+        let working_dir = Path::new("/project").join(paths.workspace_from_cwd()?);
         docker.args(&["-w", &working_dir.as_posix()?]);
     }
 
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)] // TODO: refactor
 pub(crate) fn docker_mount(
     docker: &mut Command,
-    metadata: &CargoMetadata,
-    mount_finder: &MountFinder,
-    config: &Config,
-    target: &Target,
-    cwd: &Path,
+    options: &DockerOptions,
+    paths: &DockerPaths,
     mount_cb: impl Fn(&mut Command, &Path) -> Result<String>,
     mut store_cb: impl FnMut((String, String)),
 ) -> Result<bool> {
     let mut mount_volumes = false;
     // FIXME(emilgardis 2022-04-07): This is a fallback so that if it's hard for us to do mounting logic, make it simple(r)
     // Preferably we would not have to do this.
-    if cwd.strip_prefix(&metadata.workspace_root).is_err() {
+    if !paths.in_workspace() {
         mount_volumes = true;
     }
 
-    for ref var in config.env_volumes(target)?.unwrap_or_default() {
+    for ref var in options
+        .config
+        .env_volumes(options.target())?
+        .unwrap_or_default()
+    {
         let (var, value) = validate_env_var(var)?;
         let value = match value {
             Some(v) => Ok(v.to_string()),
@@ -351,7 +555,7 @@ pub(crate) fn docker_mount(
 
         if let Ok(val) = value {
             let canonical_val = file::canonicalize(&val)?;
-            let host_path = mount_finder.find_path(&canonical_val, true)?;
+            let host_path = paths.mount_finder().find_path(&canonical_val, true)?;
             let mount_path = mount_cb(docker, host_path.as_ref())?;
             docker.args(&["-e", &format!("{}={}", host_path, mount_path)]);
             store_cb((val, mount_path));
@@ -359,9 +563,9 @@ pub(crate) fn docker_mount(
         }
     }
 
-    for path in metadata.path_dependencies() {
+    for path in paths.workspace_dependencies() {
         let canonical_path = file::canonicalize(path)?;
-        let host_path = mount_finder.find_path(&canonical_path, true)?;
+        let host_path = paths.mount_finder().find_path(&canonical_path, true)?;
         let mount_path = mount_cb(docker, host_path.as_ref())?;
         store_cb((path.to_utf8()?.to_string(), mount_path));
         mount_volumes = true;
@@ -454,78 +658,6 @@ pub(crate) fn docker_seccomp(
     Ok(())
 }
 
-pub fn needs_custom_image(target: &Target, config: &Config) -> bool {
-    config.dockerfile(target).unwrap_or_default().is_some()
-        || !config
-            .pre_build(target)
-            .unwrap_or_default()
-            .unwrap_or_default()
-            .is_empty()
-}
-
-pub(crate) fn custom_image_build(
-    target: &Target,
-    config: &Config,
-    metadata: &CargoMetadata,
-    Directories { host_root, .. }: Directories,
-    engine: &Engine,
-    msg_info: MessageInfo,
-) -> Result<String> {
-    let mut image = image_name(config, target)?;
-
-    if let Some(path) = config.dockerfile(target)? {
-        let context = config.dockerfile_context(target)?;
-        let name = config.image(target)?;
-
-        let build = Dockerfile::File {
-            path: &path,
-            context: context.as_deref(),
-            name: name.as_deref(),
-        };
-
-        image = build
-            .build(
-                config,
-                metadata,
-                engine,
-                &host_root,
-                config.dockerfile_build_args(target)?.unwrap_or_default(),
-                target,
-                msg_info,
-            )
-            .wrap_err("when building dockerfile")?;
-    }
-    let pre_build = config.pre_build(target)?;
-
-    if let Some(pre_build) = pre_build {
-        if !pre_build.is_empty() {
-            let custom = Dockerfile::Custom {
-                content: format!(
-                    r#"
-    FROM {image}
-    ARG CROSS_DEB_ARCH=
-    ARG CROSS_CMD
-    RUN eval "${{CROSS_CMD}}""#
-                ),
-            };
-            custom
-                .build(
-                    config,
-                    metadata,
-                    engine,
-                    &host_root,
-                    Some(("CROSS_CMD", pre_build.join("\n"))),
-                    target,
-                    msg_info,
-                )
-                .wrap_err("when pre-building")
-                .with_note(|| format!("CROSS_CMD={}", pre_build.join("\n")))?;
-            image = custom.image_name(target, metadata)?;
-        }
-    }
-    Ok(image)
-}
-
 pub(crate) fn image_name(config: &Config, target: &Target) -> Result<String> {
     if let Some(image) = config.image(target)? {
         return Ok(image);
@@ -556,7 +688,7 @@ fn docker_read_mount_paths(engine: &Engine) -> Result<Vec<MountDetail>> {
         command
     };
 
-    let output = docker.run_and_get_stdout(Verbosity::Quiet.into())?;
+    let output = docker.run_and_get_stdout(&mut Verbosity::Quiet.into())?;
     let info = serde_json::from_str(&output).wrap_err("failed to parse docker inspect output")?;
     dockerinfo_parse_mounts(&info)
 }
@@ -631,8 +763,8 @@ impl MountFinder {
         MountFinder { mounts }
     }
 
-    pub fn create(engine: &Engine, docker_in_docker: bool) -> Result<MountFinder> {
-        Ok(if docker_in_docker {
+    pub fn create(engine: &Engine) -> Result<MountFinder> {
+        Ok(if engine.in_docker {
             MountFinder::new(docker_read_mount_paths(engine)?)
         } else {
             MountFinder::default()
@@ -789,11 +921,11 @@ mod tests {
             }
         }
 
-        fn create_engine(msg_info: MessageInfo) -> Result<Engine> {
-            Engine::from_path(get_container_engine()?, Some(false), msg_info)
+        fn create_engine(msg_info: &mut MessageInfo) -> Result<Engine> {
+            Engine::from_path(get_container_engine()?, None, Some(false), msg_info)
         }
 
-        fn cargo_metadata(subdir: bool, msg_info: MessageInfo) -> Result<CargoMetadata> {
+        fn cargo_metadata(subdir: bool, msg_info: &mut MessageInfo) -> Result<CargoMetadata> {
             let mut metadata = cargo_metadata_with_args(
                 Some(Path::new(env!("CARGO_MANIFEST_DIR"))),
                 None,
@@ -860,7 +992,7 @@ mod tests {
         fn test_host() -> Result<()> {
             let vars = unset_env();
             let mount_finder = MountFinder::new(vec![]);
-            let metadata = cargo_metadata(false, MessageInfo::default())?;
+            let metadata = cargo_metadata(false, &mut MessageInfo::default())?;
             let directories = get_directories(&metadata, &mount_finder)?;
             paths_equal(&directories.cargo, &home()?.join(".cargo"))?;
             paths_equal(&directories.xargo, &home()?.join(".xargo"))?;
@@ -880,7 +1012,8 @@ mod tests {
         fn test_docker_in_docker() -> Result<()> {
             let vars = unset_env();
 
-            let engine = create_engine(MessageInfo::default());
+            let mut msg_info = MessageInfo::default();
+            let engine = create_engine(&mut msg_info);
             let hostname = env::var("HOSTNAME");
             if engine.is_err() || hostname.is_err() {
                 eprintln!("could not get container engine or no hostname found");
@@ -888,18 +1021,23 @@ mod tests {
                 return Ok(());
             }
             let engine = engine.unwrap();
+            if !engine.in_docker {
+                eprintln!("not in docker");
+                reset_env(vars);
+                return Ok(());
+            }
             let hostname = hostname.unwrap();
             let output = subcommand(&engine, "inspect")
                 .arg(hostname)
-                .run_and_get_output(MessageInfo::default())?;
+                .run_and_get_output(&mut msg_info)?;
             if !output.status.success() {
                 eprintln!("inspect failed");
                 reset_env(vars);
                 return Ok(());
             }
 
-            let mount_finder = MountFinder::create(&engine, true)?;
-            let metadata = cargo_metadata(true, MessageInfo::default())?;
+            let mount_finder = MountFinder::create(&engine)?;
+            let metadata = cargo_metadata(true, &mut msg_info)?;
             let directories = get_directories(&metadata, &mount_finder)?;
             let mount_finder = MountFinder::new(docker_read_mount_paths(&engine)?);
             let mount_path = |p| mount_finder.find_mount_path(p);

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -3,42 +3,45 @@ use std::fmt;
 use std::process::{Command, ExitStatus, Output};
 
 use crate::errors::*;
-use crate::shell::{self, MessageInfo, Verbosity};
+use crate::shell::MessageInfo;
 
 pub const STRIPPED_BINS: &[&str] = &[crate::docker::DOCKER, crate::docker::PODMAN, "cargo"];
 
 pub trait CommandExt {
-    fn fmt_message(&self, msg_info: MessageInfo) -> String;
+    fn fmt_message(&self, msg_info: &mut MessageInfo) -> String;
 
-    fn print(&self, msg_info: MessageInfo) -> Result<()> {
-        shell::print(&self.fmt_message(msg_info), msg_info)
+    fn print(&self, msg_info: &mut MessageInfo) -> Result<()> {
+        let msg = self.fmt_message(msg_info);
+        msg_info.print(&msg)
     }
 
-    fn info(&self, msg_info: MessageInfo) -> Result<()> {
-        shell::info(&self.fmt_message(msg_info), msg_info)
+    fn info(&self, msg_info: &mut MessageInfo) -> Result<()> {
+        let msg = self.fmt_message(msg_info);
+        msg_info.info(&msg)
     }
 
-    fn debug(&self, msg_info: MessageInfo) -> Result<()> {
-        shell::debug(&self.fmt_message(msg_info), msg_info)
+    fn debug(&self, msg_info: &mut MessageInfo) -> Result<()> {
+        let msg = self.fmt_message(msg_info);
+        msg_info.debug(&msg)
     }
 
     fn status_result(
         &self,
-        msg_info: MessageInfo,
+        msg_info: &mut MessageInfo,
         status: ExitStatus,
         output: Option<&Output>,
     ) -> Result<(), CommandError>;
-    fn run(&mut self, msg_info: MessageInfo, silence_stdout: bool) -> Result<()>;
+    fn run(&mut self, msg_info: &mut MessageInfo, silence_stdout: bool) -> Result<()>;
     fn run_and_get_status(
         &mut self,
-        msg_info: MessageInfo,
+        msg_info: &mut MessageInfo,
         silence_stdout: bool,
     ) -> Result<ExitStatus>;
-    fn run_and_get_stdout(&mut self, msg_info: MessageInfo) -> Result<String>;
-    fn run_and_get_output(&mut self, msg_info: MessageInfo) -> Result<std::process::Output>;
+    fn run_and_get_stdout(&mut self, msg_info: &mut MessageInfo) -> Result<String>;
+    fn run_and_get_output(&mut self, msg_info: &mut MessageInfo) -> Result<std::process::Output>;
     fn command_pretty(
         &self,
-        msg_info: MessageInfo,
+        msg_info: &mut MessageInfo,
         strip: impl for<'a> Fn(&'a str) -> bool,
     ) -> String;
 }
@@ -46,12 +49,12 @@ pub trait CommandExt {
 impl CommandExt for Command {
     fn command_pretty(
         &self,
-        msg_info: MessageInfo,
+        msg_info: &mut MessageInfo,
         strip: impl for<'a> Fn(&'a str) -> bool,
     ) -> String {
         // a dummy implementor of display to avoid using unwraps
-        struct C<'c, F>(&'c Command, MessageInfo, F);
-        impl<F> std::fmt::Display for C<'_, F>
+        struct C<'c, 'd, F>(&'c Command, &'d mut MessageInfo, F);
+        impl<'e, 'f, F> std::fmt::Display for C<'e, 'f, F>
         where
             F: for<'a> Fn(&'a str) -> bool,
         {
@@ -61,7 +64,7 @@ impl CommandExt for Command {
                     f,
                     "{}",
                     // if verbose, never strip, if not, let user choose
-                    crate::file::pretty_path(cmd.get_program(), move |c| if self.1.verbose() {
+                    crate::file::pretty_path(cmd.get_program(), move |c| if self.1.is_verbose() {
                         false
                     } else {
                         self.2(c)
@@ -81,18 +84,25 @@ impl CommandExt for Command {
         format!("{}", C(self, msg_info, strip))
     }
 
-    fn fmt_message(&self, msg_info: MessageInfo) -> String {
-        let verbose = (msg_info.color_choice, Verbosity::Verbose).into();
+    fn fmt_message(&self, mut msg_info: &mut MessageInfo) -> String {
+        let msg_info = &mut msg_info;
         if let Some(cwd) = self.get_current_dir() {
-            format!("+ {:?} {}", cwd, self.command_pretty(verbose, |_| false))
+            format!(
+                "+ {:?} {}",
+                cwd,
+                msg_info.as_verbose(|info| self.command_pretty(info, |_| false))
+            )
         } else {
-            format!("+ {}", self.command_pretty(verbose, |_| false))
+            format!(
+                "+ {}",
+                msg_info.as_verbose(|info| self.command_pretty(info, |_| false))
+            )
         }
     }
 
     fn status_result(
         &self,
-        msg_info: MessageInfo,
+        msg_info: &mut MessageInfo,
         status: ExitStatus,
         output: Option<&Output>,
     ) -> Result<(), CommandError> {
@@ -110,7 +120,7 @@ impl CommandExt for Command {
     }
 
     /// Runs the command to completion
-    fn run(&mut self, msg_info: MessageInfo, silence_stdout: bool) -> Result<()> {
+    fn run(&mut self, msg_info: &mut MessageInfo, silence_stdout: bool) -> Result<()> {
         let status = self.run_and_get_status(msg_info, silence_stdout)?;
         self.status_result(msg_info, status, None)
             .map_err(Into::into)
@@ -119,11 +129,11 @@ impl CommandExt for Command {
     /// Runs the command to completion
     fn run_and_get_status(
         &mut self,
-        msg_info: MessageInfo,
+        msg_info: &mut MessageInfo,
         silence_stdout: bool,
     ) -> Result<ExitStatus> {
         self.debug(msg_info)?;
-        if silence_stdout && !msg_info.verbose() {
+        if silence_stdout && msg_info.is_verbose() {
             self.stdout(std::process::Stdio::null());
         }
         self.status()
@@ -136,7 +146,7 @@ impl CommandExt for Command {
     }
 
     /// Runs the command to completion and returns its stdout
-    fn run_and_get_stdout(&mut self, msg_info: MessageInfo) -> Result<String> {
+    fn run_and_get_stdout(&mut self, msg_info: &mut MessageInfo) -> Result<String> {
         let out = self.run_and_get_output(msg_info)?;
         self.status_result(msg_info, out.status, Some(&out))
             .map_err(CommandError::to_section_report)?;
@@ -148,7 +158,7 @@ impl CommandExt for Command {
     /// # Notes
     ///
     /// This command does not check the status.
-    fn run_and_get_output(&mut self, msg_info: MessageInfo) -> Result<std::process::Output> {
+    fn run_and_get_output(&mut self, msg_info: &mut MessageInfo) -> Result<std::process::Output> {
         self.debug(msg_info)?;
         self.output().map_err(|e| {
             CommandError::CouldNotExecute {

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -81,7 +81,7 @@ pub fn rustc_command() -> Command {
     Command::new(env_program("RUSTC", "rustc"))
 }
 
-pub fn target_list(msg_info: MessageInfo) -> Result<TargetList> {
+pub fn target_list(msg_info: &mut MessageInfo) -> Result<TargetList> {
     rustc_command()
         .args(&["--print", "target-list"])
         .run_and_get_stdout(msg_info)
@@ -90,7 +90,7 @@ pub fn target_list(msg_info: MessageInfo) -> Result<TargetList> {
         })
 }
 
-pub fn sysroot(host: &Host, target: &Target, msg_info: MessageInfo) -> Result<PathBuf> {
+pub fn sysroot(host: &Host, target: &Target, msg_info: &mut MessageInfo) -> Result<PathBuf> {
     let mut stdout = rustc_command()
         .args(&["--print", "sysroot"])
         .run_and_get_stdout(msg_info)?
@@ -109,7 +109,7 @@ pub fn get_sysroot(
     host: &Host,
     target: &Target,
     channel: Option<&str>,
-    msg_info: MessageInfo,
+    msg_info: &mut MessageInfo,
 ) -> Result<(String, PathBuf)> {
     let mut sysroot = sysroot(host, target, msg_info)?;
     let default_toolchain = sysroot

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,15 +13,12 @@ static WORKSPACE: OnceCell<PathBuf> = OnceCell::new();
 /// Returns the cargo workspace for the manifest
 pub fn get_cargo_workspace() -> &'static Path {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let mut msg_info = crate::shell::Verbosity::Verbose.into();
     WORKSPACE.get_or_init(|| {
-        crate::cargo_metadata_with_args(
-            Some(manifest_dir.as_ref()),
-            None,
-            crate::shell::Verbosity::Verbose.into(),
-        )
-        .unwrap()
-        .unwrap()
-        .workspace_root
+        crate::cargo_metadata_with_args(Some(manifest_dir.as_ref()), None, &mut msg_info)
+            .unwrap()
+            .unwrap()
+            .workspace_root
     })
 }
 
@@ -73,6 +70,7 @@ release: {version}
     fn compare(expected: VersionMatch, host: &str, targ: &str) {
         let host_meta = dbg!(make_meta(host));
         let target_meta = dbg!(make_rustc_version(targ));
+        let mut msg_info = crate::shell::MessageInfo::default();
         assert_eq!(
             expected,
             warn_host_version_mismatch(
@@ -80,7 +78,7 @@ release: {version}
                 "xxxx",
                 &target_meta.0,
                 &target_meta.1,
-                crate::shell::MessageInfo::default()
+                &mut msg_info,
             )
             .unwrap(),
             "\nhost = {}\ntarg = {}",

--- a/src/tests/toml.rs
+++ b/src/tests/toml.rs
@@ -59,17 +59,12 @@ fn toml_check() -> Result<(), Box<dyn std::error::Error>> {
                 dir_entry.path().to_utf8()?,
                 text_line_no(&contents, fence.range().start),
             );
+            let mut msg_info = crate::shell::MessageInfo::default();
             assert!(if !cargo {
-                crate::cross_toml::CrossToml::parse_from_cross(
-                    &fence_content,
-                    crate::shell::MessageInfo::default(),
-                )?
+                crate::cross_toml::CrossToml::parse_from_cross(&fence_content, &mut msg_info)?
             } else {
-                crate::cross_toml::CrossToml::parse_from_cargo(
-                    &fence_content,
-                    crate::shell::MessageInfo::default(),
-                )?
-                .unwrap_or_default()
+                crate::cross_toml::CrossToml::parse_from_cargo(&fence_content, &mut msg_info)?
+                    .unwrap_or_default()
             }
             .1
             .is_empty());

--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use crate::util::{cargo_metadata, gha_error, gha_output, gha_print};
 use clap::Args;
-use cross::shell::{self, MessageInfo};
+use cross::shell::MessageInfo;
 use cross::{docker, CommandExt, ToUtf8};
 
 #[derive(Args, Debug)]
@@ -97,8 +97,6 @@ pub fn build_docker_image(
         repository,
         labels,
         verbose,
-        quiet,
-        color,
         dry_run,
         force,
         push,
@@ -112,8 +110,8 @@ pub fn build_docker_image(
         ..
     }: BuildDockerImage,
     engine: &docker::Engine,
+    msg_info: &mut MessageInfo,
 ) -> cross::Result<()> {
-    let msg_info = MessageInfo::create(verbose != 0, quiet, color.as_deref())?;
     let metadata = cargo_metadata(msg_info)?;
     let version = metadata
         .get_package("cross")
@@ -261,7 +259,7 @@ pub fn build_docker_image(
         } else {
             docker_build.print(msg_info)?;
             if !dry_run {
-                shell::fatal("refusing to push, use --force to override", msg_info, 1);
+                msg_info.fatal("refusing to push, use --force to override", 1);
             }
         }
         if gha {

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -79,7 +79,7 @@ pub fn ci(args: CiJob, metadata: CargoMetadata) -> cross::Result<()> {
                 let search = cargo_command()
                     .args(&["search", "--limit", "1"])
                     .arg("cross")
-                    .run_and_get_stdout(Verbosity::Verbose.into())?;
+                    .run_and_get_stdout(&mut Verbosity::Verbose.into())?;
                 let (cross, rest) = search
                     .split_once(" = ")
                     .ok_or_else(|| eyre::eyre!("cargo search failed"))?;

--- a/xtask/src/crosstool.rs
+++ b/xtask/src/crosstool.rs
@@ -200,17 +200,14 @@ CT_LINUX_VERSION=\"{linux_major}.{linux_minor}.{linux_patch}\""
 
 pub fn configure_crosstool(
     ConfigureCrosstool {
-        verbose,
-        quiet,
-        color,
         gcc_version,
         glibc_version,
         linux_version,
         mut targets,
         ..
     }: ConfigureCrosstool,
+    msg_info: &mut MessageInfo,
 ) -> cross::Result<()> {
-    let msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
     let gcc_version = gcc_version.as_deref().unwrap_or(DEFAULT_GCC_VERSION);
     let glibc_version = glibc_version.as_deref().unwrap_or(DEFAULT_GLIBC_VERSION);
     let linux_version = linux_version.as_deref().unwrap_or(DEFAULT_LINUX_VERSION);

--- a/xtask/src/install_git_hooks.rs
+++ b/xtask/src/install_git_hooks.rs
@@ -15,14 +15,7 @@ pub struct InstallGitHooks {
     pub color: Option<String>,
 }
 
-pub fn install_git_hooks(
-    InstallGitHooks {
-        verbose,
-        quiet,
-        color,
-    }: InstallGitHooks,
-) -> cross::Result<()> {
-    let msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
+pub fn install_git_hooks(msg_info: &mut MessageInfo) -> cross::Result<()> {
     let root = project_dir(msg_info)?;
     let git_hooks = root.join(".git").join("hooks");
     let cross_dev = root.join("xtask").join("src");

--- a/xtask/src/target_info.rs
+++ b/xtask/src/target_info.rs
@@ -41,7 +41,7 @@ fn image_info(
     target: &crate::ImageTarget,
     image: &str,
     tag: &str,
-    msg_info: MessageInfo,
+    msg_info: &mut MessageInfo,
     has_test: bool,
 ) -> cross::Result<()> {
     if !tag.starts_with("local") {
@@ -60,24 +60,21 @@ fn image_info(
     command.arg(image);
     command.args(&["bash", "-c", TARGET_INFO_SCRIPT]);
     command
-        .run(msg_info, !msg_info.verbose())
+        .run(msg_info, msg_info.is_verbose())
         .map_err(Into::into)
 }
 
 pub fn target_info(
     TargetInfo {
         mut targets,
-        verbose,
-        quiet,
-        color,
         registry,
         repository,
         tag,
         ..
     }: TargetInfo,
     engine: &docker::Engine,
+    msg_info: &mut MessageInfo,
 ) -> cross::Result<()> {
-    let msg_info = MessageInfo::create(verbose, quiet, color.as_deref())?;
     let matrix = crate::util::get_matrix();
     let test_map: BTreeMap<crate::ImageTarget, bool> = matrix
         .iter()

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -90,7 +90,7 @@ pub fn format_repo(registry: &str, repository: &str) -> String {
 pub fn pull_image(
     engine: &docker::Engine,
     image: &str,
-    msg_info: MessageInfo,
+    msg_info: &mut MessageInfo,
 ) -> cross::Result<()> {
     let mut command = docker::subcommand(engine, "pull");
     command.arg(image);
@@ -159,7 +159,7 @@ impl std::fmt::Display for ImageTarget {
     }
 }
 
-pub fn has_nightly(msg_info: MessageInfo) -> cross::Result<bool> {
+pub fn has_nightly(msg_info: &mut MessageInfo) -> cross::Result<bool> {
     cross::cargo_command()
         .arg("+nightly")
         .run_and_get_output(msg_info)
@@ -167,10 +167,10 @@ pub fn has_nightly(msg_info: MessageInfo) -> cross::Result<bool> {
         .map_err(Into::into)
 }
 
-pub fn get_channel_prefer_nightly(
-    msg_info: MessageInfo,
-    toolchain: Option<&str>,
-) -> cross::Result<Option<&str>> {
+pub fn get_channel_prefer_nightly<'a>(
+    msg_info: &mut MessageInfo,
+    toolchain: Option<&'a str>,
+) -> cross::Result<Option<&'a str>> {
     Ok(match toolchain {
         Some(t) => Some(t),
         None => match has_nightly(msg_info)? {
@@ -188,12 +188,12 @@ pub fn cargo(channel: Option<&str>) -> Command {
     command
 }
 
-pub fn cargo_metadata(msg_info: MessageInfo) -> cross::Result<cross::CargoMetadata> {
+pub fn cargo_metadata(msg_info: &mut MessageInfo) -> cross::Result<cross::CargoMetadata> {
     cross::cargo_metadata_with_args(Some(Path::new(env!("CARGO_MANIFEST_DIR"))), None, msg_info)?
         .ok_or_else(|| eyre::eyre!("could not find cross workspace"))
 }
 
-pub fn project_dir(msg_info: MessageInfo) -> cross::Result<PathBuf> {
+pub fn project_dir(msg_info: &mut MessageInfo) -> cross::Result<PathBuf> {
     Ok(cargo_metadata(msg_info)?.workspace_root)
 }
 
@@ -216,7 +216,7 @@ pub fn gha_output(tag: &str, content: &str) {
     println!("::set-output name={tag}::{}", content)
 }
 
-pub fn read_dockerfiles(msg_info: MessageInfo) -> cross::Result<Vec<(PathBuf, String)>> {
+pub fn read_dockerfiles(msg_info: &mut MessageInfo) -> cross::Result<Vec<(PathBuf, String)>> {
     let root = project_dir(msg_info)?;
     let docker = root.join("docker");
     let mut dockerfiles = vec![];
@@ -244,7 +244,8 @@ mod tests {
     fn check_ubuntu_base() -> cross::Result<()> {
         // count all the entries of FROM for our images
         let mut counts = BTreeMap::new();
-        let dockerfiles = read_dockerfiles(Verbosity::Verbose.into())?;
+        let mut msg_info = Verbosity::Verbose.into();
+        let dockerfiles = read_dockerfiles(&mut msg_info)?;
         for (path, dockerfile) in dockerfiles {
             let lines: Vec<&str> = dockerfile.lines().collect();
             let index = lines


### PR DESCRIPTION
Reduces the number of arguments to the function signatures, making the code much easier to understand, and relocates some things. For example, `docker_in_docker` is now associated with `Engine`, and now with `cli::Args`. Likewise, unstable doctests is now a part of `Environment` and not `cli::Args`. `MessageInfo` now stores mutable state (needs to clear lines) and is no longer copyable, and a single instance is created in lib and passed around everywhere as a mutable reference.

The changes with `MessageInfo` will allow us to erase lines in the future, both from `stderr` and `stdout`, which we currently don't use but will allow us to close #859.

 This also fixes an issue where `-vv+` was not recognized as a valid verbose flag: `cargo` can handle 1 or more `v` characters. Also allowed parsing of `--color=value` args, when we previously only accepted `--color value`.