### PR TITLE
introduce verbosity levels

### DIFF
--- a/.changes/968.json
+++ b/.changes/968.json
@@ -1,0 +1,4 @@
+{
+    "description": "only print rustup --verbose if `-vv` or `CROSS_VERBOSE=1` is used",
+    "type": "fixed"
+}

--- a/src/bin/cross.rs
+++ b/src/bin/cross.rs
@@ -18,7 +18,11 @@ pub fn main() -> cross::Result<()> {
     let target_list = rustc::target_list(&mut Verbosity::Quiet.into())?;
     let args = cli::parse(&target_list)?;
     let subcommand = args.subcommand;
-    let mut msg_info = shell::MessageInfo::create(args.verbose, args.quiet, args.color.as_deref())?;
+    let mut msg_info = shell::MessageInfo::create(
+        args.verbose + cross::config::bool_from_envvar("CROSS_DEBUG") as u8,
+        args.quiet,
+        args.color.as_deref(),
+    )?;
     let status = match cross::run(args, target_list, &mut msg_info)? {
         Some(status) => status,
         None => {

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -367,7 +367,7 @@ mod tests {
             "bisector-nightly-2022-04-26-x86_64-unknown-linux-gnu",
             "/tmp/cross/sysroot".as_ref(),
             &crate::config::Config::new(None),
-            &mut MessageInfo::create(true, false, None).unwrap(),
+            &mut MessageInfo::create(2, false, None).unwrap(),
         )
         .unwrap();
     }

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -39,7 +39,7 @@ fn rustup_command(msg_info: &mut MessageInfo, no_flags: bool) -> Command {
         Verbosity::Quiet => {
             cmd.arg("--quiet");
         }
-        Verbosity::Verbose => {
+        Verbosity::Verbose(2..) => {
             cmd.arg("--verbose");
         }
         _ => (),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,7 +15,7 @@ static WORKSPACE: OnceCell<PathBuf> = OnceCell::new();
 /// Returns the cargo workspace for the manifest
 pub fn get_cargo_workspace() -> &'static Path {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let mut msg_info = crate::shell::Verbosity::Verbose.into();
+    let mut msg_info = crate::shell::Verbosity::Verbose(2).into();
     #[allow(clippy::unwrap_used)]
     WORKSPACE.get_or_init(|| {
         crate::cargo_metadata_with_args(Some(manifest_dir.as_ref()), None, &mut msg_info)

--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -118,7 +118,7 @@ pub fn build_docker_image(
     msg_info: &mut MessageInfo,
 ) -> cross::Result<()> {
     let verbose = match verbose {
-        0 => msg_info.is_verbose() as u8,
+        0 => msg_info.verbosity.level(),
         v => v,
     };
     let metadata = cargo_metadata(msg_info)?;

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -90,7 +90,7 @@ pub fn ci(args: CiJob, metadata: CargoMetadata) -> cross::Result<()> {
                 let search = cargo_command()
                     .args(&["search", "--limit", "1"])
                     .arg("cross")
-                    .run_and_get_stdout(&mut Verbosity::Verbose.into())?;
+                    .run_and_get_stdout(&mut Verbosity::Verbose(2).into())?;
                 let (cross, rest) = search
                     .split_once(" = ")
                     .ok_or_else(|| eyre::eyre!("cargo search failed"))?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -115,7 +115,7 @@ pub fn main() -> cross::Result<()> {
             hooks::test(cli.toolchain.as_deref(), &mut msg_info)?;
         }
         Commands::CiJob(args) => {
-            let metadata = cargo_metadata(&mut Verbosity::Verbose.into())?;
+            let metadata = cargo_metadata(&mut Verbosity::Verbose(2).into())?;
             ci::ci(args, metadata)?;
         }
         Commands::ConfigureCrosstool(args) => {

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -20,7 +20,7 @@ pub fn get_cargo_workspace() -> &'static Path {
         cross::cargo_metadata_with_args(
             Some(manifest_dir.as_ref()),
             None,
-            &mut MessageInfo::create(true, false, None).expect("should not fail"),
+            &mut MessageInfo::create(2, false, None).expect("should not fail"),
         )
         .unwrap()
         .unwrap()
@@ -274,7 +274,7 @@ mod tests {
     fn check_ubuntu_base() -> cross::Result<()> {
         // count all the entries of FROM for our images
         let mut counts = BTreeMap::new();
-        let mut msg_info = Verbosity::Verbose.into();
+        let mut msg_info = Verbosity::Verbose(2).into();
         let dockerfiles = read_dockerfiles(&mut msg_info)?;
         for (path, dockerfile) in dockerfiles {
             let lines: Vec<&str> = dockerfile.lines().collect();


### PR DESCRIPTION
this will make it so rustup doesn't show verbose unless `-vv` or `-v` and `CROSS_DEBUG` is used.
