### PR TITLE
Resolve symlinks for cargo and xargo home.

### DIFF
--- a/.changes/947.json
+++ b/.changes/947.json
@@ -1,0 +1,12 @@
+[
+    {
+        "type": "internal",
+        "description": "resolve symlinks to cargo and xargo home before mounting",
+        "issues": [373]
+    },
+    {
+        "type": "fixed",
+        "description": "mount cargo, xargo, and the sysroot at the same path as on the host to avoid unnecessary recompilation.",
+        "issues": [551]
+    }
+]

--- a/src/bin/commands/containers.rs
+++ b/src/bin/commands/containers.rs
@@ -451,15 +451,14 @@ pub fn create_persistent_volume(
     docker::remote::copy_volume_container_xargo(
         engine,
         &container,
-        &dirs.xargo,
-        &toolchain_host,
+        &dirs,
         mount_prefix.as_ref(),
         msg_info,
     )?;
     docker::remote::copy_volume_container_cargo(
         engine,
         &container,
-        &dirs.cargo,
+        &dirs,
         mount_prefix.as_ref(),
         copy_registry,
         msg_info,
@@ -467,7 +466,7 @@ pub fn create_persistent_volume(
     docker::remote::copy_volume_container_rust(
         engine,
         &container,
-        &toolchain,
+        &dirs,
         None,
         mount_prefix.as_ref(),
         msg_info,

--- a/src/docker/image.rs
+++ b/src/docker/image.rs
@@ -135,6 +135,12 @@ impl ImagePlatform {
     }
 }
 
+impl Default for ImagePlatform {
+    fn default() -> ImagePlatform {
+        ImagePlatform::DEFAULT
+    }
+}
+
 impl TryFrom<&str> for ImagePlatform {
     type Error = <Self as std::str::FromStr>::Err;
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -143,6 +143,11 @@ where
     read_(path.as_ref())
 }
 
+pub fn create_dir_all(path: impl AsRef<Path>) -> Result<()> {
+    fs::create_dir_all(path.as_ref())
+        .wrap_err_with(|| format!("couldn't create directory {:?}", path.as_ref()))
+}
+
 fn read_(path: &Path) -> Result<String> {
     let mut s = String::new();
     File::open(path)
@@ -222,12 +227,11 @@ pub fn maybe_canonicalize(path: &Path) -> Cow<'_, OsStr> {
 
 pub fn write_file(path: impl AsRef<Path>, overwrite: bool) -> Result<File> {
     let path = path.as_ref();
-    fs::create_dir_all(
+    create_dir_all(
         &path
             .parent()
             .ok_or_else(|| eyre::eyre!("could not find parent directory for `{path:?}`"))?,
-    )
-    .wrap_err_with(|| format!("couldn't create directory `{path:?}`"))?;
+    )?;
 
     let mut open = fs::OpenOptions::new();
     open.write(true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,6 +235,12 @@ impl<'a> From<&'a str> for TargetTriple {
     }
 }
 
+impl Default for TargetTriple {
+    fn default() -> TargetTriple {
+        TargetTriple::DEFAULT
+    }
+}
+
 impl std::str::FromStr for TargetTriple {
     type Err = std::convert::Infallible;
 
@@ -364,6 +370,12 @@ impl Target {
             || self.triple().starts_with("i686");
 
         arch_32bit && self.is_android()
+    }
+}
+
+impl Default for Target {
+    fn default() -> Target {
+        Target::DEFAULT
     }
 }
 


### PR DESCRIPTION
Resolve symlinks for the xargo and cargo home (as well as the Nix store) prior to mounting, since they are mounted at a fixed location anyway. This is because podman mounts symlinks as root by default. We always canonicalize the paths on the host, after creating them, to ensure that any symlinks are resolved.

Say we have `/path/to/home`, and `/path/to` is a symlink but `/path/to/home` doesn't exist yet. Trying to canonicalize `/path/to/home/.xargo` will fail, and will still be a symlink if we maybe canonicalize before. First creating the directories and canonicalizing them on the host should always work.

Change the mount points from `/cargo`, `/xargo`, and `/rust` to the same paths as on the host, which avoids unnecessary recompilation when `cargo` and `cross` are intermittently used.

Closes #280.
Closes #373.
Closes #551.