### PR TITLE
Add process lock to avoid parallel cross issues.

### DIFF
--- a/.changes/963.json
+++ b/.changes/963.json
@@ -1,0 +1,5 @@
+{
+    "description": "add lock to prevent deadlock with docker when invoked multiple times.",
+    "type": "fixed",
+    "issues": [496]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "serde_json",
  "shell-escape",
  "shell-words",
+ "small-lock",
  "tempfile",
  "thiserror",
  "toml",
@@ -469,6 +470,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +713,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
+name = "small-lock"
+version = "0.0.1"
+dependencies = [
+ "libc",
+ "threadpool",
+ "winapi",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +804,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 dev = []
 
 [workspace]
-members = ["xtask"]
+members = ["small-lock", "xtask"]
 
 [dependencies]
 atty = "0.2"
@@ -47,6 +47,7 @@ walkdir = { version = "2", optional = true }
 tempfile = "3.3.0"
 owo-colors = { version = "3.4.0", features = ["supports-colors"] }
 semver = "1"
+small-lock = { version = "0.0.1", path = "small-lock" }
 
 [target.'cfg(not(windows))'.dependencies]
 nix = { version = "0.24", default-features = false, features = ["user"] }

--- a/small-lock/Cargo.toml
+++ b/small-lock/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+documentation = "https://github.com/cross-rs/cross"
+license = "MIT OR Apache-2.0"
+name = "small-lock"
+repository = "https://github.com/cross-rs/cross"
+version = "0.0.1"
+edition = "2021"
+
+[target.'cfg(not(windows))'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies.winapi]
+version = "0.3"
+features = [
+    "errhandlingapi",
+    "handleapi",
+    "synchapi",
+    "winbase",
+    "winerror",
+]
+
+[dev-dependencies]
+threadpool = "1.8.1"

--- a/small-lock/src/lib.rs
+++ b/small-lock/src/lib.rs
@@ -1,0 +1,154 @@
+//! A minimal-dependency, safe API for a named process lock.
+//!
+//! This uses `flock` on Unix-like systems and `CreateMutex` on Linux.
+//! This is meant to be a drop-in-replacement for `named_lock`, and
+//! therefore features an identical API.
+
+#![deny(missing_debug_implementations, rust_2018_idioms)]
+#![warn(
+    clippy::explicit_into_iter_loop,
+    clippy::explicit_iter_loop,
+    clippy::implicit_clone,
+    clippy::inefficient_to_string,
+    clippy::map_err_ignore,
+    clippy::map_unwrap_or,
+    clippy::ref_binding_to_reference,
+    clippy::semicolon_if_nothing_returned,
+    clippy::str_to_string,
+    clippy::string_to_string,
+    // needs clippy 1.61 clippy::unwrap_used
+)]
+
+#[cfg(target_family = "unix")]
+mod unix;
+#[cfg(target_family = "unix")]
+pub use unix::*;
+
+#[cfg(target_family = "windows")]
+mod windows;
+#[cfg(target_family = "windows")]
+pub use windows::*;
+
+use std::error;
+use std::fmt;
+use std::io;
+use std::result;
+
+#[cfg(target_family = "unix")]
+use std::path::Path;
+
+/// Named (or by path) lock.
+#[derive(Debug)]
+pub struct NamedLock {
+    inner: InnerLock,
+}
+
+impl NamedLock {
+    /// Create a lock file with a given name.
+    ///
+    /// By default, this will the current temporary directory
+    /// and create a file at `$TMP/{name}.lock`.
+    pub fn create(name: impl AsRef<str>) -> Result<NamedLock> {
+        Ok(NamedLock {
+            inner: InnerLock::create(name)?,
+        })
+    }
+
+    /// Creates a lock file at a specific path.
+    /// The parent directory must exist.
+    #[cfg(target_family = "unix")]
+    pub fn with_path(path: impl AsRef<Path>) -> Result<NamedLock> {
+        Ok(NamedLock {
+            inner: InnerLock::with_path(path)?,
+        })
+    }
+
+    /// Lock the named lock.
+    pub fn lock(&self) -> Result<NamedLockGuard<'_>> {
+        Ok(NamedLockGuard {
+            _inner: self.inner.lock()?,
+        })
+    }
+
+    /// Try to lock the named lock.
+    ///
+    /// Returns `Error::WouldBlock` if it cannot acquire the lock
+    /// because it would block.
+    pub fn try_lock(&self) -> Result<NamedLockGuard<'_>> {
+        Ok(NamedLockGuard {
+            _inner: self.inner.try_lock()?,
+        })
+    }
+
+    /// Unlock the named lock.
+    pub fn unlock(&self) -> Result<()> {
+        self.inner.unlock()
+    }
+}
+
+/// Scoped guard for the named lock.
+#[derive(Debug)]
+pub struct NamedLockGuard<'a> {
+    _inner: InnerLockGuard<'a>,
+}
+
+/// Error type for the lockfile.
+#[derive(Debug)]
+pub enum Error {
+    InvalidCharacter,
+    CreateFailed(io::Error),
+    LockFailed(io::Error),
+    UnlockFailed(io::Error),
+    WouldBlock,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::InvalidCharacter => f.write_str("invalid character found in file name"),
+            Error::CreateFailed(e) => f.write_fmt(format_args!("lock creation failed with {e}")),
+            Error::LockFailed(e) => f.write_fmt(format_args!("unable to acquire lock with {e}")),
+            Error::UnlockFailed(e) => f.write_fmt(format_args!("unable to release lock with {e}")),
+            Error::WouldBlock => f.write_str("acquiring lock would block"),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Error::CreateFailed(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+/// Lock type for creating results.
+pub type Result<T> = result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{thread, time};
+
+    #[test]
+    fn test_lock() {
+        let workers = 4;
+        let jobs = 8;
+        let pool = threadpool::ThreadPool::new(workers);
+        let start = time::SystemTime::now();
+        for _ in 0..jobs {
+            pool.execute(move || {
+                let lock = NamedLock::create("cross-rs-test-lock").unwrap();
+                let _guard = lock.lock().unwrap();
+                thread::sleep(time::Duration::from_millis(500));
+            });
+        }
+        pool.join();
+
+        // should be ~4s elapsed, due to the locks
+        let end = time::SystemTime::now();
+        let diff = end.duration_since(start).unwrap();
+        assert!((4000..=6000).contains(&diff.as_millis()));
+    }
+}

--- a/small-lock/src/unix.rs
+++ b/small-lock/src/unix.rs
@@ -1,0 +1,89 @@
+#![cfg(target_family = "unix")]
+#![doc(hidden)]
+
+use std::env;
+use std::fs::File;
+use std::io;
+use std::os::unix::io::AsRawFd;
+use std::path::Path;
+
+use crate::{Error, Result};
+
+#[derive(Debug)]
+pub struct InnerLock {
+    file: File,
+}
+
+impl InnerLock {
+    pub fn create(name: impl AsRef<str>) -> Result<InnerLock> {
+        match is_valid_filename(name.as_ref()) {
+            true => {
+                let mut file_name = name.as_ref().to_owned();
+                file_name.push_str(".lock");
+                InnerLock::with_path(env::temp_dir().join(file_name))
+            }
+            false => Err(Error::InvalidCharacter),
+        }
+    }
+
+    pub fn with_path(path: impl AsRef<Path>) -> Result<InnerLock> {
+        Ok(InnerLock {
+            file: File::create(path).map_err(Error::CreateFailed)?,
+        })
+    }
+
+    pub fn lock(&self) -> Result<InnerLockGuard<'_>> {
+        // SAFETY: safe, since we have valid flags.
+        unsafe { self._lock(libc::LOCK_EX) }
+    }
+
+    pub fn try_lock(&self) -> Result<InnerLockGuard<'_>> {
+        // SAFETY: safe, since we have valid flags.
+        unsafe { self._lock(libc::LOCK_EX | libc::LOCK_NB) }
+    }
+
+    /// # SAFETY
+    ///
+    /// Safe as long as the flags are correct.
+    unsafe fn _lock(&self, flags: libc::c_int) -> Result<InnerLockGuard<'_>> {
+        // SAFETY: safe if we have a valid file descriptor.
+        let fd = self.file.as_raw_fd();
+        match libc::flock(fd, flags) {
+            0 => Ok(InnerLockGuard { lock: self }),
+            libc::EWOULDBLOCK => Err(Error::WouldBlock),
+            code => Err(Error::LockFailed(io::Error::from_raw_os_error(code))),
+        }
+    }
+
+    pub fn unlock(&self) -> Result<()> {
+        // SAFETY: safe, since we use valid flags
+        unsafe { self._unlock(libc::LOCK_UN) }
+    }
+
+    /// # SAFETY
+    ///
+    /// Safe as long as the flags are correct.
+    unsafe fn _unlock(&self, flags: libc::c_int) -> Result<()> {
+        let fd = self.file.as_raw_fd();
+        match libc::flock(fd, flags) {
+            0 => Ok(()),
+            code => Err(Error::UnlockFailed(io::Error::from_raw_os_error(code))),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InnerLockGuard<'a> {
+    lock: &'a InnerLock,
+}
+
+impl<'a> Drop for InnerLockGuard<'a> {
+    fn drop(&mut self) {
+        self.lock.unlock().ok();
+    }
+}
+
+fn is_valid_filename(name: &str) -> bool {
+    // the name cannot have a /
+    !name.contains('/')
+}

--- a/small-lock/src/windows.rs
+++ b/small-lock/src/windows.rs
@@ -1,0 +1,147 @@
+#![cfg(target_family = "windows")]
+#![doc(hidden)]
+
+use std::io;
+use std::ptr;
+
+use winapi::shared::minwindef::{DWORD, MAX_PATH};
+use winapi::shared::winerror::WAIT_TIMEOUT;
+use winapi::um::errhandlingapi::GetLastError;
+use winapi::um::handleapi::CloseHandle;
+use winapi::um::synchapi::{CreateMutexW, ReleaseMutex, WaitForSingleObject};
+use winapi::um::winbase::{INFINITE, WAIT_ABANDONED, WAIT_OBJECT_0};
+use winapi::um::winnt::{HANDLE, WCHAR};
+
+use crate::{Error, Result};
+
+/// Named (or by path) lock.
+#[derive(Debug)]
+pub struct InnerLock {
+    handle: HANDLE,
+    _lpname: Vec<WCHAR>,
+}
+
+// the logic for the mutex functionality is based off of this example:
+// https://docs.microsoft.com/en-us/windows/win32/sync/using-mutex-objects
+impl InnerLock {
+    pub fn create(name: impl AsRef<str>) -> Result<InnerLock> {
+        match is_valid_namespace(name.as_ref()) {
+            // SAFETY: safe since it contains valid characters
+            true => unsafe { InnerLock::_create(name.as_ref()) },
+            false => Err(Error::InvalidCharacter),
+        }
+    }
+
+    /// # Safety
+    ///
+    /// Name must have valid characters.
+    unsafe fn _create(name: &str) -> Result<InnerLock> {
+        // we want the security descriptor structure to be null,
+        // so it cannot be inherited by child processes.
+        let lpname = to_wide_string(name);
+        let handle = CreateMutexW(ptr::null_mut(), 0, lpname.as_ptr());
+        match handle.is_null() {
+            true => Err(get_last_error()),
+            false => Ok(InnerLock {
+                handle,
+                _lpname: lpname,
+            }),
+        }
+    }
+
+    pub fn lock(&self) -> Result<InnerLockGuard<'_>> {
+        self._lock(INFINITE)
+    }
+
+    pub fn try_lock(&self) -> Result<InnerLockGuard<'_>> {
+        self._lock(0)
+    }
+
+    fn _lock(&self, millis: DWORD) -> Result<InnerLockGuard<'_>> {
+        // Safe, since the handle must be valid.
+        match unsafe { WaitForSingleObject(self.handle, millis) } {
+            WAIT_ABANDONED | WAIT_OBJECT_0 => Ok(InnerLockGuard { lock: self }),
+            WAIT_TIMEOUT => Err(Error::WouldBlock),
+            code => Err(Error::LockFailed(io::Error::from_raw_os_error(code as i32))),
+        }
+    }
+
+    pub fn unlock(&self) -> Result<()> {
+        self._unlock()
+    }
+
+    /// # SAFETY
+    ///
+    /// Safe, since the handle must be valid.
+    fn _unlock(&self) -> Result<()> {
+        // Safe, since the handle must be valid.
+        match unsafe { ReleaseMutex(self.handle) } {
+            0 => Err(get_last_error()),
+            _ => Ok(()),
+        }
+    }
+}
+
+impl Drop for InnerLock {
+    fn drop(&mut self) {
+        // SAFETY: safe, since the handle is valid.
+        unsafe { CloseHandle(self.handle) };
+    }
+}
+
+#[derive(Debug)]
+pub struct InnerLockGuard<'a> {
+    lock: &'a InnerLock,
+}
+
+impl<'a> Drop for InnerLockGuard<'a> {
+    fn drop(&mut self) {
+        self.lock.unlock().ok();
+    }
+}
+
+fn is_valid_namespace(name: &str) -> bool {
+    // the name cannot have a backslash, and must be <= MAX_PATH characters.
+    // https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createmutexw
+    name.len() <= MAX_PATH && !name.contains('/')
+}
+
+/// convert a string to an owned wide string
+fn to_wide_string(s: &str) -> Vec<WCHAR> {
+    // wchar_t is always 16-bit for UTF-16LE encodings.
+    assert_eq!(WCHAR::BITS, 16);
+    let mut vec: Vec<WCHAR> = s.encode_utf16().collect();
+    vec.push(0);
+    vec
+}
+
+fn get_last_error() -> Error {
+    // SAFETY: safe, since GetLastError is always safe.
+    let code = unsafe { GetLastError() };
+    Error::CreateFailed(io::Error::from_raw_os_error(code as i32))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_wide_string() {
+        assert_eq!(to_wide_string(""), vec![0]);
+        assert_eq!(
+            to_wide_string("hello world"),
+            vec![104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0]
+        );
+        assert_eq!(
+            to_wide_string("모든 사람은 교육을 받을 권리를"),
+            vec![
+                47784, 46304, 32, 49324, 46988, 51008, 32, 44368, 50977, 51012, 32, 48155, 51012,
+                32, 44428, 47532, 47484, 0
+            ]
+        );
+        assert_eq!(
+            to_wide_string("🔥🔥🔥🔥🔥"),
+            vec![55357, 56613, 55357, 56613, 55357, 56613, 55357, 56613, 55357, 56613, 0]
+        );
+    }
+}

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -39,6 +39,22 @@ pub fn image_name(target: &str, sub: Option<&str>, repository: &str, tag: &str) 
     }
 }
 
+fn create_lock(name: &str) -> Result<small_lock::NamedLock> {
+    #[cfg(target_family = "windows")]
+    {
+        small_lock::NamedLock::create(name).map_err(Into::into)
+    }
+    #[cfg(target_family = "unix")]
+    {
+        use crate::file;
+        use std::fs;
+
+        let cross_dir = file::cross_dir()?;
+        fs::create_dir_all(&cross_dir)?;
+        small_lock::NamedLock::with_path(&cross_dir.join(name)).map_err(Into::into)
+    }
+}
+
 pub fn run(
     options: DockerOptions,
     paths: DockerPaths,
@@ -51,6 +67,19 @@ pub fn run(
             1,
         );
     }
+
+    // lock to avoid issues with docker failing with multiple processes at once just
+    // lock on any container engine, since we don't want to deal with engine aliases.
+    let lock = create_lock("cross-rs-container-engine")?;
+    let _guard = match lock.try_lock() {
+        Ok(guard) => Ok(guard),
+        Err(small_lock::Error::WouldBlock) => {
+            msg_info.note("Blocking waiting for file lock on container engine")?;
+            lock.lock()
+        }
+        Err(e) => Err(e),
+    }?;
+
     if options.is_remote() {
         remote::run(options, paths, args, msg_info).wrap_err("could not complete remote run")
     } else {

--- a/src/file.rs
+++ b/src/file.rs
@@ -277,6 +277,16 @@ pub fn write_file(path: impl AsRef<Path>, overwrite: bool) -> Result<File> {
         .wrap_err(format!("couldn't write to file `{path:?}`"))
 }
 
+fn data_dir() -> Result<PathBuf> {
+    directories::BaseDirs::new()
+        .map(|d| d.data_dir().to_path_buf())
+        .ok_or(eyre::eyre!("unable to get data directory"))
+}
+
+pub fn cross_dir() -> Result<PathBuf> {
+    Ok(data_dir()?.join("cross-rs"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/temp.rs
+++ b/src/temp.rs
@@ -2,19 +2,14 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::errors::Result;
+use crate::file;
 
 // open temporary directories and files so we ensure we cleanup on exit.
 static mut FILES: Vec<tempfile::NamedTempFile> = vec![];
 static mut DIRS: Vec<tempfile::TempDir> = vec![];
 
-fn data_dir() -> Option<PathBuf> {
-    directories::BaseDirs::new().map(|d| d.data_dir().to_path_buf())
-}
-
 pub fn dir() -> Result<PathBuf> {
-    data_dir()
-        .map(|p| p.join("cross-rs").join("tmp"))
-        .ok_or(eyre::eyre!("unable to get data directory"))
+    Ok(file::cross_dir()?.join("tmp"))
 }
 
 pub(crate) fn has_tempfiles() -> bool {


### PR DESCRIPTION
Docker can have deadlocks or similar issues when invoked multiple times
in rapid succession, so this implements a small and correct process lock
with an identical API to `named_lock`. This allows us to prevent
invoking Docker multiple times.

The implementation uses `flock` on Linux/UNIX-like systems, which on
Linux is guaranteed to be cleaned up when the process exits. On Windows, it uses `CreateMutexW`, which also guarantees to be cleaned up when the process exits.

We use this rather than `fd-lock` because `fd-lock` has more dependencies, and it also uses `LockFile` on Windows which is not guaranteed to be cleaned up in a timely manner. The API is also designed for file locks, not process locks, which is only a good abstraction on UNIX-like systems.

We use this rather than `named_lock` since it has numerous, unnecessary dependencies. This allows us to have no external dependencies besides libc and the Windows API, for an extremely lightweight locking library.

Fixes #496.