### PR TITLE
Support cargo term variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- #921 - use `CARGO_TERM_VERBOSE`, `CARGO_TERM_QUIET`, and `CARGO_TERM_COLOR` environment variables for cross terminal output.
 - #913 - added the `x86_64-unknown-illumos` target.
 - #905 - added `qemu-runner` for musl images, allowing use of native or emulated runners.
 - #905 - added qemu emulation to `i586-unknown-linux-gnu`, `i686-unknown-linux-musl`, and `i586-unknown-linux-gnu`, so they can run on an `x86` CPU, rather than an `x86_64` CPU.

--- a/src/bin/commands/clean.rs
+++ b/src/bin/commands/clean.rs
@@ -13,7 +13,7 @@ pub struct Clean {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
     /// Force removal of images.

--- a/src/bin/commands/containers.rs
+++ b/src/bin/commands/containers.rs
@@ -12,7 +12,7 @@ pub struct ListVolumes {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
     /// Container engine (such as docker or podman).
@@ -34,7 +34,7 @@ pub struct RemoveAllVolumes {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
     /// Force removal of volumes.
@@ -62,7 +62,7 @@ pub struct PruneVolumes {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
     /// Remove volumes. Default is a dry run.
@@ -93,7 +93,7 @@ pub struct CreateVolume {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
     /// Container engine (such as docker or podman).
@@ -126,7 +126,7 @@ pub struct RemoveVolume {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
     /// Container engine (such as docker or podman).
@@ -223,7 +223,7 @@ pub struct ListContainers {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
     /// Container engine (such as docker or podman).
@@ -245,7 +245,7 @@ pub struct RemoveAllContainers {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
     /// Force removal of containers.

--- a/src/bin/commands/images.rs
+++ b/src/bin/commands/images.rs
@@ -20,7 +20,7 @@ pub struct ListImages {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
     /// Container engine (such as docker or podman).
@@ -46,7 +46,7 @@ pub struct RemoveImages {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
     /// Force removal of images.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use std::{env, path::PathBuf};
 use crate::cargo::Subcommand;
 use crate::errors::Result;
 use crate::rustc::TargetList;
-use crate::shell::MessageInfo;
+use crate::shell::{self, MessageInfo};
 use crate::Target;
 
 #[derive(Debug)]
@@ -143,7 +143,6 @@ pub fn parse(target_list: &TargetList) -> Result<Args> {
     let mut quiet = false;
     let mut verbose = false;
     let mut color = None;
-    let mut default_msg_info = MessageInfo::default();
 
     {
         let mut args = env::args().skip(1);
@@ -164,7 +163,7 @@ pub fn parse(target_list: &TargetList) -> Result<Args> {
                     ArgKind::Next => {
                         match parse_next_arg(arg, &mut all, ToOwned::to_owned, &mut args) {
                             Some(c) => Some(c),
-                            None => default_msg_info.fatal_usage("--color <WHEN>", 1),
+                            None => shell::invalid_color(None),
                         }
                     }
                     ArgKind::Equal => Some(parse_equal_arg(arg, &mut all, ToOwned::to_owned)),

--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -29,7 +29,7 @@ pub struct BuildDockerImage {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
     /// Print but do not execute the build commands.
@@ -112,6 +112,10 @@ pub fn build_docker_image(
     engine: &docker::Engine,
     msg_info: &mut MessageInfo,
 ) -> cross::Result<()> {
+    let verbose = match verbose {
+        0 => msg_info.is_verbose() as u8,
+        v => v,
+    };
     let metadata = cargo_metadata(msg_info)?;
     let version = metadata
         .get_package("cross")

--- a/xtask/src/crosstool.rs
+++ b/xtask/src/crosstool.rs
@@ -23,7 +23,7 @@ pub struct ConfigureCrosstool {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
     /// The gcc version to configure for.

--- a/xtask/src/hooks.rs
+++ b/xtask/src/hooks.rs
@@ -18,7 +18,7 @@ pub struct Check {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
     /// Run shellcheck on all files, not just staged files.
@@ -34,7 +34,7 @@ pub struct Test {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
 }

--- a/xtask/src/install_git_hooks.rs
+++ b/xtask/src/install_git_hooks.rs
@@ -10,7 +10,7 @@ pub struct InstallGitHooks {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
 }

--- a/xtask/src/target_info.rs
+++ b/xtask/src/target_info.rs
@@ -19,7 +19,7 @@ pub struct TargetInfo {
     /// Do not print cross log messages.
     #[clap(short, long)]
     pub quiet: bool,
-    /// Whether messages should use color output.
+    /// Coloring: auto, always, never
     #[clap(long)]
     pub color: Option<String>,
     /// Image registry.


### PR DESCRIPTION
Use the `CARGO_TERM_VERBOSE`, `CARGO_TERM_QUIET`, and `CARGO_TERM_COLOR` environment variables for cross terminal output. This enables us to detect term settings via environment variables, which are overridden by command-line flags, which is our own behavior.

Cargo has CLI flags override environment variables, and verbose and quiet cannot be set for the same level. So if `CARGO_TERM_VERBOSE=true` and `--quiet` are used, then we use the quiet setting, but if `--verbose` and `--quiet` are used, then we print a fatal error message.

Closes #919.