### PR TITLE
Terminate child containers on program termination.

### DIFF
--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -1,4 +1,4 @@
-pub mod custom;
+pub(crate) mod custom;
 mod engine;
 mod image;
 mod local;

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -549,6 +549,19 @@ impl Container {
         unsafe { CONTAINER.exists() }
     }
 
+    // when the `docker run` command finished.
+    // the container has already exited, so no cleanup required.
+    pub fn exit(&mut self) {
+        self.exists.store(false, Ordering::SeqCst);
+    }
+
+    pub fn exit_static() {
+        // SAFETY: an atomic store.
+        unsafe {
+            CONTAINER.exit();
+        }
+    }
+
     // when the `docker exec` command finished.
     pub fn finish(&mut self, is_tty: bool, msg_info: &mut MessageInfo) {
         // relax the no-timeout and lack of output

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, ExitStatus, Output};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{env, fs, time};
 
 use super::custom::{Dockerfile, PreBuild};
@@ -15,8 +16,8 @@ use crate::extensions::{CommandExt, SafeCommand};
 use crate::file::{self, write_file, PathExt, ToUtf8};
 use crate::id;
 use crate::rustc::QualifiedToolchain;
-use crate::shell::{MessageInfo, Verbosity};
-use crate::{CargoVariant, Target, TargetTriple};
+use crate::shell::{ColorChoice, MessageInfo, Verbosity};
+use crate::{CargoVariant, OutputExt, Target, TargetTriple};
 
 use rustc_version::Version as RustcVersion;
 
@@ -486,6 +487,273 @@ impl Directories {
     pub fn package_directories(&self) -> &PackageDirectories {
         &self.package
     }
+}
+
+// the mount directory for the data volume.
+pub const MOUNT_PREFIX: &str = "/cross";
+// the prefix used when naming volumes
+pub const VOLUME_PREFIX: &str = "cross-";
+// default timeout to stop a container (in seconds)
+pub const DEFAULT_TIMEOUT: u32 = 2;
+// instant kill in case of a non-graceful exit
+pub const NO_TIMEOUT: u32 = 0;
+
+pub(crate) static mut CONTAINER: Container = Container::new();
+
+// we need to specify drops for the containers, but we
+// also need to ensure the drops are called on a
+// termination handler. we use an atomic bool to ensure
+// that the drop only gets called once, even if we have
+// the signal handle invoked multiple times or it fails.
+#[allow(missing_debug_implementations)]
+pub struct Container {
+    deleter: Option<DeleteContainer>,
+    exists: AtomicBool,
+}
+
+impl Container {
+    pub const fn new() -> Container {
+        Container {
+            deleter: None,
+            exists: AtomicBool::new(false),
+        }
+    }
+
+    pub fn create(engine: Engine, name: String) -> Result<()> {
+        // SAFETY: guarded by an atomic swap
+        unsafe {
+            if !CONTAINER.exists.swap(true, Ordering::SeqCst) {
+                CONTAINER.deleter = Some(DeleteContainer {
+                    engine,
+                    name,
+                    timeout: NO_TIMEOUT,
+                    color_choice: ColorChoice::Never,
+                    verbosity: Verbosity::Quiet,
+                });
+                Ok(())
+            } else {
+                eyre::bail!("attempted to create already existing container.");
+            }
+        }
+    }
+
+    // the static functions have been placed by the internal functions to
+    // verify the internal functions are wrapped in atomic load/stores.
+
+    pub fn exists(&self) -> bool {
+        self.exists.load(Ordering::SeqCst)
+    }
+
+    pub fn exists_static() -> bool {
+        // SAFETY: an atomic load.
+        unsafe { CONTAINER.exists() }
+    }
+
+    // when the `docker exec` command finished.
+    pub fn finish(&mut self, is_tty: bool, msg_info: &mut MessageInfo) {
+        // relax the no-timeout and lack of output
+        // ensure we have atomic ordering
+        if self.exists() {
+            let deleter = self.deleter.as_mut().unwrap();
+            if is_tty {
+                deleter.timeout = DEFAULT_TIMEOUT;
+            }
+            deleter.color_choice = msg_info.color_choice;
+            deleter.verbosity = msg_info.verbosity;
+        }
+
+        self.terminate();
+    }
+
+    pub fn finish_static(is_tty: bool, msg_info: &mut MessageInfo) {
+        // SAFETY: internally guarded by an atomic load.
+        unsafe {
+            CONTAINER.finish(is_tty, msg_info);
+        }
+    }
+
+    // terminate the container early. leaves the struct in a valid
+    // state, so it's async safe, but so the container will not
+    // be stopped again.
+    pub fn terminate(&mut self) {
+        if self.exists.swap(false, Ordering::SeqCst) {
+            let deleter = self.deleter.as_mut().unwrap();
+            let mut msg_info = MessageInfo::new(deleter.color_choice, deleter.verbosity);
+            container_stop(
+                &deleter.engine,
+                &deleter.name,
+                deleter.timeout,
+                &mut msg_info,
+            )
+            .ok();
+            container_rm(&deleter.engine, &deleter.name, &mut msg_info).ok();
+
+            self.deleter = None;
+        }
+    }
+}
+
+impl Drop for Container {
+    fn drop(&mut self) {
+        self.terminate();
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ContainerState {
+    Created,
+    Running,
+    Paused,
+    Restarting,
+    Dead,
+    Exited,
+    DoesNotExist,
+}
+
+impl ContainerState {
+    pub fn new(state: &str) -> Result<Self> {
+        match state {
+            "created" => Ok(ContainerState::Created),
+            "running" => Ok(ContainerState::Running),
+            "paused" => Ok(ContainerState::Paused),
+            "restarting" => Ok(ContainerState::Restarting),
+            "dead" => Ok(ContainerState::Dead),
+            "exited" => Ok(ContainerState::Exited),
+            "" => Ok(ContainerState::DoesNotExist),
+            _ => eyre::bail!("unknown container state: got {state}"),
+        }
+    }
+
+    #[must_use]
+    pub fn is_stopped(&self) -> bool {
+        matches!(self, Self::Exited | Self::DoesNotExist)
+    }
+
+    #[must_use]
+    pub fn exists(&self) -> bool {
+        !matches!(self, Self::DoesNotExist)
+    }
+}
+
+// the lack of [MessageInfo] is because it'd require a mutable reference,
+// since we don't need the functionality behind the [MessageInfo], we can just store the basic
+// MessageInfo configurations.
+pub(crate) struct DeleteContainer {
+    engine: Engine,
+    name: String,
+    timeout: u32,
+    color_choice: ColorChoice,
+    verbosity: Verbosity,
+}
+
+pub(crate) fn run_and_get_status(
+    engine: &Engine,
+    args: &[&str],
+    msg_info: &mut MessageInfo,
+) -> Result<ExitStatus> {
+    command(engine)
+        .args(args)
+        .run_and_get_status(msg_info, true)
+}
+
+pub(crate) fn run_and_get_output(
+    engine: &Engine,
+    args: &[&str],
+    msg_info: &mut MessageInfo,
+) -> Result<Output> {
+    command(engine).args(args).run_and_get_output(msg_info)
+}
+
+pub fn container_stop(
+    engine: &Engine,
+    container: &str,
+    timeout: u32,
+    msg_info: &mut MessageInfo,
+) -> Result<ExitStatus> {
+    run_and_get_status(
+        engine,
+        &["stop", container, "--time", &timeout.to_string()],
+        msg_info,
+    )
+}
+
+pub fn container_stop_default(
+    engine: &Engine,
+    container: &str,
+    msg_info: &mut MessageInfo,
+) -> Result<ExitStatus> {
+    // we want a faster timeout, since this might happen in signal
+    // handler. our containers normally clean up pretty fast, it's
+    // only without a pseudo-tty that they don't.
+    container_stop(engine, container, DEFAULT_TIMEOUT, msg_info)
+}
+
+/// if stopping a container succeeds without a timeout, this command
+/// can fail because the container no longer exists. however, if
+/// the container was killed, we need to cleanup the exited container.
+/// just silence any warnings.
+pub fn container_rm(
+    engine: &Engine,
+    container: &str,
+    msg_info: &mut MessageInfo,
+) -> Result<ExitStatus> {
+    run_and_get_output(engine, &["rm", container], msg_info).map(|output| output.status)
+}
+
+pub fn volume_create(
+    engine: &Engine,
+    volume: &str,
+    msg_info: &mut MessageInfo,
+) -> Result<ExitStatus> {
+    run_and_get_status(engine, &["volume", "create", volume], msg_info)
+}
+
+pub fn volume_rm(engine: &Engine, volume: &str, msg_info: &mut MessageInfo) -> Result<ExitStatus> {
+    run_and_get_status(engine, &["volume", "rm", volume], msg_info)
+}
+
+pub fn volume_exists(engine: &Engine, volume: &str, msg_info: &mut MessageInfo) -> Result<bool> {
+    run_and_get_output(engine, &["volume", "inspect", volume], msg_info)
+        .map(|output| output.status.success())
+}
+
+pub fn existing_volumes(
+    engine: &Engine,
+    toolchain: &QualifiedToolchain,
+    msg_info: &mut MessageInfo,
+) -> Result<Vec<String>> {
+    let list = run_and_get_output(
+        engine,
+        &[
+            "volume",
+            "list",
+            "--format",
+            "{{.Name}}",
+            "--filter",
+            &format!("name=^{VOLUME_PREFIX}{}", toolchain),
+        ],
+        msg_info,
+    )?
+    .stdout()?;
+
+    if list.is_empty() {
+        Ok(vec![])
+    } else {
+        Ok(list.split('\n').map(ToOwned::to_owned).collect())
+    }
+}
+
+pub fn container_state(
+    engine: &Engine,
+    container: &str,
+    msg_info: &mut MessageInfo,
+) -> Result<ContainerState> {
+    let stdout = command(engine)
+        .args(["ps", "-a"])
+        .args(["--filter", &format!("name={container}")])
+        .args(["--format", "{{.State}}"])
+        .run_and_get_stdout(msg_info)?;
+    ContainerState::new(stdout.trim())
 }
 
 pub(crate) fn time_to_millis(timestamp: &time::SystemTime) -> Result<u64> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-use crate::docker::remote;
+use crate::docker;
 use crate::temp;
 
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -102,7 +102,7 @@ unsafe fn termination_handler() {
     // however, we'd need to store the engine path and the argument list as
     // a global CString and `Vec<CString>`, respectively. this atomic guard
     // makes this safe regardless.
-    remote::CONTAINER = None;
+    docker::CONTAINER.terminate();
 
     // EOWNERDEAD, seems to be the same on linux, macos, and bash on windows.
     std::process::exit(130);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -104,7 +104,8 @@ unsafe fn termination_handler() {
     // makes this safe regardless.
     docker::CONTAINER.terminate();
 
-    // EOWNERDEAD, seems to be the same on linux, macos, and bash on windows.
+    // all termination exit codes are 128 + signal code. the exit code is
+    // 130 for Ctrl+C or SIGINT (signal code 2) for linux, macos, and windows.
     std::process::exit(130);
 }
 


### PR DESCRIPTION
Upon receiving a termination signal, ensuring any spawned containers are also terminated. This is required since we intentional do not attach stdint to the container. This means, however, that interrupts such as Ctrl+C did not stop the build process. Likewise, termination signals such as SIGTERM merely exited cross, and did not terminate the container.

This also refactors the global container state to store whether the container exists and current logic to terminate the container if it exists. By coupling the two, it simplifies safe handling and modification of this global state. Since we have a signal handler, these functions may be called asynchronously, therefore any global state may be modified, rendering the current state invalid if not appropriately guarded. Coupling the two ensures that our logic is sound.

Fixes the regression in #964.
Closes #1041.