### PR TITLE
Improve error diagnostics and other changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Dockerfile.* linguist-language=Dockerfile

--- a/ci/test-remote.sh
+++ b/ci/test-remote.sh
@@ -45,7 +45,9 @@ cross_test_cpp() {
 
     pushd "${td}"
     retry cargo fetch
-    "${CROSS}" run --target "${TARGET}"
+    "${CROSS}" run --target "${TARGET}" | grep "Hello, world!"
+    sed -i 's/Hello, world/Hello, test/g' hellopp.cc
+    "${CROSS}" run --target "${TARGET}" | grep "Hello, test!"
     popd
 
     rm -rf "${td}"

--- a/src/bin/commands/containers.rs
+++ b/src/bin/commands/containers.rs
@@ -396,7 +396,7 @@ pub fn create_persistent_volume(
     if let Some(channel) = channel {
         toolchain.channel = channel.channel.clone();
     };
-    let mount_finder = docker::MountFinder::create(engine)?;
+    let mount_finder = docker::MountFinder::create(engine, msg_info)?;
     let dirs = docker::ToolchainDirectories::assemble(&mount_finder, toolchain.clone())?;
     let container_id = dirs.unique_container_identifier(&toolchain.host().target)?;
     let volume_id = dirs.unique_toolchain_identifier()?;
@@ -464,7 +464,7 @@ pub fn remove_persistent_volume(
     if let Some(channel) = channel {
         toolchain.channel = channel.channel.clone();
     };
-    let mount_finder = docker::MountFinder::create(engine)?;
+    let mount_finder = docker::MountFinder::create(engine, msg_info)?;
     let dirs = docker::ToolchainDirectories::assemble(&mount_finder, toolchain)?;
     let volume_id = dirs.unique_toolchain_identifier()?;
     let volume = docker::DockerVolume::new(engine, &volume_id);

--- a/src/bin/commands/images.rs
+++ b/src/bin/commands/images.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use clap::builder::PossibleValue;
 use clap::{Args, Subcommand};
 use cross::docker::{self, CROSS_CUSTOM_DOCKERFILE_IMAGE_PREFIX};
 use cross::shell::MessageInfo;
@@ -50,10 +51,10 @@ impl clap::ValueEnum for OutputFormat {
         &[Self::Human, Self::Json]
     }
 
-    fn to_possible_value<'a>(&self) -> Option<clap::PossibleValue<'a>> {
+    fn to_possible_value(&self) -> Option<PossibleValue> {
         match self {
-            OutputFormat::Human => Some(clap::PossibleValue::new("human")),
-            OutputFormat::Json => Some(clap::PossibleValue::new("json")),
+            OutputFormat::Human => Some(PossibleValue::new("human")),
+            OutputFormat::Json => Some(PossibleValue::new("json")),
         }
     }
 }

--- a/src/bin/cross.rs
+++ b/src/bin/cross.rs
@@ -18,13 +18,7 @@ pub fn main() -> cross::Result<()> {
     let target_list = rustc::target_list(&mut Verbosity::Quiet.into())?;
     let args = cli::parse(&target_list)?;
     let subcommand = args.subcommand;
-    let mut msg_info = shell::MessageInfo::create(
-        args.verbose
-            + cross::config::bool_from_envvar(&std::env::var("CROSS_DEBUG").unwrap_or_default())
-                as u8,
-        args.quiet,
-        args.color.as_deref(),
-    )?;
+    let mut msg_info = shell::MessageInfo::create(args.verbose, args.quiet, args.color.as_deref())?;
     let status = match cross::run(args, target_list, &mut msg_info)? {
         Some(status) => status,
         None => {

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -29,6 +29,7 @@ macro_rules! bail_container_exited {
     }};
 }
 
+#[track_caller]
 fn subcommand_or_exit(engine: &Engine, cmd: &str) -> Result<Command> {
     bail_container_exited!();
     Ok(engine.subcommand(cmd))
@@ -42,6 +43,7 @@ impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
     // NOTE: `reldir` should be a relative POSIX path to the root directory
     // on windows, this should be something like `mnt/c`. that is, all paths
     // inside the container should not have the mount prefix.
+    #[track_caller]
     fn create_dir(
         &self,
         reldir: &str,
@@ -57,6 +59,7 @@ impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
 
     // copy files for a docker volume, for remote host support
     // NOTE: `reldst` has the same caveats as `reldir` in `create_dir`.
+    #[track_caller]
     fn copy_files(
         &self,
         src: &Path,
@@ -72,6 +75,7 @@ impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
     }
 
     // copy files for a docker volume, for remote host support
+    #[track_caller]
     fn copy_files_nocache(
         &self,
         src: &Path,
@@ -92,6 +96,7 @@ impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
 
     // copy files for a docker volume, for remote host support
     // provides a list of files relative to src.
+    #[track_caller]
     fn copy_file_list(
         &self,
         src: &Path,
@@ -116,6 +121,7 @@ impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
 
     // removed files from a docker volume, for remote host support
     // provides a list of files relative to src.
+    #[track_caller]
     fn remove_file_list(
         &self,
         reldst: &str,
@@ -156,6 +162,7 @@ impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
             .run_and_get_status(msg_info, true)
     }
 
+    #[track_caller]
     fn container_path_exists(
         &self,
         relpath: &str,
@@ -173,6 +180,7 @@ impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
             .success())
     }
 
+    #[track_caller]
     pub fn copy_xargo(&self, mount_prefix: &str, msg_info: &mut MessageInfo) -> Result<()> {
         let dirs = &self.toolchain_dirs;
         let reldst = dirs.xargo_mount_path_relative()?;
@@ -194,6 +202,7 @@ impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
         Ok(())
     }
 
+    #[track_caller]
     pub fn copy_cargo(
         &self,
         mount_prefix: &str,
@@ -230,6 +239,7 @@ impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
     }
 
     // copy over files needed for all targets in the toolchain that should never change
+    #[track_caller]
     fn copy_rust_base(&self, mount_prefix: &str, msg_info: &mut MessageInfo) -> Result<()> {
         let dirs = &self.toolchain_dirs;
 
@@ -273,6 +283,7 @@ impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
         warn_symlinks(had_symlinks, msg_info)
     }
 
+    #[track_caller]
     fn copy_rust_manifest(&self, mount_prefix: &str, msg_info: &mut MessageInfo) -> Result<()> {
         let dirs = &self.toolchain_dirs;
 
@@ -298,6 +309,7 @@ impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
     }
 
     // copy over the toolchain for a specific triple
+    #[track_caller]
     fn copy_rust_triple(
         &self,
         target_triple: &TargetTriple,
@@ -335,6 +347,7 @@ impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
         Ok(())
     }
 
+    #[track_caller]
     pub fn copy_rust(
         &self,
         target_triple: Option<&TargetTriple>,
@@ -355,6 +368,7 @@ impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
         Ok(())
     }
 
+    #[track_caller]
     fn copy_mount(
         &self,
         src: &Path,

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -696,22 +696,26 @@ impl<'a, 'b> DockerVolume<'a, 'b> {
         Self { engine, name }
     }
 
+    #[track_caller]
     pub fn create(&self, msg_info: &mut MessageInfo) -> Result<ExitStatus> {
         self.engine
             .run_and_get_status(&["volume", "create", self.name], msg_info)
     }
 
+    #[track_caller]
     pub fn remove(&self, msg_info: &mut MessageInfo) -> Result<ExitStatus> {
         self.engine
             .run_and_get_status(&["volume", "rm", self.name], msg_info)
     }
 
+    #[track_caller]
     pub fn exists(&self, msg_info: &mut MessageInfo) -> Result<bool> {
         self.engine
             .run_and_get_output(&["volume", "inspect", self.name], msg_info)
             .map(|output| output.status.success())
     }
 
+    #[track_caller]
     pub fn existing(
         engine: &Engine,
         toolchain: &QualifiedToolchain,
@@ -834,6 +838,7 @@ impl Engine {
         command
     }
 
+    #[track_caller]
     pub(crate) fn run_and_get_status(
         &self,
         args: &[&str],
@@ -842,6 +847,7 @@ impl Engine {
         self.command().args(args).run_and_get_status(msg_info, true)
     }
 
+    #[track_caller]
     pub(crate) fn run_and_get_output(
         &self,
         args: &[&str],

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -200,8 +200,9 @@ impl DockerPaths {
         metadata: CargoMetadata,
         cwd: PathBuf,
         toolchain: QualifiedToolchain,
+        msg_info: &mut MessageInfo,
     ) -> Result<Self> {
-        let mount_finder = MountFinder::create(engine)?;
+        let mount_finder = MountFinder::create(engine, msg_info)?;
         let (directories, metadata) =
             Directories::assemble(&mount_finder, metadata, &cwd, toolchain)?;
         Ok(Self {
@@ -1325,7 +1326,10 @@ pub(crate) fn get_image(config: &Config, target: &Target, uses_zig: bool) -> Res
     Ok(image)
 }
 
-fn docker_read_mount_paths(engine: &Engine) -> Result<Vec<MountDetail>> {
+fn docker_read_mount_paths(
+    engine: &Engine,
+    msg_info: &mut MessageInfo,
+) -> Result<Vec<MountDetail>> {
     let hostname = env::var("HOSTNAME").wrap_err("HOSTNAME environment variable not found")?;
 
     let mut docker: Command = {
@@ -1334,7 +1338,7 @@ fn docker_read_mount_paths(engine: &Engine) -> Result<Vec<MountDetail>> {
         command
     };
 
-    let output = docker.run_and_get_stdout(&mut Verbosity::Quiet.into())?;
+    let output = docker.run_and_get_stdout(msg_info)?;
     let info = serde_json::from_str(&output).wrap_err("failed to parse docker inspect output")?;
     dockerinfo_parse_mounts(&info)
 }
@@ -1410,9 +1414,9 @@ impl MountFinder {
         MountFinder { mounts }
     }
 
-    pub fn create(engine: &Engine) -> Result<MountFinder> {
+    pub fn create(engine: &Engine, msg_info: &mut MessageInfo) -> Result<MountFinder> {
         Ok(if engine.in_docker {
-            MountFinder::new(docker_read_mount_paths(engine)?)
+            MountFinder::new(docker_read_mount_paths(engine, msg_info)?)
         } else {
             MountFinder::default()
         })
@@ -1695,12 +1699,12 @@ mod tests {
                 return Ok(());
             }
 
-            let mount_finder = MountFinder::create(&engine)?;
+            let mount_finder = MountFinder::create(&engine, &mut msg_info)?;
             let metadata = cargo_metadata(true, &mut msg_info)?;
             let (directories, _) = get_directories(metadata, &mount_finder)?;
             let toolchain_dirs = directories.toolchain_directories();
             let package_dirs = directories.package_directories();
-            let mount_finder = MountFinder::new(docker_read_mount_paths(&engine)?);
+            let mount_finder = MountFinder::new(docker_read_mount_paths(&engine, &mut msg_info)?);
             let mount_path = |p| mount_finder.find_mount_path(p);
 
             paths_equal(toolchain_dirs.cargo(), &mount_path(home()?.join(".cargo")))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -707,7 +707,13 @@ To override the toolchain mounted in the image, set `target.{}.image.toolchain =
                     engine.register_binfmt(&target, msg_info)?;
                 }
 
-                let paths = docker::DockerPaths::create(&engine, metadata, cwd, toolchain.clone())?;
+                let paths = docker::DockerPaths::create(
+                    &engine,
+                    metadata,
+                    cwd,
+                    toolchain.clone(),
+                    msg_info,
+                )?;
                 let options = docker::DockerOptions::new(
                     engine,
                     target.clone(),


### PR DESCRIPTION
- don't hide hostname querying in verbose
- output cross images as json
- associate `CROSS_DEBUG` with `MessageInfo`
<img width="490" alt="image" src="https://user-images.githubusercontent.com/1502855/195405356-1f673155-6be1-4f9f-9cc7-2cbf50604345.png">
- track caller when doing debug or error prints from `MessageInfo` and print the line it comes from


