### PR TITLE
added default nix_store value

### DIFF
--- a/.changes/989.json
+++ b/.changes/989.json
@@ -1,0 +1,5 @@
+{
+    "type": "changed",
+    "description": "add default nix_store value to solve nix-related issues",
+    "issues": [260]
+}

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -305,7 +305,9 @@ impl Directories {
             Some(store) => {
                 eyre::bail!("unable to find provided nix-store directory {store:?}");
             }
-            None if cfg!(target_os = "linux") && default_nix_store.exists() => Some(default_nix_store),
+            None if cfg!(target_os = "linux") && default_nix_store.exists() => {
+                Some(default_nix_store)
+            }
             None => None,
         };
 

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -294,7 +294,7 @@ impl Directories {
         let xargo = file::canonicalize(&xargo)?;
         let nix_store = match nix_store {
             Some(store) => Some(file::canonicalize(&store)?),
-            None => None,
+            None => Some(PathBuf::from(r"/nix/store")),
         };
 
         let cargo = mount_finder.find_mount_path(cargo);


### PR DESCRIPTION
This pull request fixes the nix related issues described in #260. Its super simple, I just made the nix_store match statement default to `/nix/store` if the NIX_STORE variable is not set. 

There might be some edge cases where this won't fix the problem, but should be fine for any normal NixOS installation.


