### PR TITLE
fix path issue

### DIFF
--- a/.changes/994.json
+++ b/.changes/994.json
@@ -1,0 +1,5 @@
+{
+    "type": "fixed",
+    "description": "fixed wrong path used for target when pre-building in container in container mode",
+    "issues": [993]
+}

--- a/ci/test-cross-image.sh
+++ b/ci/test-cross-image.sh
@@ -35,6 +35,17 @@ git clone --depth 1 https://github.com/cross-rs/rust-cpp-hello-word "${td}"
 cd "${td}"
 cross run --target "${TARGET}"
 '
+td="$(mkcargotemp -d)"
+git clone --depth 1 https://github.com/cross-rs/rust-cpp-hello-word "${td}"
+cd "${td}"
+echo '# Cross.toml
+[target.'${TARGET}']
+pre-build = ["exit 0"]
+' > Cross.toml
+docker run --rm -e TARGET -e CROSS_CONTAINER_IN_CONTAINER=1 -e "CROSS_TARGET_${TARGET_UPPER//-/_}_IMAGE" \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v $PWD:/mount -w /mount \
+        "${CROSS_TARGET_CROSS_IMAGE}" cross build --target "${TARGET}"
 }
 
 main "${@}"

--- a/ci/test-docker-in-docker.sh
+++ b/ci/test-docker-in-docker.sh
@@ -23,8 +23,8 @@ ci_dir=$(realpath "${ci_dir}")
 . "${ci_dir}"/shared.sh
 
 main() {
-    docker run -v "${PROJECT_HOME}":"${PROJECT_HOME}" -w "${PROJECT_HOME}" \
-        --rm -e TARGET -e RUSTFLAGS -e RUST_TEST_THREADS \
+    docker run --platform linux/amd64 -v "${PROJECT_HOME}":"${PROJECT_HOME}" -w "${PROJECT_HOME}" \
+        --rm -e TARGET -e TARGET_UPPER -e RUSTFLAGS -e RUST_TEST_THREADS \
         -e LLVM_PROFILE_FILE -e CARGO_INCREMENTAL \
         -e "CROSS_TARGET_${TARGET_UPPER//-/_}_IMAGE" \
         -v /var/run/docker.sock:/var/run/docker.sock \
@@ -55,10 +55,14 @@ git clone --depth 1 https://github.com/cross-rs/test-workspace "${td}"
 cd "${td}"
 cross build --target "${TARGET}" --workspace \
     --manifest-path="./workspace/Cargo.toml" --verbose
+eval CROSS_TARGET_${TARGET_UPPER//-/_}_PRE_BUILD="exit" cross build --target "${TARGET}" --workspace \
+    --manifest-path="./workspace/Cargo.toml" --verbose
 cd workspace
 cross build --target "${TARGET}" --workspace --verbose
+eval CROSS_TARGET_${TARGET_UPPER//-/_}_PRE_BUILD="exit" cross build --target "${TARGET}" --workspace --verbose
 cd binary
 cross run --target "${TARGET}" --verbose
+eval CROSS_TARGET_${TARGET_UPPER//-/_}_PRE_BUILD="exit" cross run --target "${TARGET}" --verbose
 '
 }
 

--- a/src/bin/commands/containers.rs
+++ b/src/bin/commands/containers.rs
@@ -401,7 +401,7 @@ pub fn create_persistent_volume(
     if let Some(channel) = channel {
         toolchain = toolchain.with_picked(&config, channel.clone(), msg_info)?;
     };
-    let (metadata, dirs) = docker::get_package_info(engine, toolchain.clone(), msg_info)?;
+    let (dirs, metadata) = docker::get_package_info(engine, toolchain.clone(), msg_info)?;
     let container = docker::remote::unique_container_identifier(&toolchain_host, &metadata, &dirs)?;
     let volume = dirs.toolchain.unique_toolchain_identifier()?;
 
@@ -490,7 +490,7 @@ pub fn remove_persistent_volume(
     if let Some(channel) = channel {
         toolchain = toolchain.with_picked(&config, channel.clone(), msg_info)?;
     };
-    let (_, dirs) = docker::get_package_info(engine, toolchain.clone(), msg_info)?;
+    let (dirs, _) = docker::get_package_info(engine, toolchain.clone(), msg_info)?;
     let volume = dirs.toolchain.unique_toolchain_identifier()?;
 
     if !docker::remote::volume_exists(engine, &volume, msg_info)? {


### PR DESCRIPTION
fixes #993 

```
+ /usr/local/bin/docker buildx build --label 'org.cross-rs.for-cross-target=aarch64-unknown-linux-gnu' --label 'org.cross-rs.runs-with=x86_64-unknown-linux-gnu' --label 'org.cross-rs.workspace_root=/tmp/tmp.cmePkb/workspace' --tag localhost/cross-rs/cross-custom-workspace:aarch64-unknown-linux-gnu-e570c-pre-build --build-arg 'CROSS_CMD=exit' --build-arg 'CROSS_DEB_ARCH=arm64' --file /tmp/tmp.cmePkb/workspace/target/aarch64-unknown-linux-gnu/Dockerfile.aarch64-unknown-linux-gnu-custom --output 'type=docker' /var/lib/docker/overlay2/5b7e7f3b1f39b622d2a665281973f5c1bdc2dce21f33c0bc105ceee253cfbe42/merged/tmp/tmp.cmePkb
error: unable to prepare context: path "/var/lib/docker/overlay2/5b7e7f3b1f39b622d2a665281973f5c1bdc2dce21f33c0bc105ceee253cfbe42/merged/tmp/tmp.cmePkb" not found
Error: 
   0: could not run container
   1: when building custom image
   2: when pre-building
   3: `/usr/local/bin/docker buildx build --label 'org.cross-rs.for-cross-target=aarch64-unknown-linux-gnu' --label 'org.cross-rs.runs-with=x86_64-unknown-linux-gnu' --label 'org.cross-rs.workspace_root=/tmp/tmp.cmePkb/workspace' --tag localhost/cross-rs/cross-custom-workspace:aarch64-unknown-linux-gnu-e570c-pre-build --build-arg 'CROSS_CMD=exit' --build-arg 'CROSS_DEB_ARCH=arm64' --file /tmp/tmp.cmePkb/workspace/target/aarch64-unknown-linux-gnu/Dockerfile.aarch64-unknown-linux-gnu-custom --output 'type=docker' /var/lib/docker/overlay2/5b7e7f3b1f39b622d2a665281973f5c1bdc2dce21f33c0bc105ceee253cfbe42/merged/tmp/tmp.cmePkb` failed with exit status: 1
```

this issue presents because the `--file` arg is wrong
