### PR TITLE
Workaround for slow CentOS builds depending on the ulimit.

### DIFF
--- a/docker/aarch64-linux-gnu-glibc.sh
+++ b/docker/aarch64-linux-gnu-glibc.sh
@@ -3,6 +3,9 @@
 set -x
 set -euo pipefail
 
+# shellcheck disable=SC1091
+. lib.sh
+
 unpack_rpm() {
     local package="${1}"
     curl --retry 3 "http://mirror.centos.org/altarch/7/os/aarch64/Packages/${package}" -O
@@ -35,6 +38,7 @@ cp_gcc_archive() {
 }
 
 main() {
+    set_centos_ulimit
     yum install -y epel-release
     yum install -y gcc-aarch64-linux-gnu gcc-c++-aarch64-linux-gnu binutils-aarch64-linux-gnu binutils gcc-c++ glibc-devel
     yum clean all

--- a/docker/lib.sh
+++ b/docker/lib.sh
@@ -3,6 +3,12 @@
 
 purge_list=()
 
+set_centos_ulimit() {
+    # this is a bug affecting buildkit with yum when ulimit is unlimited
+    # https://github.com/docker/buildx/issues/379#issuecomment-1196517905
+    ulimit -n 1024000
+}
+
 install_packages() {
     if grep -i ubuntu /etc/os-release; then
         apt-get update
@@ -15,6 +21,7 @@ install_packages() {
             fi
         done
     else
+        set_centos_ulimit
         for pkg in "${@}"; do
             if ! yum list installed "${pkg}" >/dev/null 2>/dev/null; then
                 yum install -y "${pkg}"

--- a/docker/qemu.sh
+++ b/docker/qemu.sh
@@ -54,6 +54,7 @@ build_static_libattr() {
 
     pushd "${td}"
 
+    set_centos_ulimit
     yum install -y gettext
 
     curl --retry 3 -sSfL "https://download.savannah.nongnu.org/releases/attr/attr-${version}.src.tar.gz" -O


### PR DESCRIPTION
Fixes CentOS builds being ~10x slower with certain configurations, where `LimitNOFILE=infinity`. This sets the ulimit for open file descriptors manually, which fixes the issue. See the upstream issue https://github.com/docker/buildx/issues/379. 