### PR TITLE
Change `mips64-unknown-linux-gnuabi64` to hard-float.

### DIFF
--- a/.changes/974.json
+++ b/.changes/974.json
@@ -1,0 +1,11 @@
+[
+    {
+        "description": "change `mips64-unknown-linux-muslabi64` target to hard-float target.",
+        "type": "fixed",
+        "issues": [906]
+    },
+    {
+        "description": "build static libgcc and link to static libgcc for `mips64-unknown-linux-muslabi64` target.",
+        "type": "fixed"
+    }
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
             - { target: mipsel-unknown-linux-gnu,         os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }
             - { target: mips64-unknown-linux-gnuabi64,    os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1 }
             - { target: mips64el-unknown-linux-gnuabi64,  os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }
-            - { target: mips64-unknown-linux-muslabi64,   os: ubuntu-latest,                    std: 1, run: 1 }
+            - { target: mips64-unknown-linux-muslabi64,   os: ubuntu-latest,  cpp:1, dylib: 1,  std: 1, run: 1, runners: qemu-user }
             - { target: mips64el-unknown-linux-muslabi64, os: ubuntu-latest,                    std: 1, run: 1 }
             - { target: powerpc-unknown-linux-gnu,        os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }
             - { target: powerpc64-unknown-linux-gnu,      os: ubuntu-latest,  cpp: 1, dylib: 1, std: 1, run: 1, runners: qemu-user qemu-system }

--- a/docker/Dockerfile.mips64-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-muslabi64
@@ -14,19 +14,25 @@ RUN /qemu.sh mips64
 
 COPY musl.sh /
 RUN /musl.sh \
-    TARGET=mips64-linux-muslsf \
+    TARGET=mips64-linux-musl \
     "COMMON_CONFIG += -with-arch=mips64r2"
 
-ENV CROSS_MUSL_SYSROOT=/usr/local/mips64-linux-muslsf
+ENV CROSS_MUSL_SYSROOT=/usr/local/mips64-linux-musl
 COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_MUSL_SYSROOT mips64-sf
+RUN /musl-symlink.sh $CROSS_MUSL_SYSROOT mips64
+RUN mkdir -p $CROSS_MUSL_SYSROOT/usr/lib64
+# needed for the C/C++ runner
+RUN ln -s $CROSS_MUSL_SYSROOT/usr/lib/libc.so $CROSS_MUSL_SYSROOT/usr/lib64/libc.so
+RUN ln -s $CROSS_MUSL_SYSROOT/usr/lib/libc.so.1 $CROSS_MUSL_SYSROOT/usr/lib64/libc.so.1
+
+COPY mips64-linux-muslabi64-gcc.sh /usr/bin/
 
 COPY qemu-runner /
 
-ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_LINKER=mips64-linux-muslsf-gcc \
+ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_LINKER=mips64-linux-muslabi64-gcc.sh \
     CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_RUNNER="/qemu-runner mips64" \
-    CC_mips64_unknown_linux_muslabi64=mips64-linux-muslsf-gcc \
-    CXX_mips64_unknown_linux_muslabi64=mips64-linux-muslsf-g++ \
+    CC_mips64_unknown_linux_muslabi64=mips64-linux-musl-gcc \
+    CXX_mips64_unknown_linux_muslabi64=mips64-linux-musl-g++ \
     BINDGEN_EXTRA_CLANG_ARGS_mips64_unknown_linux_muslabi64="--sysroot=$CROSS_MUSL_SYSROOT" \
     QEMU_LD_PREFIX=$CROSS_MUSL_SYSROOT \
     RUST_TEST_THREADS=1

--- a/docker/mips64-linux-muslabi64-gcc.sh
+++ b/docker/mips64-linux-muslabi64-gcc.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# this fixes an issue of missing symbols from the command lines
+# these soft-float routines are required even for hard-float targets.
+#   (strtod.lo): undefined reference to symbol '__trunctfsf2@@GCC_3.0'
+
+set -x
+set -euo pipefail
+
+main() {
+    if [[ $# -gt 0 ]]; then
+        exec mips64-linux-musl-gcc "${@}" -lgcc -static-libgcc
+    else
+        exec mips64-linux-musl-gcc "${@}"
+    fi
+}
+
+main "${@}"


### PR DESCRIPTION
Changes `mips64-unknown-linux-gnuabi64` to use a hard-float musl toolchain, rather than a soft-float one.

Closes #906.