### PR TITLE
Add support for other overlay filesystems.

### DIFF
--- a/.changes/1039.json
+++ b/.changes/1039.json
@@ -1,0 +1,4 @@
+{
+    "description": "support overlay and fuse-overlayfs storage drivers",
+    "type": "added"
+}

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -846,7 +846,7 @@ fn dockerinfo_parse_root_mount_path(info: &serde_json::Value) -> Result<MountDet
         .and_then(|v| v.as_str())
         .ok_or_else(|| eyre::eyre!("no driver name found"))?;
 
-    if driver_name == "overlay2" {
+    if driver_name.to_lowercase().contains("overlay") {
         let path = info
             .pointer("/0/GraphDriver/Data/MergedDir")
             .and_then(|v| v.as_str())


### PR DESCRIPTION
This allows other storage engines, such as `overlay` and `fuse-overlayfs` to be used with `CROSS_CONTAINER_IN_CONTAINER`. Any overlay filesystem can be supported, and this has been tested with both `overlay` and `overlay2`.