### PR TITLE
Fixing superfluous download of pre-built target rust-std when build-s…

### DIFF
--- a/.changes/1024.json
+++ b/.changes/1024.json
@@ -1,0 +1,5 @@
+{
+    "description": "`rust-std` is no longer downloaded when using `build-std = true`",
+    "type": "fixed",
+    "breaking": false
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -624,6 +624,7 @@ To override the toolchain mounted in the image, set `target.{}.image.toolchain =
                 }
 
                 if !uses_xargo
+                    && !uses_build_std
                     && !available_targets.is_installed(&target)
                     && available_targets.contains(&target)
                 {


### PR DESCRIPTION
This fix prevents the unnecessary download of of the target's pre-built rust-std when the target specified in Cross.toml has `build-std = true`. When this configuration is set, pulling the targets pre-built rust-std is unnecessary and is not used during the build. 

An example `Cross.toml` file could look like:

```
[target.x86_64-unknown-freebsd]
build-std = true
```

with respective build commands:

```
cross build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-freebsd --release
```
```
cross build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-netbsd --release
```

You will note, the `freebsd` build will not pull the pre-built `freebsd rust-std` and the build will succeed, while the `netbsd` will still pull the pre-built std i.e:

```
info: downloading component 'rust-std' for 'x86_64-unknown-netbsd'
info: installing component 'rust-std' for 'x86_64-unknown-netbsd'
```
