### PR TITLE
Provide fallback for rustc version when envvars not present.

### DIFF
--- a/docker/Dockerfile.aarch64-unknown-linux-musl
+++ b/docker/Dockerfile.aarch64-unknown-linux-musl
@@ -21,6 +21,7 @@ COPY musl-symlink.sh /
 RUN /musl-symlink.sh $CROSS_MUSL_SYSROOT aarch64
 
 COPY aarch64-linux-musl-gcc.sh /usr/bin/
+COPY rustc_info.sh /
 
 COPY qemu-runner base-runner.sh /
 

--- a/docker/Dockerfile.armv5te-unknown-linux-musleabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-musleabi
@@ -27,6 +27,7 @@ RUN /musl-symlink.sh $CROSS_MUSL_SYSROOT arm
 COPY qemu-runner base-runner.sh /
 
 COPY arm-linux-musleabi-gcc.sh /usr/bin/
+COPY rustc_info.sh /
 
 ENV CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_LINKER=arm-linux-musleabi-gcc.sh \
     CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_RUNNER="/qemu-runner arm" \

--- a/docker/Dockerfile.mips64-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-muslabi64
@@ -28,6 +28,7 @@ RUN ln -s $CROSS_MUSL_SYSROOT/usr/lib/libc.so $CROSS_MUSL_SYSROOT/usr/lib64/libc
 RUN ln -s $CROSS_MUSL_SYSROOT/usr/lib/libc.so.1 $CROSS_MUSL_SYSROOT/usr/lib64/libc.so.1
 
 COPY mips64-linux-musl-gcc.sh /usr/bin/
+COPY rustc_info.sh /
 
 COPY qemu-runner base-runner.sh /
 

--- a/docker/Dockerfile.mips64el-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-muslabi64
@@ -28,6 +28,7 @@ RUN ln -s $CROSS_MUSL_SYSROOT/usr/lib/libc.so $CROSS_MUSL_SYSROOT/usr/lib64/libc
 RUN ln -s $CROSS_MUSL_SYSROOT/usr/lib/libc.so.1 $CROSS_MUSL_SYSROOT/usr/lib64/libc.so.1
 
 COPY mips64el-linux-musl-gcc.sh /usr/bin/
+COPY rustc_info.sh /
 
 COPY qemu-runner base-runner.sh /
 

--- a/docker/aarch64-linux-musl-gcc.sh
+++ b/docker/aarch64-linux-musl-gcc.sh
@@ -7,8 +7,14 @@
 set -x
 set -euo pipefail
 
+# shellcheck disable=SC1091
+. /rustc_info.sh
+
 main() {
-    if (( CROSS_RUSTC_MINOR_VERSION >= 48 )) || [[ $# -eq 0 ]]; then
+    local minor
+    minor=$(rustc_minor_version)
+
+    if (( minor >= 48 )) || [[ $# -eq 0 ]]; then
         # no workaround
         exec aarch64-linux-musl-gcc "${@}"
     else

--- a/docker/arm-linux-musleabi-gcc.sh
+++ b/docker/arm-linux-musleabi-gcc.sh
@@ -9,8 +9,14 @@
 set -x
 set -euo pipefail
 
+# shellcheck disable=SC1091
+. /rustc_info.sh
+
 main() {
-    if (( CROSS_RUSTC_MINOR_VERSION >= 65 )) || [[ $# -eq 0 ]]; then
+    local minor
+    minor=$(rustc_minor_version)
+
+    if (( minor >= 65 )) || [[ $# -eq 0 ]]; then
         exec arm-linux-musleabi-gcc "${@}"
     else
         exec arm-linux-musleabi-gcc "${@}" -lgcc -static-libgcc

--- a/docker/mips64-linux-musl-gcc.sh
+++ b/docker/mips64-linux-musl-gcc.sh
@@ -9,8 +9,14 @@
 set -x
 set -euo pipefail
 
+# shellcheck disable=SC1091
+. /rustc_info.sh
+
 main() {
-    if (( CROSS_RUSTC_MINOR_VERSION >= 65 )) || [[ $# -eq 0 ]]; then
+    local minor
+    minor=$(rustc_minor_version)
+
+    if (( minor >= 65 )) || [[ $# -eq 0 ]]; then
         exec mips64-linux-musl-gcc "${@}"
     else
         exec mips64-linux-musl-gcc "${@}" -lgcc -static-libgcc

--- a/docker/mips64el-linux-musl-gcc.sh
+++ b/docker/mips64el-linux-musl-gcc.sh
@@ -9,8 +9,14 @@
 set -x
 set -euo pipefail
 
+# shellcheck disable=SC1091
+. /rustc_info.sh
+
 main() {
-    if (( CROSS_RUSTC_MINOR_VERSION >= 65 )) || [[ $# -eq 0 ]]; then
+    local minor
+    minor=$(rustc_minor_version)
+
+    if (( minor >= 65 )) || [[ $# -eq 0 ]]; then
         exec mips64el-linux-musl-gcc "${@}"
     else
         exec mips64el-linux-musl-gcc "${@}" -lgcc -static-libgcc

--- a/docker/rustc_info.sh
+++ b/docker/rustc_info.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# FIXME: remove this file further on, especially after
+# 0.2.5 has been released and we've had a weeks of
+# releases on main so people can update images.
+# people may use newer versions of cross with older
+# images for backwards compatibility, but we don't
+# need to guarantee newer images work with older cross
+# versions.
+# https://github.com/cross-rs/cross/issues/1046
+
+# NOTE: this will fail if rustc does not provide version
+# info, which may happen with a custom toolchain.
+rustc_version() {
+    rustc -Vv | grep '^release:' | cut -d ':' -f2
+}
+
+rustc_major_version() {
+    if [[ -z "${CROSS_RUSTC_MAJOR_VERSION:-}" ]]; then
+        CROSS_RUSTC_MAJOR_VERSION=$(rustc_version | cut -d '.' -f1)
+        export CROSS_RUSTC_MAJOR_VERSION
+    fi
+    echo "${CROSS_RUSTC_MAJOR_VERSION}"
+}
+
+rustc_minor_version() {
+    if [[ -z "${CROSS_RUSTC_MINOR_VERSION:-}" ]]; then
+        CROSS_RUSTC_MINOR_VERSION=$(rustc_version | cut -d '.' -f2)
+        export CROSS_RUSTC_MINOR_VERSION
+    fi
+    echo "${CROSS_RUSTC_MINOR_VERSION}"
+}
+
+rustc_patch_version() {
+    if [[ -z "${CROSS_RUSTC_PATCH_VERSION:-}" ]]; then
+        CROSS_RUSTC_PATCH_VERSION=$(rustc_version | cut -d '.' -f3)
+        export CROSS_RUSTC_PATCH_VERSION
+    fi
+    echo "${CROSS_RUSTC_PATCH_VERSION}"
+}


### PR DESCRIPTION
Fixes an issue where `CROSS_RUSTC_MINOR_VERSION` is not present when using older versions of cross but newer images. This only uses the fallback if the minor version is not provided as an environment variable by cross itself.