### PR TITLE
Deny installation of conflicting Debian packages.

### DIFF
--- a/.changes/931.json
+++ b/.changes/931.json
@@ -1,0 +1,4 @@
+{
+    "description": "deny installation of debian packages that conflict with our cross-compiler toolchains.",
+    "type": "fixed"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [v0.2.4] - 2022-07-10
 
-## Fixed
+### Fixed
 
 - #930 - fix any parsing of 1-character subcommands
 - #929 - Fixed issue where `--verbose` would not output data when it should

--- a/docker/Dockerfile.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu
@@ -14,6 +14,11 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-aarch64-linux-gnu \
     libc6-dev-arm64-cross
 
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=arm64 /deny-debian-packages.sh \
+    binutils \
+    binutils-aarch64-linux-gnu
+
 COPY qemu.sh /
 RUN /qemu.sh aarch64 softmmu
 

--- a/docker/Dockerfile.arm-unknown-linux-gnueabi
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabi
@@ -10,11 +10,17 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-COPY qemu.sh /
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-arm-linux-gnueabi \
-    libc6-dev-armel-cross && \
-    /qemu.sh arm
+    libc6-dev-armel-cross
+
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=armel /deny-debian-packages.sh \
+    binutils \
+    binutils-arm-linux-gnueabi
+
+COPY qemu.sh /
+RUN /qemu.sh arm
 
 COPY qemu-runner /
 

--- a/docker/Dockerfile.armv5te-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-gnueabi
@@ -10,12 +10,18 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-COPY qemu.sh /
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-arm-linux-gnueabi \
     crossbuild-essential-armel \
-    libc6-dev-armel-cross && \
-    /qemu.sh arm
+    libc6-dev-armel-cross
+
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=armel /deny-debian-packages.sh \
+    binutils \
+    binutils-arm-linux-gnueabi
+
+COPY qemu.sh /
+RUN /qemu.sh arm
 
 COPY qemu-runner /
 

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -14,6 +14,11 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-arm-linux-gnueabihf \
     libc6-dev-armhf-cross
 
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=armhf /deny-debian-packages.sh \
+    binutils \
+    binutils-arm-linux-gnueabihf
+
 COPY qemu.sh /
 RUN /qemu.sh arm softmmu
 

--- a/docker/Dockerfile.mips64-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-gnuabi64
@@ -10,11 +10,17 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-COPY qemu.sh /
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-mips64-linux-gnuabi64 \
-    libc6-dev-mips64-cross && \
-    /qemu.sh mips64
+    libc6-dev-mips64-cross
+
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=mips64 /deny-debian-packages.sh \
+    binutils \
+    binutils-mips64-linux-gnuabi64
+
+COPY qemu.sh /
+RUN /qemu.sh mips64
 
 COPY qemu-runner /
 

--- a/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
@@ -14,6 +14,11 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-mips64el-linux-gnuabi64 \
     libc6-dev-mips64el-cross
 
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=mips64el /deny-debian-packages.sh \
+    binutils \
+    binutils-mips64el-linux-gnuabi64
+
 COPY qemu.sh /
 RUN /qemu.sh mips64el softmmu
 

--- a/docker/Dockerfile.mipsel-unknown-linux-gnu
+++ b/docker/Dockerfile.mipsel-unknown-linux-gnu
@@ -14,6 +14,11 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-mipsel-linux-gnu \
     libc6-dev-mipsel-cross
 
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=mipsel /deny-debian-packages.sh \
+    binutils \
+    binutils-mipsel-linux-gnu
+
 COPY qemu.sh /
 RUN /qemu.sh mipsel softmmu
 

--- a/docker/Dockerfile.powerpc-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc-unknown-linux-gnu
@@ -14,6 +14,11 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-powerpc-linux-gnu \
     libc6-dev-powerpc-cross
 
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=powerpc /deny-debian-packages.sh \
+    binutils \
+    binutils-powerpc-linux-gnu
+
 COPY qemu.sh /
 RUN /qemu.sh ppc softmmu
 

--- a/docker/Dockerfile.powerpc64-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64-unknown-linux-gnu
@@ -14,6 +14,11 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-powerpc64-linux-gnu \
     libc6-dev-ppc64-cross
 
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=ppc64 /deny-debian-packages.sh \
+    binutils \
+    binutils-powerpc64-linux-gnu
+
 COPY qemu.sh /
 RUN /qemu.sh ppc64 softmmu
 

--- a/docker/Dockerfile.powerpc64le-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64le-unknown-linux-gnu
@@ -14,6 +14,11 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-powerpc64le-linux-gnu \
     libc6-dev-ppc64el-cross
 
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=ppc64el /deny-debian-packages.sh \
+    binutils \
+    binutils-powerpc64le-linux-gnu
+
 COPY qemu.sh /
 RUN /qemu.sh ppc64le softmmu
 

--- a/docker/Dockerfile.riscv64gc-unknown-linux-gnu
+++ b/docker/Dockerfile.riscv64gc-unknown-linux-gnu
@@ -14,6 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     g++-riscv64-linux-gnu \
     libc6-dev-riscv64-cross
 
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=riscv64 /deny-debian-packages.sh \
+    binutils \
+    binutils-riscv64-linux-gnu
+
 COPY qemu.sh /
 RUN /qemu.sh riscv64
 

--- a/docker/Dockerfile.s390x-unknown-linux-gnu
+++ b/docker/Dockerfile.s390x-unknown-linux-gnu
@@ -14,6 +14,11 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-s390x-linux-gnu \
     libc6-dev-s390x-cross
 
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=s390x /deny-debian-packages.sh \
+    binutils \
+    binutils-s390x-linux-gnu
+
 COPY qemu.sh /
 RUN /qemu.sh s390x softmmu
 

--- a/docker/Dockerfile.sparc64-unknown-linux-gnu
+++ b/docker/Dockerfile.sparc64-unknown-linux-gnu
@@ -14,6 +14,11 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-sparc64-linux-gnu \
     libc6-dev-sparc64-cross
 
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=sparc64 /deny-debian-packages.sh \
+    binutils \
+    binutils-sparc64-linux-gnu
+
 COPY qemu.sh /
 RUN /qemu.sh sparc64 softmmu
 

--- a/docker/deny-debian-packages.sh
+++ b/docker/deny-debian-packages.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -x
+set -euo pipefail
+
+main() {
+    local package
+
+    for package in "${@}"; do
+        echo "Package: ${package}:${TARGET_ARCH}
+Pin: release *
+Pin-Priority: -1" > "/etc/apt/preferences.d/${package}"
+        echo "${package}"
+    done
+
+    rm "${0}"
+}
+
+main "${@}"


### PR DESCRIPTION
Deny the installation of Debian packages that conflict with our cross-compiler toolchains, by using package pinning with a -1 priority to ensure they have no installation candidate.