### PR TITLE
 Ignore tests that touch the filesystem if sandboxed. 

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -23,6 +23,11 @@ fn main() {
         .unwrap()
         .write_all(commit_info().as_bytes())
         .unwrap();
+
+    if env::var("CROSS_SANDBOXED").is_ok() {
+        println!("cargo:rustc-cfg=cross_sandboxed");
+    }
+    println!("cargo:rerun-if-env-changed=CROSS_SANDBOXED");
 }
 
 fn commit_info() -> String {

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -1059,6 +1059,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg_attr(cross_sandboxed, ignore)]
         fn test_host() -> Result<()> {
             let vars = unset_env();
             let mount_finder = MountFinder::new(vec![]);


### PR DESCRIPTION
Adds an environment variable `CROSS_SANDBOXED` that skips tests that touch the filesystem if set.

Closes #943.