### PR TITLE
Fix image build errors with podman and nerdctl.

### DIFF
--- a/.changes/1033.json
+++ b/.changes/1033.json
@@ -1,0 +1,5 @@
+{
+    "description": "fix --cache-from using podman.",
+    "type": "fixed",
+    "issues": [1031]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,45 @@ jobs:
         run: ./ci/test-docker-in-docker.sh
         shell: bash
 
+  podman:
+    name: podman
+    runs-on: ubuntu-latest
+    needs: [shellcheck, test, check]
+    if: github.event_name == 'push'
+    strategy:
+      fail-fast: false
+    outputs:
+      has-image: ${{ steps.prepare-meta.outputs.has-image }}
+      images: ${{ steps.build-docker-image.outputs.images && fromJSON(steps.build-docker-image.outputs.images)  }}
+      coverage-artifact: ${{ steps.cov.outputs.artifact-name }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/setup-rust
+
+      - name: Install Podman
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update
+          sudo apt-get install podman --no-install-recommends --assume-yes
+
+      - name: LLVM instrument coverage
+        id: cov
+        uses: ./.github/actions/cargo-llvm-cov
+        with:
+          name: cross-podman-aarch64-unknown-linux-gnu
+
+      - name: Install cross
+        run: cargo install --path . --force --debug
+
+      - name: Run Podman Test
+        run: ./ci/test-podman.sh
+        env:
+          CROSS_CONTAINER_ENGINE: podman
+          TARGET: aarch64-unknown-linux-gnu
+        shell: bash
+
   publish:
     needs: [build, check, fmt, clippy, cargo-deny]
     runs-on: ubuntu-latest
@@ -331,7 +370,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   conclusion:
-    needs: [shellcheck, fmt, clippy, test, generate-matrix, build, publish, check, remote, bisect, docker-in-docker, foreign]
+    needs: [shellcheck, fmt, clippy, test, generate-matrix, build, publish, check, remote, bisect, docker-in-docker, foreign, podman]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/ci/test-podman.sh
+++ b/ci/test-podman.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091,SC1090
+
+# test to see that running and building images with podman works.
+
+set -x
+set -eo pipefail
+
+export CROSS_CONTAINER_ENGINE=podman
+if [[ -z "${TARGET}" ]]; then
+    export TARGET="aarch64-unknown-linux-gnu"
+fi
+
+ci_dir=$(dirname "${BASH_SOURCE[0]}")
+ci_dir=$(realpath "${ci_dir}")
+. "${ci_dir}"/shared.sh
+
+main() {
+    local td=
+    local parent=
+    local target="${TARGET}"
+
+    retry cargo fetch
+    cargo build
+    export CROSS="${PROJECT_HOME}/target/debug/cross"
+
+    td="$(mkcargotemp -d)"
+    parent=$(dirname "${td}")
+    pushd "${td}"
+    cargo init --bin --name "hello" .
+
+    echo '[build]
+pre-build = ["apt-get update"]' > "${parent}/Cross.toml"
+
+    CROSS_CONTAINER_ENGINE="${CROSS_ENGINE}" "${CROSS}" build --target "${target}" --verbose
+
+    popd
+    rm -rf "${td}"
+}
+
+main


### PR DESCRIPTION
Ensures that docker and nerdctl, which support the custom `--output` and `--cache-from` flags use them, while podman and unknown container engines use the strict, minimal subset podman supports. This is because podman only supports a registry/repository, without a tag, for `--cache-from`, which means it synchronizes poorly with our target subs, like `centos`. Therefore, unless unsupported, we should always use the features available for our container engine.

This also fixes the `--pull` flag on nerdctl, which is unsupported. Engines without BuildKit extensions by default, such as nerdctl, now do not use `buildx` unless explicitly enabled with `CROSS_CONTAINER_ENGINE_NO_BUILDKIT=0`.

Closes #1031.