### PR TITLE
Allow users to ignore config files in the package.

### DIFF
--- a/.changes/936.json
+++ b/.changes/936.json
@@ -1,0 +1,5 @@
+{
+    "type": "added",
+    "description": "allow users to ignore config files in the package.",
+    "issues": [621]
+}

--- a/docs/cross_toml.md
+++ b/docs/cross_toml.md
@@ -21,6 +21,7 @@ For example:
 
 ```toml
 [build.env]
+ignore-cargo-config = false
 volumes = ["VOL1_ARG", "VOL2_ARG"]
 passthrough = ["IMPORTANT_ENV_VARIABLES"]
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,6 +96,10 @@ impl Environment {
         self.get_target_var(target, "RUNNER")
     }
 
+    fn ignore_cargo_config(&self, target: &Target) -> (Option<bool>, Option<bool>) {
+        self.get_values_for("ENV_IGNORE_CARGO_CONFIG", target, bool_from_envvar)
+    }
+
     fn passthrough(&self, target: &Target) -> (Option<Vec<String>>, Option<Vec<String>>) {
         self.get_values_for("ENV_PASSTHROUGH", target, split_to_cloned_by_ws)
     }
@@ -273,6 +277,14 @@ impl Config {
 
     pub fn build_std(&self, target: &Target) -> Option<bool> {
         self.bool_from_config(target, Environment::build_std, CrossToml::build_std)
+    }
+
+    pub fn ignore_cargo_config(&self, target: &Target) -> Option<bool> {
+        self.bool_from_config(
+            target,
+            Environment::ignore_cargo_config,
+            CrossToml::ignore_cargo_config,
+        )
     }
 
     pub fn image(&self, target: &Target) -> Result<Option<String>> {

--- a/src/cross_toml.rs
+++ b/src/cross_toml.rs
@@ -11,7 +11,9 @@ use std::str::FromStr;
 
 /// Environment configuration
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
 pub struct CrossEnvConfig {
+    ignore_cargo_config: Option<bool>,
     volumes: Option<Vec<String>>,
     passthrough: Option<Vec<String>>,
 }
@@ -273,6 +275,15 @@ impl CrossToml {
         self.get_value(target, |b| b.build_std, |t| t.build_std)
     }
 
+    /// Returns the whether to ignore cargo config files.
+    pub fn ignore_cargo_config(&self, target: &Target) -> (Option<bool>, Option<bool>) {
+        self.get_value(
+            target,
+            |b| b.env.ignore_cargo_config,
+            |t| t.env.ignore_cargo_config,
+        )
+    }
+
     /// Returns the list of environment variables to pass through for `build` and `target`
     pub fn env_passthrough(&self, target: &Target) -> (Option<&[String]>, Option<&[String]>) {
         self.get_ref(
@@ -489,6 +500,7 @@ mod tests {
             targets: HashMap::new(),
             build: CrossBuildConfig {
                 env: CrossEnvConfig {
+                    ignore_cargo_config: Some(false),
                     volumes: Some(vec![s!("VOL1_ARG"), s!("VOL2_ARG")]),
                     passthrough: Some(vec![s!("VAR1"), s!("VAR2")]),
                 },
@@ -506,6 +518,7 @@ mod tests {
           pre-build = ["echo 'Hello World!'"]
 
           [build.env]
+          ignore-cargo-config = false
           volumes = ["VOL1_ARG", "VOL2_ARG"]
           passthrough = ["VAR1", "VAR2"]
         "#;
@@ -526,6 +539,7 @@ mod tests {
             },
             CrossTargetConfig {
                 env: CrossEnvConfig {
+                    ignore_cargo_config: None,
                     passthrough: Some(vec![s!("VAR1"), s!("VAR2")]),
                     volumes: Some(vec![s!("VOL1_ARG"), s!("VOL2_ARG")]),
                 },
@@ -580,6 +594,7 @@ mod tests {
                 pre_build: Some(PreBuild::Lines(vec![s!("echo 'Hello'")])),
                 runner: None,
                 env: CrossEnvConfig {
+                    ignore_cargo_config: None,
                     passthrough: None,
                     volumes: Some(vec![s!("VOL")]),
                 },
@@ -590,6 +605,7 @@ mod tests {
             targets: target_map,
             build: CrossBuildConfig {
                 env: CrossEnvConfig {
+                    ignore_cargo_config: Some(true),
                     volumes: None,
                     passthrough: Some(vec![]),
                 },
@@ -607,6 +623,7 @@ mod tests {
             pre-build = []
 
             [build.env]
+            ignore-cargo-config = true
             passthrough = []
 
             [target.aarch64-unknown-linux-gnu]
@@ -648,6 +665,7 @@ mod tests {
             targets: HashMap::new(),
             build: CrossBuildConfig {
                 env: CrossEnvConfig {
+                    ignore_cargo_config: None,
                     passthrough: None,
                     volumes: None,
                 },

--- a/src/docker/local.rs
+++ b/src/docker/local.rs
@@ -50,7 +50,7 @@ pub(crate) fn run(
     docker
         .args(&["-v", &format!("{}:/rust:Z,ro", dirs.sysroot.to_utf8()?)])
         .args(&["-v", &format!("{}:/target:Z", dirs.target.to_utf8()?)]);
-    docker_cwd(&mut docker, &paths)?;
+    docker_cwd(&mut docker, &paths, options.ignore_cargo_config)?;
 
     // When running inside NixOS or using Nix packaging we need to add the Nix
     // Store to the running container so it can load the needed binaries.

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -1170,7 +1170,7 @@ symlink_recurse \"${{prefix}}\"
     let mut docker = subcommand(engine, "exec");
     docker_user_id(&mut docker, engine.kind);
     docker_envvars(&mut docker, &options.config, target, msg_info)?;
-    docker_cwd(&mut docker, &paths)?;
+    docker_cwd(&mut docker, &paths, options.ignore_cargo_config)?;
     docker.arg(&container);
     docker.args(&["sh", "-c", &format!("PATH=$PATH:/rust/bin {:?}", cmd)]);
     bail_container_exited!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,8 +532,14 @@ pub fn run() -> Result<ExitStatus> {
                 }
 
                 let paths = docker::DockerPaths::create(&engine, metadata, cwd, sysroot)?;
-                let options =
-                    docker::DockerOptions::new(engine, target.clone(), config, uses_xargo);
+                let ignore_cargo_config = config.ignore_cargo_config(&target).unwrap_or_default();
+                let options = docker::DockerOptions::new(
+                    engine,
+                    target.clone(),
+                    config,
+                    uses_xargo,
+                    ignore_cargo_config,
+                );
                 let status = docker::run(options, paths, &filtered_args, &mut msg_info)
                     .wrap_err("could not run container")?;
                 let needs_host = args.subcommand.map_or(false, |sc| sc.needs_host(is_remote));


### PR DESCRIPTION
Adds the `CROSS_IGNORE_CARGO_CONFIG` environment variable, which if set will mount an anoymous data volume for each `.cargo` subdirectory for the current directory and any parent directories up to the workspace root. If the build is called outside the workspace root or at the workspace root, only mount at the `$PWD/.cargo`.

Partially addresses #621.