### PR TITLE
suggest that buildx needs to be available

### DIFF
--- a/src/bin/commands/images.rs
+++ b/src/bin/commands/images.rs
@@ -276,7 +276,7 @@ pub fn list_images(
             map.get_mut(&target).expect("map must have key").push(image);
         }
     }
-    let mut keys: Vec<&str> = map.iter().map(|(k, _)| k.as_ref()).collect();
+    let mut keys: Vec<&str> = map.keys().map(|k| k.as_ref()).collect();
     keys.sort_unstable();
 
     let print_string =

--- a/src/docker/engine.rs
+++ b/src/docker/engine.rs
@@ -69,6 +69,8 @@ pub struct Engine {
 }
 
 impl Engine {
+    pub const CROSS_CONTAINER_ENGINE_NO_BUILDKIT_ENV: &'static str =
+        "CROSS_CONTAINER_ENGINE_NO_BUILDKIT";
     pub fn new(
         in_docker: Option<bool>,
         is_remote: Option<bool>,
@@ -135,7 +137,7 @@ impl Engine {
 
     #[must_use]
     pub fn has_buildkit() -> bool {
-        !env::var("CROSS_CONTAINER_ENGINE_NO_BUILDKIT")
+        !env::var(Self::CROSS_CONTAINER_ENGINE_NO_BUILDKIT_ENV)
             .map(|x| bool_from_envvar(&x))
             .unwrap_or_default()
     }


### PR DESCRIPTION
touches on #1055

```
❯ cross build --target x86_64-unknown-linux-gnu
unknown flag: --label
See 'docker buildx build --help'.
Error: 
   0: could not run container
   1: when building custom image
   2: when pre-building
   3: `docker buildx build --platform linux/amd64 --labela 'org.cross-rs.for-cross-target=x86_64-unknown-linux-gnu' --label 'org.cross-rs.runs-with=x86_64-unknown-linux-gnu' --label 'org.cross-rs.workspace_root=/Users/emil/workspace/cross' --tag localhost/cross-rs/cross-custom-cross:x86_64-unknown-linux-gnu-b0dac-pre-build --build-arg 'CROSS_CMD=hello world' --build-arg 'CROSS_DEB_ARCH=amd64' --file /Users/emil/workspace/cross/target/x86_64-unknown-linux-gnu/Dockerfile.x86_64-unknown-linux-gnu-custom --output 'type=docker' /Users/emil/workspace/cross` failed with exit status: 125

Warning: call to docker failed
Suggestion: is `buildx` available for the container engine?
Note: disable the `buildkit` dependency optionally with `CROSS_CONTAINER_ENGINE_NO_BUILDKIT=1`
Note: CROSS_CMD=hello world
```