### PR TITLE
Update deny list to all system packages for ARMv6 HF.

### DIFF
--- a/.changes/1018.json
+++ b/.changes/1018.json
@@ -1,0 +1,4 @@
+{
+    "description": "deny installation of armhf debian packages for the arm-unknown-linux-gnueabihf target.",
+    "type": "fixed"
+}

--- a/docker/Dockerfile.arm-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabihf
@@ -17,6 +17,9 @@ RUN /crosstool-ng.sh arm-unknown-linux-gnueabihf.config 5
 
 ENV PATH /x-tools/arm-unknown-linux-gnueabihf/bin/:$PATH
 
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=armhf /deny-debian-packages.sh
+
 COPY qemu.sh /
 RUN /qemu.sh arm
 

--- a/docker/deny-debian-packages.sh
+++ b/docker/deny-debian-packages.sh
@@ -3,15 +3,24 @@
 set -x
 set -euo pipefail
 
-main() {
-    local package
-
-    for package in "${@}"; do
-        echo "Package: ${package}:${TARGET_ARCH}
+deny_package() {
+    local package="${1}"
+    local filename="${2}"
+    echo "Package: ${package}:${TARGET_ARCH}
 Pin: release *
-Pin-Priority: -1" > "/etc/apt/preferences.d/${package}"
-        echo "${package}"
-    done
+Pin-Priority: -1" > "/etc/apt/preferences.d/${filename}"
+}
+
+main() {
+    if [[ $# -eq 0 ]]; then
+        deny_package '*' "all-packages"
+    else
+        local package
+        for package in "${@}"; do
+            deny_package "${package}" "${package}"
+            echo "${package}"
+        done
+    fi
 
     rm "${0}"
 }


### PR DESCRIPTION
Currently, when using `arm-unknown-linux-gnueabihf`, users frequently try to install packages for the `armhf` Debian architecture, objects which are compiled for ARMv7-A, and therefore are not compatibility with ARMv6 platforms such as the Raspberry Pi 0. This differs from the soft-float targets, where packages for the `armel` architecture are compiled for the ARMv5TE architecture, and therefore are compatible with ARMv5TE, ARMv6, and ARMv7 soft-float targets.

Deny-listing all packages for the `armhf` architecture prevents issues such as in #1017, where the use of ARMv7 system packages are linked to the binary, so the resulting binary can no longer be executed on an ARMv6 platform. This is difficult to detect until the user attempts to use the generated objects (binaries, libraries) on native hardware.

Also linked is #426.