### PR TITLE
Fix tests, linkers, and specifications for various targets.

### DIFF
--- a/.changes/1028.json
+++ b/.changes/1028.json
@@ -26,10 +26,6 @@
         "breaking": true
     },
     {
-        "description": "document whether MIPS musl targets are hard or soft float.",
-        "type": "internal"
-    },
-    {
         "description": "convert mips-unknown-linux-musl and mipsel-unknown-linux-musl to use the mips32r2 architecture, identical to the rust targets.",
         "type": "changed",
         "breaking": true

--- a/.changes/1028.json
+++ b/.changes/1028.json
@@ -1,0 +1,37 @@
+[
+    {
+        "description": "link to libgcc for armv5te-unknown-linux-musleabi.",
+        "type": "fixed"
+    },
+    {
+        "description": "add C++ support for FreeBSD targets.",
+        "type": "added"
+    },
+    {
+        "description": "test dynamic library support for Android targets in CI.",
+        "type": "internal"
+    },
+    {
+        "description": "test partial C++ support for mips64el-unknown-linux-muslabi64 in CI.",
+        "type": "internal"
+    },
+    {
+        "description": "convert mips64el-unknown-linux-muslabi64 to a hard-float toolchain to match the rust target.",
+        "type": "changed",
+        "breaking": true
+    },
+    {
+        "description": "convert mips64el-unknown-linux-muslabi64 to use the mips64r2 architecture, identical to the rust target.",
+        "type": "changed",
+        "breaking": true
+    },
+    {
+        "description": "document whether MIPS musl targets are hard or soft float.",
+        "type": "internal"
+    },
+    {
+        "description": "convert mips-unknown-linux-musl and mipsel-unknown-linux-musl to use the mips32r2 architecture, identical to the rust targets.",
+        "type": "changed",
+        "breaking": true
+    }
+]

--- a/docker/Dockerfile.armv5te-unknown-linux-musleabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-musleabi
@@ -26,7 +26,9 @@ RUN /musl-symlink.sh $CROSS_MUSL_SYSROOT arm
 
 COPY qemu-runner base-runner.sh /
 
-ENV CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_LINKER=arm-linux-musleabi-gcc \
+COPY arm-linux-musleabi-gcc.sh /usr/bin/
+
+ENV CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_LINKER=arm-linux-musleabi-gcc.sh \
     CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_RUNNER="/qemu-runner arm" \
     CC_armv5te_unknown_linux_musleabi=arm-linux-musleabi-gcc \
     CXX_armv5te_unknown_linux_musleabi=arm-linux-musleabi-g++ \

--- a/docker/Dockerfile.i686-unknown-freebsd
+++ b/docker/Dockerfile.i686-unknown-freebsd
@@ -19,7 +19,9 @@ COPY freebsd-install.sh /
 COPY freebsd-extras.sh /
 RUN /freebsd-extras.sh
 
-ENV CARGO_TARGET_I686_UNKNOWN_FREEBSD_LINKER=i686-unknown-freebsd12-gcc \
+COPY i686-unknown-freebsd12-gcc.sh /usr/bin
+
+ENV CARGO_TARGET_I686_UNKNOWN_FREEBSD_LINKER=i686-unknown-freebsd12-gcc.sh \
     CC_i686_unknown_freebsd=i686-unknown-freebsd12-gcc \
     CXX_i686_unknown_freebsd=i686-unknown-freebsd12-g++ \
     BINDGEN_EXTRA_CLANG_ARGS_i686_unknown_freebsd="--sysroot=/usr/local/i686-unknown-freebsd12" \

--- a/docker/Dockerfile.mips-unknown-linux-musl
+++ b/docker/Dockerfile.mips-unknown-linux-musl
@@ -13,6 +13,8 @@ RUN /xargo.sh
 COPY qemu.sh /
 RUN /qemu.sh mips
 
+# this is a soft-float target for the mips32r2 architecture
+# https://github.com/rust-lang/rust/blob/75d3027fb5ce1af6712e4503c9574802212101bd/compiler/rustc_target/src/spec/mips_unknown_linux_musl.rs#L7
 COPY musl.sh /
 RUN /musl.sh \
     TARGET=mips-linux-muslsf \

--- a/docker/Dockerfile.mips64-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-muslabi64
@@ -12,6 +12,8 @@ RUN /xargo.sh
 COPY qemu.sh /
 RUN /qemu.sh mips64
 
+# this is a hard-float target for the mips64r2 architecture
+# https://github.com/rust-lang/rust/blob/75d3027fb5ce1af6712e4503c9574802212101bd/compiler/rustc_target/src/spec/mips64_unknown_linux_muslabi64.rs#L7
 COPY musl.sh /
 RUN /musl.sh \
     TARGET=mips64-linux-musl \

--- a/docker/Dockerfile.mips64el-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-muslabi64
@@ -12,21 +12,29 @@ RUN /xargo.sh
 COPY qemu.sh /
 RUN /qemu.sh mips64el
 
+# this is a hard-float target for the mips64r2 architecture
+# https://github.com/rust-lang/rust/blob/75d3027fb5ce1af6712e4503c9574802212101bd/compiler/rustc_target/src/spec/mips64el_unknown_linux_muslabi64.rs#L6
 COPY musl.sh /
 RUN /musl.sh \
-    TARGET=mips64el-linux-muslsf \
-    "COMMON_CONFIG += -with-arch=mips64"
+    TARGET=mips64el-linux-musl \
+    "COMMON_CONFIG += -with-arch=mips64r2"
 
-ENV CROSS_MUSL_SYSROOT=/usr/local/mips64el-linux-muslsf
+ENV CROSS_MUSL_SYSROOT=/usr/local/mips64el-linux-musl
 COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_MUSL_SYSROOT mips64el-sf
+RUN /musl-symlink.sh $CROSS_MUSL_SYSROOT mips64el
+RUN mkdir -p $CROSS_MUSL_SYSROOT/usr/lib64
+# needed for the C/C++ runners
+RUN ln -s $CROSS_MUSL_SYSROOT/usr/lib/libc.so $CROSS_MUSL_SYSROOT/usr/lib64/libc.so
+RUN ln -s $CROSS_MUSL_SYSROOT/usr/lib/libc.so.1 $CROSS_MUSL_SYSROOT/usr/lib64/libc.so.1
+
+COPY mips64el-linux-musl-gcc.sh /usr/bin/
 
 COPY qemu-runner base-runner.sh /
 
-ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_LINKER=mips64el-linux-muslsf-gcc \
+ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_LINKER=mips64el-linux-musl-gcc.sh \
     CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_RUNNER="/qemu-runner mips64el" \
-    CC_mips64el_unknown_linux_muslabi64=mips64el-linux-muslsf-gcc \
-    CXX_mips64el_unknown_linux_muslabi64=mips64el-linux-muslsf-g++ \
+    CC_mips64el_unknown_linux_muslabi64=mips64el-linux-musl-gcc \
+    CXX_mips64el_unknown_linux_muslabi64=mips64el-linux-musl-g++ \
     BINDGEN_EXTRA_CLANG_ARGS_mips64el_unknown_linux_muslabi64="--sysroot=$CROSS_MUSL_SYSROOT" \
     QEMU_LD_PREFIX=$CROSS_MUSL_SYSROOT \
     RUST_TEST_THREADS=1

--- a/docker/Dockerfile.mipsel-unknown-linux-musl
+++ b/docker/Dockerfile.mipsel-unknown-linux-musl
@@ -13,10 +13,12 @@ RUN /xargo.sh
 COPY qemu.sh /
 RUN /qemu.sh mipsel
 
+# this is a soft-float target for the mips32r2 architecture
+# https://github.com/rust-lang/rust/blob/75d3027fb5ce1af6712e4503c9574802212101bd/compiler/rustc_target/src/spec/mipsel_unknown_linux_musl.rs#L6
 COPY musl.sh /
 RUN /musl.sh \
     TARGET=mipsel-linux-muslsf \
-    "COMMON_CONFIG += -with-arch=mips32"
+    "COMMON_CONFIG += -with-arch=mips32r2"
 
 ENV CROSS_MUSL_SYSROOT=/usr/local/mipsel-linux-muslsf
 COPY musl-symlink.sh /

--- a/docker/Dockerfile.x86_64-unknown-freebsd
+++ b/docker/Dockerfile.x86_64-unknown-freebsd
@@ -19,7 +19,9 @@ COPY freebsd-install.sh /
 COPY freebsd-extras.sh /
 RUN /freebsd-extras.sh
 
-ENV CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER=x86_64-unknown-freebsd12-gcc \
+COPY x86_64-unknown-freebsd12-gcc.sh /usr/bin
+
+ENV CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER=x86_64-unknown-freebsd12-gcc.sh \
     CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd12-gcc \
     CXX_x86_64_unknown_freebsd=x86_64-unknown-freebsd12-g++ \
     BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_freebsd="--sysroot=/usr/local/x86_64-unknown-freebsd12" \

--- a/docker/aarch64-linux-musl-gcc.sh
+++ b/docker/aarch64-linux-musl-gcc.sh
@@ -8,13 +8,7 @@ set -x
 set -euo pipefail
 
 main() {
-    local release=
-    release=$(rustc -Vv | grep '^release:' | cut -d ':' -f2)
-    # NOTE we assume `major` is always "1"
-    local minor=
-    minor=$(echo "$release" | cut -d '.' -f2)
-
-    if (( minor >= 48 )) || [[ $# -eq 0 ]]; then
+    if (( CROSS_RUSTC_MINOR_VERSION >= 48 )) || [[ $# -eq 0 ]]; then
         # no workaround
         exec aarch64-linux-musl-gcc "${@}"
     else

--- a/docker/arm-linux-musleabi-gcc.sh
+++ b/docker/arm-linux-musleabi-gcc.sh
@@ -2,7 +2,7 @@
 
 # this linker wrapper works around the missing sync `sync_X_and_fetch`
 # routines. this affects rust versions with compiler-builtins <= 0.1.77,
-# which has not yet been merged into stable. this requires the `-lgcc`
+# which affects toolchains older than 1.65 which require the `-lgcc`
 # linker flag to provide the missing builtin.
 # https://github.com/rust-lang/compiler-builtins/pull/484
 
@@ -10,7 +10,7 @@ set -x
 set -euo pipefail
 
 main() {
-    if [[ $# -eq 0 ]]; then
+    if (( CROSS_RUSTC_MINOR_VERSION >= 65 )) || [[ $# -eq 0 ]]; then
         exec arm-linux-musleabi-gcc "${@}"
     else
         exec arm-linux-musleabi-gcc "${@}" -lgcc -static-libgcc

--- a/docker/i686-unknown-freebsd12-gcc.sh
+++ b/docker/i686-unknown-freebsd12-gcc.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# the freebsd images need libstdc++ to be linked as well
+# otherwise, we get `undefined reference to `std::ios_base::Init::Init()'`
+
+set -x
+set -euo pipefail
+
+main() {
+    if [[ $# -eq 0 ]]; then
+        exec i686-unknown-freebsd12-gcc "${@}"
+    else
+        exec i686-unknown-freebsd12-gcc "${@}" -lc++ -lstdc++
+    fi
+}
+
+main "${@}"

--- a/docker/mips64-linux-musl-gcc.sh
+++ b/docker/mips64-linux-musl-gcc.sh
@@ -2,7 +2,7 @@
 
 # this linker wrapper works around the missing soft-fp routine __trunctfsf2
 # this affects rust versions with compiler-builtins <= 0.1.77,
-# which has not yet been merged into stable. this requires the `-lgcc`
+# which affects toolchains older than 1.65 which require the `-lgcc`
 # linker flag to provide the missing builtin.
 # https://github.com/rust-lang/compiler-builtins/pull/483
 
@@ -10,7 +10,7 @@ set -x
 set -euo pipefail
 
 main() {
-    if [[ $# -eq 0 ]]; then
+    if (( CROSS_RUSTC_MINOR_VERSION >= 65 )) || [[ $# -eq 0 ]]; then
         exec mips64-linux-musl-gcc "${@}"
     else
         exec mips64-linux-musl-gcc "${@}" -lgcc -static-libgcc

--- a/docker/mips64el-linux-musl-gcc.sh
+++ b/docker/mips64el-linux-musl-gcc.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# this linker wrapper works around the missing soft-fp routine __trunctfsf2
+# this affects rust versions with compiler-builtins <= 0.1.77,
+# which has not yet been merged into stable. this requires the `-lgcc`
+# linker flag to provide the missing builtin.
+# https://github.com/rust-lang/compiler-builtins/pull/483
+
+set -x
+set -euo pipefail
+
+main() {
+    if [[ $# -eq 0 ]]; then
+        exec mips64el-linux-musl-gcc "${@}"
+    else
+        exec mips64el-linux-musl-gcc "${@}" -lgcc -static-libgcc
+    fi
+}
+
+main "${@}"

--- a/docker/mips64el-linux-musl-gcc.sh
+++ b/docker/mips64el-linux-musl-gcc.sh
@@ -2,7 +2,7 @@
 
 # this linker wrapper works around the missing soft-fp routine __trunctfsf2
 # this affects rust versions with compiler-builtins <= 0.1.77,
-# which has not yet been merged into stable. this requires the `-lgcc`
+# which affects toolchains older than 1.65 which require the `-lgcc`
 # linker flag to provide the missing builtin.
 # https://github.com/rust-lang/compiler-builtins/pull/483
 
@@ -10,7 +10,7 @@ set -x
 set -euo pipefail
 
 main() {
-    if [[ $# -eq 0 ]]; then
+    if (( CROSS_RUSTC_MINOR_VERSION >= 65 )) || [[ $# -eq 0 ]]; then
         exec mips64el-linux-musl-gcc "${@}"
     else
         exec mips64el-linux-musl-gcc "${@}" -lgcc -static-libgcc

--- a/docker/x86_64-unknown-freebsd12-gcc.sh
+++ b/docker/x86_64-unknown-freebsd12-gcc.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# the freebsd images need libstdc++ to be linked as well
+# otherwise, we get `undefined reference to `std::ios_base::Init::Init()'`
+
+set -x
+set -euo pipefail
+
+main() {
+    if [[ $# -eq 0 ]]; then
+        exec x86_64-unknown-freebsd12-gcc "${@}"
+    else
+        exec x86_64-unknown-freebsd12-gcc "${@}" -lc++ -lstdc++
+    fi
+}
+
+main "${@}"

--- a/src/docker/local.rs
+++ b/src/docker/local.rs
@@ -38,14 +38,7 @@ pub(crate) fn run(
         .image
         .platform
         .specify_platform(&options.engine, &mut docker);
-    docker_envvars(
-        &mut docker,
-        &options.config,
-        dirs,
-        &options.target,
-        options.cargo_variant,
-        msg_info,
-    )?;
+    docker_envvars(&mut docker, &options, dirs, msg_info)?;
 
     docker_mount(
         &mut docker,

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -1209,14 +1209,7 @@ symlink_recurse \"${{prefix}}\"
     // 6. execute our cargo command inside the container
     let mut docker = subcommand(engine, "exec");
     docker_user_id(&mut docker, engine.kind);
-    docker_envvars(
-        &mut docker,
-        &options.config,
-        dirs,
-        target,
-        options.cargo_variant,
-        msg_info,
-    )?;
+    docker_envvars(&mut docker, &options, dirs, msg_info)?;
     docker_cwd(&mut docker, &paths)?;
     docker.arg(&container);
     docker.args(["sh", "-c", &build_command(dirs, &cmd)]);

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -574,7 +574,7 @@ pub(crate) fn docker_envvars(
 
     let (major, minor, patch) = match options.rustc_version.as_ref() {
         Some(version) => (version.major, version.minor, version.patch),
-        // no toolchain version available, always provide older
+        // no toolchain version available, always provide the oldest
         // compiler available. this isn't a major issue because
         // linking will libgcc will not include symbols found in
         // the builtins.

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -576,7 +576,7 @@ pub(crate) fn docker_envvars(
         Some(version) => (version.major, version.minor, version.patch),
         // no toolchain version available, always provide the oldest
         // compiler available. this isn't a major issue because
-        // linking will libgcc will not include symbols found in
+        // linking with libgcc will not include symbols found in
         // the builtins.
         None => (1, 0, 0),
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,17 +595,19 @@ To override the toolchain mounted in the image, set `target.{}.image.toolchain =
                 }
             };
 
-            if let Some((rustc_version, channel, rustc_commit)) = toolchain.rustc_version()? {
+            let mut rustc_version = None;
+            if let Some((version, channel, commit)) = toolchain.rustc_version()? {
                 if toolchain.date.is_none() {
                     warn_host_version_mismatch(
                         &host_version_meta,
                         &toolchain,
-                        &rustc_version,
-                        &rustc_commit,
+                        &version,
+                        &commit,
                         msg_info,
                     )?;
                 }
                 is_nightly = channel == Channel::Nightly;
+                rustc_version = Some(version);
             }
 
             let uses_build_std = config.build_std(&target).unwrap_or(false);
@@ -711,6 +713,7 @@ To override the toolchain mounted in the image, set `target.{}.image.toolchain =
                     config,
                     image,
                     cargo_variant,
+                    rustc_version,
                 );
                 let status = docker::run(options, paths, &filtered_args, msg_info)
                     .wrap_err("could not run container")?;

--- a/targets.toml
+++ b/targets.toml
@@ -157,6 +157,8 @@ run = true
 [[target]]
 target = "mips64el-unknown-linux-muslabi64"
 os = "ubuntu-latest"
+# FIXME: Lacking partial C++ support due to missing compiler builtins.
+cpp = true
 std = true
 run = true
 
@@ -191,6 +193,7 @@ runners = "qemu-user qemu-system"
 target = "riscv64gc-unknown-linux-gnu"
 os = "ubuntu-latest"
 cpp = true
+dylib = true
 std = true
 run = true
 runners = "qemu-user qemu-system"
@@ -309,6 +312,7 @@ run = true
 target = "aarch64-linux-android"
 os = "ubuntu-latest"
 cpp = true
+dylib = true
 std = true
 run = true
 
@@ -316,6 +320,7 @@ run = true
 target = "arm-linux-androideabi"
 os = "ubuntu-latest"
 cpp = true
+dylib = true
 std = true
 run = true
 
@@ -323,6 +328,7 @@ run = true
 target = "armv7-linux-androideabi"
 os = "ubuntu-latest"
 cpp = true
+dylib = true
 std = true
 run = true
 
@@ -337,6 +343,7 @@ run = true
 target = "i686-linux-android"
 os = "ubuntu-latest"
 cpp = true
+dylib = true
 std = true
 run = true
 
@@ -344,6 +351,7 @@ run = true
 target = "x86_64-linux-android"
 os = "ubuntu-latest"
 cpp = true
+dylib = true
 std = true
 run = true
 
@@ -387,12 +395,14 @@ build-std = true
 [[target]]
 target = "i686-unknown-freebsd"
 os = "ubuntu-latest"
+cpp = true
 dylib = true
 std = true
 
 [[target]]
 target = "x86_64-unknown-freebsd"
 os = "ubuntu-latest"
+cpp = true
 dylib = true
 std = true
 


### PR DESCRIPTION
- Fixes linking to libgcc for `armv5te-unknown-linux-musleabi`.
- Adds C++ support for FreeBSD targets by linking to `libstdc++`.
- Tests dynamic library support for Android targets in CI.
- Tests C++ support for `mips64el-unknown-linux-muslabi64` in CI.
- Convert `mips64el-unknown-linux-muslabi64` to a hard-float toolchain to match the rust target.
- Convert `mips64el-unknown-linux-muslabi64` to use the `mips64r2` architecture.
- Convert `mips-unknown-linux-musl` and `mipsel-unknown-linux-musl` to use the `mips32r2` architecture, identical to the rust targets.
- Document whether MIPS musl targets are hard or soft float.