### PR TITLE
Warn when mounted volume likely uses a path rather than an environment variable.

### DIFF
--- a/src/docker/local.rs
+++ b/src/docker/local.rs
@@ -47,6 +47,7 @@ pub(crate) fn run(
         &paths,
         |docker, host, absolute| mount(docker, host, absolute, ""),
         |_| {},
+        msg_info,
     )?;
 
     docker.arg("--rm");

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -937,6 +937,7 @@ pub(crate) fn run(
         &paths,
         |_, _, _| Ok(()),
         |(src, dst)| volumes.push((src, dst)),
+        msg_info,
     )
     .wrap_err("could not determine mount points")?;
 


### PR DESCRIPTION
Closes #1069.