### PR TITLE
Fix linkage and C++ support for musl targets.

### DIFF
--- a/.changes/1063.json
+++ b/.changes/1063.json
@@ -1,0 +1,13 @@
+[
+    {
+        "type": "changed",
+        "description": "changed musl targets to use static-pie linkage by default, consistent with Alpine.",
+        "breaking": true
+    },
+    {
+        "type": "fixed",
+        "description": "fixed C++ support for musl targets.",
+        "issues": [902],
+        "breaking": true
+    }
+]

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -182,6 +182,21 @@ main() {
 
         rm -rf "${td}"
     fi
+
+    # special tests for a shared C runtime, since we disable the shared c++ runtime
+    # https://github.com/cross-rs/cross/issues/902
+    if [[ "${TARGET}" == *-linux-musl* ]]; then
+        td=$(mkcargotemp -d)
+
+        pushd "${td}"
+        cargo init --bin --name hello .
+        retry cargo fetch
+        RUSTFLAGS="-C target-feature=-crt-static" \
+            "${CROSS[@]}" build --target "${TARGET}" ${CROSS_FLAGS}
+        popd
+
+        rm -rf "${td}"
+    fi
 }
 
 cross_run() {

--- a/docker/musl-symlink.sh
+++ b/docker/musl-symlink.sh
@@ -49,6 +49,10 @@ main() {
         fi
     done
 
+    # ensure we statically link libstdc++, so avoid segfaults with c++
+    # https://github.com/cross-rs/cross/issues/902
+    rm "${sysroot}"/lib/libstdc++.so* || true
+
     echo "${sysroot}/lib" >> "/etc/ld-musl-${arch}.path"
 
     rm -rf "${0}"

--- a/docker/musl.sh
+++ b/docker/musl.sh
@@ -36,13 +36,20 @@ main() {
     # Don't depend on the mirrors of sabotage linux that musl-cross-make uses.
     local linux_headers_site=https://ci-mirrors.rust-lang.org/rustc/sabotage-linux-tarballs
 
+    # alpine GCC is built with `--enable-default-pie`, so we want to
+    # ensure we use that. we want support for shared runtimes except for
+    # libstdc++, however, the only way to do that is to simply remove
+    # the shared libraries later. on alpine, binaries use static-pie
+    # linked, so our behavior has maximum portability, and is consistent
+    # with popular musl distros.
     hide_output make install "-j$(nproc)" \
         GCC_VER=9.2.0 \
         MUSL_VER=1.1.24 \
         BINUTILS_VER=2.33.1 \
         DL_CMD='curl --retry 3 -sSfL -C - -o' \
-        LINUX_HEADERS_SITE=$linux_headers_site \
+        LINUX_HEADERS_SITE="${linux_headers_site}" \
         OUTPUT=/usr/local/ \
+        "GCC_CONFIG += --enable-default-pie" \
         "${@}"
 
     purge_packages

--- a/targets.toml
+++ b/targets.toml
@@ -22,8 +22,11 @@ deploy = true
 [[target]]
 target = "x86_64-unknown-linux-musl"
 os = "ubuntu-latest"
+cpp = true
+dylib = true
 std = true
 run = true
+runners = "native qemu-user"
 deploy = true
 
 [[target]]


### PR DESCRIPTION
Change behavior to use static-pie linkage by default (consistent with Alpine's behavior for pure Rust packages as well as those with external C dependencies), and fix musl targets with C++ dependencies by forcing static-pie linkage to standard libraries.

Closes #902.