### PR TITLE
Use non-canonical paths for mount paths.

### DIFF
--- a/.changes/942.json
+++ b/.changes/942.json
@@ -1,0 +1,15 @@
+[
+    {
+        "description": "use non-canonical paths for mount locations.",
+        "type": "changed",
+        "issues": [920]
+    },
+    {
+        "description": "fixed DeviceNS drive parsing in creating WSL-style paths on windows.",
+        "type": "fixed"
+    },
+    {
+        "description": "fixed the environment variable name for mounted volumes.",
+        "type": "fixed"
+    }
+]


### PR DESCRIPTION
Symlinks and canonical paths can destroy assumptions about paths: say I have a file at `/tmp/path/to/file` I reference in my crate, and ask to mount `/tmp/path/to` on the container. Currently, on macOS, since `/tmp` is a symlink to `/private/tmp`, the code that expects `/tmp/path/to/file` will fail because in the container it will be mounted at `/private/tmp/path/to/file`.

In addition, this fixes `DeviceNS` parsing with drive letters (this previously didn't matter since it never occurred, due to `dunce` canonicalization). This PR also fixes a minor bug where the host root instead of the var names was passed as the environment variable (introduced in #904).

Closes #920.