### PR TITLE
Fix FreeBSD migration to `.pkg` extensions.

### DIFF
--- a/docker/Dockerfile.i686-unknown-freebsd
+++ b/docker/Dockerfile.i686-unknown-freebsd
@@ -10,12 +10,14 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
+RUN echo "export ARCH=i686" > /freebsd-arch.sh
 COPY freebsd-common.sh /
 COPY freebsd.sh /
-RUN /freebsd.sh i686
+RUN /freebsd.sh
 
+COPY freebsd-install.sh /
 COPY freebsd-extras.sh /
-RUN /freebsd-extras.sh i686
+RUN /freebsd-extras.sh
 
 ENV CARGO_TARGET_I686_UNKNOWN_FREEBSD_LINKER=i686-unknown-freebsd12-gcc \
     CC_i686_unknown_freebsd=i686-unknown-freebsd12-gcc \

--- a/docker/Dockerfile.x86_64-unknown-freebsd
+++ b/docker/Dockerfile.x86_64-unknown-freebsd
@@ -10,12 +10,14 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
+RUN echo "export ARCH=x86_64" > /freebsd-arch.sh
 COPY freebsd-common.sh /
 COPY freebsd.sh /
-RUN /freebsd.sh x86_64
+RUN /freebsd.sh
 
+COPY freebsd-install.sh /
 COPY freebsd-extras.sh /
-RUN /freebsd-extras.sh x86_64
+RUN /freebsd-extras.sh
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER=x86_64-unknown-freebsd12-gcc \
     CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd12-gcc \

--- a/docker/freebsd-common.sh
+++ b/docker/freebsd-common.sh
@@ -3,6 +3,9 @@
 set -x
 set -euo pipefail
 
+# shellcheck disable=SC1091
+. freebsd-arch.sh
+
 export BSD_ARCH=
 case "${ARCH}" in
     x86_64)

--- a/docker/freebsd-extras.sh
+++ b/docker/freebsd-extras.sh
@@ -22,22 +22,26 @@ main() {
 
     curl --retry 3 -sSfL "${pkg_source}/packagesite.txz" -O
     tar -C "${td}/packagesite" -xJf packagesite.txz
-    local openssl_ver
-    local sqlite_ver
-    openssl_ver=$(jq -c '. | select ( .name == "openssl" ) | .version' "${td}/packagesite/packagesite.yaml")
-    sqlite_ver=$(jq -c '. | select ( .name == "sqlite3" ) | .version' "${td}/packagesite/packagesite.yaml")
-    openssl_ver=${openssl_ver//'"'/}
-    sqlite_ver=${sqlite_ver//'"'/}
+    local openssl_path
+    local sqlite_path
+    local openssl_pkg
+    local sqlite_pkg
+    openssl_path=$(jq -c '. | select ( .name == "openssl" ) | .repopath' "${td}/packagesite/packagesite.yaml")
+    sqlite_path=$(jq -c '. | select ( .name == "sqlite3" ) | .repopath' "${td}/packagesite/packagesite.yaml")
+    openssl_path=${openssl_path//'"'/}
+    sqlite_path=${sqlite_path//'"'/}
+    openssl_pkg=$(basename "${openssl_path}")
+    sqlite_pkg=$(basename "${sqlite_path}")
 
     local target="${ARCH}-unknown-freebsd${BSD_MAJOR}"
 
     # Adding openssl lib
-    curl --retry 3 -sSfL "${pkg_source}/All/openssl-${openssl_ver}.txz" -O
-    tar -C "${td}/openssl" -xJf "openssl-${openssl_ver}.txz" /usr/local/lib /usr/local/include/
+    curl --retry 3 -sSfL "${pkg_source}/${openssl_path}" -O
+    tar -C "${td}/openssl" -xJf "${openssl_pkg}" /usr/local/lib /usr/local/include/
 
     # Adding sqlite3
-    curl --retry 3 -sSfL "${pkg_source}/All/sqlite3-${sqlite_ver}.txz" -O
-    tar -C "${td}/sqlite" -xJf "sqlite3-${sqlite_ver}.txz" /usr/local/lib
+    curl --retry 3 -sSfL "${pkg_source}/${sqlite_path}" -O
+    tar -C "${td}/sqlite" -xJf "${sqlite_pkg}" /usr/local/lib
 
     # Copy the linked library
     local destdir="/usr/local/${target}"

--- a/docker/freebsd-extras.sh
+++ b/docker/freebsd-extras.sh
@@ -3,59 +3,17 @@
 set -x
 set -euo pipefail
 
-export ARCH="${1}"
 # shellcheck disable=SC1091
 . lib.sh
 # shellcheck disable=SC1091
 . freebsd-common.sh
+# shellcheck disable=SC1091
+. freebsd-install.sh
 
 main() {
-    local pkg_source="https://pkg.freebsd.org/FreeBSD:${BSD_MAJOR}:${BSD_ARCH}/quarterly"
-    install_packages curl jq xz-utils
+    setup_packagesite
+    install_freebsd_package openssl sqlite3
 
-    local td
-    td="$(mktemp -d)"
-
-    mkdir "${td}"/{openssl,sqlite,packagesite}
-
-    pushd "${td}"
-
-    curl --retry 3 -sSfL "${pkg_source}/packagesite.txz" -O
-    tar -C "${td}/packagesite" -xJf packagesite.txz
-    local openssl_path
-    local sqlite_path
-    local openssl_pkg
-    local sqlite_pkg
-    openssl_path=$(jq -c '. | select ( .name == "openssl" ) | .repopath' "${td}/packagesite/packagesite.yaml")
-    sqlite_path=$(jq -c '. | select ( .name == "sqlite3" ) | .repopath' "${td}/packagesite/packagesite.yaml")
-    openssl_path=${openssl_path//'"'/}
-    sqlite_path=${sqlite_path//'"'/}
-    openssl_pkg=$(basename "${openssl_path}")
-    sqlite_pkg=$(basename "${sqlite_path}")
-
-    local target="${ARCH}-unknown-freebsd${BSD_MAJOR}"
-
-    # Adding openssl lib
-    curl --retry 3 -sSfL "${pkg_source}/${openssl_path}" -O
-    tar -C "${td}/openssl" -xJf "${openssl_pkg}" /usr/local/lib /usr/local/include/
-
-    # Adding sqlite3
-    curl --retry 3 -sSfL "${pkg_source}/${sqlite_path}" -O
-    tar -C "${td}/sqlite" -xJf "${sqlite_pkg}" /usr/local/lib
-
-    # Copy the linked library
-    local destdir="/usr/local/${target}"
-    cp -r "${td}/openssl/usr/local/include" "${destdir}"
-    cp "${td}/openssl/usr/local/lib"/lib{crypto,ssl}.a "${destdir}/lib"
-    cp "${td}/openssl/usr/local/lib"/lib{crypto,ssl}.so* "${destdir}/lib"
-    cp "${td}/sqlite/usr/local/lib"/libsqlite3.so* "${destdir}/lib"
-
-    purge_packages
-
-    # clean up
-    popd
-
-    rm -rf "${td}"
     rm "${0}"
 }
 

--- a/docker/freebsd-install.sh
+++ b/docker/freebsd-install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -x
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. freebsd-common.sh
+
+export PACKAGESITE=/opt/freebsd-packagesite/packagesite.yaml
+export PKG_SOURCE="https://pkg.freebsd.org/FreeBSD:${BSD_MAJOR}:${BSD_ARCH}/quarterly"
+export TARGET="${ARCH}-unknown-freebsd${BSD_MAJOR}"
+
+setup_packagesite() {
+    apt-get update && apt-get install --assume-yes --no-install-recommends \
+        curl \
+        jq \
+        xz-utils
+
+    mkdir /opt/freebsd-packagesite
+    curl --retry 3 -sSfL "${PKG_SOURCE}/packagesite.txz" -O
+    tar -C /opt/freebsd-packagesite -xJf packagesite.txz
+
+    rm packagesite.txz
+}
+
+install_freebsd_package() {
+    local name
+    local path
+    local pkg
+    local td
+    local destdir="/usr/local/${TARGET}"
+
+    td="$(mktemp -d)"
+    pushd "${td}"
+
+    for name in "${@}"; do
+        path=$(jq -c '. | select ( .name == "'"${name}"'" ) | .repopath' "${PACKAGESITE}")
+        if [[ -z "${path}" ]]; then
+            echo "Unable to find package ${name}" >&2
+            exit 1
+        fi
+        path=${path//'"'/}
+        pkg=$(basename "${path}")
+
+        mkdir "${td}"/package
+        curl --retry 3 -sSfL "${PKG_SOURCE}/${path}" -O
+        tar -C "${td}/package" -xJf "${pkg}"
+        cp -r "${td}/package/usr/local"/* "${destdir}"/
+
+        rm "${td:?}/${pkg}"
+        rm -rf "${td:?}/package"
+    done
+
+    # clean up
+    popd
+    rm -rf "${td:?}"
+}

--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -3,7 +3,6 @@
 set -x
 set -euo pipefail
 
-export ARCH="${1}"
 # shellcheck disable=SC1091
 . freebsd-common.sh
 # shellcheck disable=SC1091


### PR DESCRIPTION
Uses the `path` key rather than the `version` extension to get the proper location for the package URL, which is still compressed as a tar XZ archive.