### PR TITLE
Stop parsing arguments to `cross run` after `--`.

### DIFF
--- a/.changes/1049.json
+++ b/.changes/1049.json
@@ -1,0 +1,5 @@
+{
+    "type": "changed",
+    "description": "stop parsing arguments to `cross run` after `--`",
+    "issues": [1048]
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -175,7 +175,10 @@ pub fn parse(target_list: &TargetList) -> Result<Args> {
             if arg.is_empty() {
                 continue;
             }
-            if let v @ 1.. = is_verbose(arg.as_str()) {
+            if matches!(arg.as_str(), "--") {
+                all.push(arg);
+                all.extend(args.by_ref());
+            } else if let v @ 1.. = is_verbose(arg.as_str()) {
                 verbose += v;
                 all.push(arg);
             } else if matches!(arg.as_str(), "--version" | "-V") {


### PR DESCRIPTION
Resolves #1048.

Stop parsing arguments to `cross run` after `--`, but still add them to `args.all` so they will be passed to the program being run.