### PR TITLE
supplement `TARGETPLATFORM` with `RUST_TOOLCHAIN`

### DIFF
--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -189,6 +189,11 @@ pub fn build_docker_image(
             docker_build.arg("--load");
         }
 
+        docker_build.args(&[
+            "--build-arg",
+            &format!("RUST_TOOLCHAIN={}", platform.target),
+        ]);
+
         let mut tags = vec![];
 
         match (ref_type.as_deref(), ref_name.as_deref()) {


### PR DESCRIPTION
this is not strictly needed, but could be nice
