### PR TITLE
Fix SELinux labels to allow shared use.

### DIFF
--- a/.changes/962.json
+++ b/.changes/962.json
@@ -1,0 +1,5 @@
+{
+    "description": "fix SELinux labels to allow use in multiple containers and/or the host filesystem.",
+    "type": "fixed",
+    "issues": [961]
+}

--- a/src/docker/local.rs
+++ b/src/docker/local.rs
@@ -14,7 +14,7 @@ fn mount(docker: &mut Command, host_path: &Path, absolute_path: &Path, prefix: &
     let mount_path = absolute_path.as_posix_absolute()?;
     docker.args(&[
         "-v",
-        &format!("{}:{prefix}{}", host_path.to_utf8()?, mount_path),
+        &format!("{}:{prefix}{}:z", host_path.to_utf8()?, mount_path),
     ]);
     Ok(())
 }
@@ -64,28 +64,28 @@ pub(crate) fn run(
     docker
         .args(&[
             "-v",
-            &format!("{}:{}:Z", dirs.xargo.to_utf8()?, dirs.xargo_mount_path()),
+            &format!("{}:{}:z", dirs.xargo.to_utf8()?, dirs.xargo_mount_path()),
         ])
         .args(&[
             "-v",
-            &format!("{}:{}:Z", dirs.cargo.to_utf8()?, dirs.cargo_mount_path()),
+            &format!("{}:{}:z", dirs.cargo.to_utf8()?, dirs.cargo_mount_path()),
         ])
         // Prevent `bin` from being mounted inside the Docker container.
         .args(&["-v", &format!("{}/bin", dirs.cargo_mount_path())]);
     docker.args(&[
         "-v",
-        &format!("{}:{}:Z", dirs.host_root.to_utf8()?, dirs.mount_root),
+        &format!("{}:{}:z", dirs.host_root.to_utf8()?, dirs.mount_root),
     ]);
     docker
         .args(&[
             "-v",
             &format!(
-                "{}:{}:Z,ro",
+                "{}:{}:z,ro",
                 dirs.get_sysroot().to_utf8()?,
                 dirs.sysroot_mount_path()
             ),
         ])
-        .args(&["-v", &format!("{}:/target:Z", dirs.target.to_utf8()?)]);
+        .args(&["-v", &format!("{}:/target:z", dirs.target.to_utf8()?)]);
     docker_cwd(&mut docker, &paths)?;
 
     // When running inside NixOS or using Nix packaging we need to add the Nix
@@ -94,7 +94,7 @@ pub(crate) fn run(
         docker.args(&[
             "-v",
             &format!(
-                "{}:{}:Z",
+                "{}:{}:z",
                 nix_store.to_utf8()?,
                 nix_store.as_posix_absolute()?
             ),


### PR DESCRIPTION
Ensure that the volumes are not mounted as private, unshared volumes since we might mount with the host filesystem. This also fixes permissions issues with reading data from a mounted volume using a rootless container engine.

Fixes a bug introduced in #251.
Closes #961.

This is because the `Z` SELinux label assumes the data is not shared between containers and not being used by the host, as documented below:

> If you use selinux you can add the z or Z options to modify the selinux label of the host file or directory being mounted into the container. This affects the file or directory on the host machine itself and can have consequences outside of the scope of Docker.
> 
> - The z option indicates that the bind mount content is shared among multiple containers.
> - The Z option indicates that the bind mount content is private and unshared.
> 
> Use extreme caution with these options. Bind-mounting a system directory such as /home or /usr with the Z option renders your host machine inoperable and you may need to relabel the host machine files by hand.

Prior to this, we used the `Z` label, when we should have been using the `z` label.