### PR TITLE
Fix persistent data volumes with remote cross.

### DIFF
--- a/src/bin/commands/containers.rs
+++ b/src/bin/commands/containers.rs
@@ -443,29 +443,10 @@ pub fn create_persistent_volume(
     docker::Container::create(engine.clone(), container.clone())?;
     docker.run_and_get_status(msg_info, false)?;
 
-    docker::remote::copy_volume_container_xargo(
-        engine,
-        &container,
-        &dirs,
-        mount_prefix.as_ref(),
-        msg_info,
-    )?;
-    docker::remote::copy_volume_container_cargo(
-        engine,
-        &container,
-        &dirs,
-        mount_prefix.as_ref(),
-        copy_registry,
-        msg_info,
-    )?;
-    docker::remote::copy_volume_container_rust(
-        engine,
-        &container,
-        &dirs,
-        None,
-        mount_prefix.as_ref(),
-        msg_info,
-    )?;
+    let data_volume = docker::remote::DataVolume::new(engine, &container, &dirs);
+    data_volume.copy_xargo(mount_prefix.as_ref(), msg_info)?;
+    data_volume.copy_cargo(mount_prefix.as_ref(), copy_registry, msg_info)?;
+    data_volume.copy_rust(None, mount_prefix.as_ref(), msg_info)?;
 
     docker::Container::finish_static(is_tty, msg_info);
 

--- a/src/bin/commands/containers.rs
+++ b/src/bin/commands/containers.rs
@@ -320,7 +320,8 @@ fn get_cross_volumes(
     msg_info: &mut MessageInfo,
 ) -> cross::Result<Vec<String>> {
     use cross::docker::VOLUME_PREFIX;
-    let stdout = docker::subcommand(engine, "volume")
+    let stdout = engine
+        .subcommand("volume")
         .arg("list")
         .args(["--format", "{{.Name}}"])
         // handles simple regex: ^ for start of line.
@@ -348,7 +349,7 @@ pub fn remove_all_volumes(
 ) -> cross::Result<()> {
     let volumes = get_cross_volumes(engine, msg_info)?;
 
-    let mut command = docker::subcommand(engine, "volume");
+    let mut command = engine.subcommand("volume");
     command.arg("rm");
     if force {
         command.arg("--force");
@@ -370,7 +371,7 @@ pub fn prune_volumes(
     engine: &docker::Engine,
     msg_info: &mut MessageInfo,
 ) -> cross::Result<()> {
-    let mut command = docker::subcommand(engine, "volume");
+    let mut command = engine.subcommand("volume");
     command.args(["prune", "--force"]);
     if execute {
         command.run(msg_info, false).map_err(Into::into)
@@ -421,7 +422,7 @@ pub fn create_persistent_volume(
 
     // create a dummy running container to copy data over
     let mount_prefix = docker::MOUNT_PREFIX;
-    let mut docker = docker::subcommand(engine, "run");
+    let mut docker = engine.subcommand("run");
     docker.args(["--name", &container_id]);
     docker.arg("--rm");
     docker.args(["-v", &format!("{}:{}", volume_id, mount_prefix)]);
@@ -482,7 +483,8 @@ fn get_cross_containers(
     msg_info: &mut MessageInfo,
 ) -> cross::Result<Vec<String>> {
     use cross::docker::VOLUME_PREFIX;
-    let stdout = docker::subcommand(engine, "ps")
+    let stdout = engine
+        .subcommand("ps")
         .arg("-a")
         .args(["--format", "{{.Names}}: {{.State}}"])
         // handles simple regex: ^ for start of line.
@@ -525,13 +527,13 @@ pub fn remove_all_containers(
 
     let mut commands = vec![];
     if !running.is_empty() {
-        let mut stop = docker::subcommand(engine, "stop");
+        let mut stop = engine.subcommand("stop");
         stop.args(&running);
         commands.push(stop);
     }
 
     if !(stopped.is_empty() && running.is_empty()) {
-        let mut rm = docker::subcommand(engine, "rm");
+        let mut rm = engine.subcommand("rm");
         if force {
             rm.arg("--force");
         }

--- a/src/bin/commands/containers.rs
+++ b/src/bin/commands/containers.rs
@@ -397,34 +397,34 @@ pub fn create_persistent_volume(
     };
     let mount_finder = docker::MountFinder::create(engine)?;
     let dirs = docker::ToolchainDirectories::assemble(&mount_finder, toolchain.clone())?;
-    let container = dirs.unique_container_identifier(&toolchain.host().target)?;
-    let volume = dirs.unique_toolchain_identifier()?;
+    let container_id = dirs.unique_container_identifier(&toolchain.host().target)?;
+    let volume_id = dirs.unique_toolchain_identifier()?;
+    let volume = docker::DockerVolume::new(engine, &volume_id);
 
-    if docker::volume_exists(engine, &volume, msg_info)? {
-        eyre::bail!("Error: volume {volume} already exists.");
+    if volume.exists(msg_info)? {
+        eyre::bail!("Error: volume {volume_id} already exists.");
     }
 
-    docker::subcommand(engine, "volume")
-        .args(["create", &volume])
-        .run_and_get_status(msg_info, false)?;
+    volume.create(msg_info)?;
 
     // stop the container if it's already running
-    let state = docker::container_state(engine, &container, msg_info)?;
+    let container = docker::DockerContainer::new(engine, &container_id);
+    let state = container.state(msg_info)?;
     if !state.is_stopped() {
-        msg_info.warn(format_args!("container {container} was running."))?;
-        docker::container_stop_default(engine, &container, msg_info)?;
+        msg_info.warn(format_args!("container {container_id} was running."))?;
+        container.stop_default(msg_info)?;
     }
     if state.exists() {
-        msg_info.warn(format_args!("container {container} was exited."))?;
-        docker::container_rm(engine, &container, msg_info)?;
+        msg_info.warn(format_args!("container {container_id} was exited."))?;
+        container.remove(msg_info)?;
     }
 
     // create a dummy running container to copy data over
     let mount_prefix = docker::MOUNT_PREFIX;
     let mut docker = docker::subcommand(engine, "run");
-    docker.args(["--name", &container]);
+    docker.args(["--name", &container_id]);
     docker.arg("--rm");
-    docker.args(["-v", &format!("{}:{}", volume, mount_prefix)]);
+    docker.args(["-v", &format!("{}:{}", volume_id, mount_prefix)]);
     docker.arg("-d");
     let is_tty = io::Stdin::is_atty() && io::Stdout::is_atty() && io::Stderr::is_atty();
     if is_tty {
@@ -440,15 +440,15 @@ pub fn create_persistent_volume(
         docker.args(["sh", "-c", "sleep infinity"]);
     }
     // store first, since failing to non-existing container is fine
-    docker::Container::create(engine.clone(), container.clone())?;
+    docker::ChildContainer::create(engine.clone(), container_id.clone())?;
     docker.run_and_get_status(msg_info, false)?;
 
-    let data_volume = docker::remote::DataVolume::new(engine, &container, &dirs);
+    let data_volume = docker::ContainerDataVolume::new(engine, &container_id, &dirs);
     data_volume.copy_xargo(mount_prefix.as_ref(), msg_info)?;
     data_volume.copy_cargo(mount_prefix.as_ref(), copy_registry, msg_info)?;
     data_volume.copy_rust(None, mount_prefix.as_ref(), msg_info)?;
 
-    docker::Container::finish_static(is_tty, msg_info);
+    docker::ChildContainer::finish_static(is_tty, msg_info);
 
     Ok(())
 }
@@ -465,13 +465,14 @@ pub fn remove_persistent_volume(
     };
     let mount_finder = docker::MountFinder::create(engine)?;
     let dirs = docker::ToolchainDirectories::assemble(&mount_finder, toolchain)?;
-    let volume = dirs.unique_toolchain_identifier()?;
+    let volume_id = dirs.unique_toolchain_identifier()?;
+    let volume = docker::DockerVolume::new(engine, &volume_id);
 
-    if !docker::volume_exists(engine, &volume, msg_info)? {
-        eyre::bail!("Error: volume {volume} does not exist.");
+    if !volume.exists(msg_info)? {
+        eyre::bail!("Error: volume {volume_id} does not exist.");
     }
 
-    docker::volume_rm(engine, &volume, msg_info)?;
+    volume.remove(msg_info)?;
 
     Ok(())
 }

--- a/src/bin/commands/containers.rs
+++ b/src/bin/commands/containers.rs
@@ -441,7 +441,7 @@ pub fn create_persistent_volume(
     }
     // store first, since failing to non-existing container is fine
     docker::ChildContainer::create(engine.clone(), container_id.clone())?;
-    docker.run_and_get_status(msg_info, false)?;
+    docker.run_and_get_status(msg_info, true)?;
 
     let data_volume = docker::ContainerDataVolume::new(engine, &container_id, &dirs);
     data_volume.copy_xargo(mount_prefix.as_ref(), msg_info)?;

--- a/src/bin/commands/images.rs
+++ b/src/bin/commands/images.rs
@@ -166,7 +166,8 @@ fn get_cross_images(
     msg_info: &mut MessageInfo,
     local: bool,
 ) -> cross::Result<Vec<Image>> {
-    let mut images: BTreeSet<_> = cross::docker::subcommand(engine, "images")
+    let mut images: BTreeSet<_> = engine
+        .subcommand("images")
         .args(["--format", "{{.Repository}}:{{.Tag}} {{.ID}}"])
         .args([
             "--filter",
@@ -177,7 +178,8 @@ fn get_cross_images(
         .map(parse_image)
         .collect();
 
-    let stdout = cross::docker::subcommand(engine, "images")
+    let stdout = engine
+        .subcommand("images")
         .args(["--format", "{{.Repository}}:{{.Tag}} {{.ID}}"])
         .run_and_get_stdout(msg_info)?;
     let ids: Vec<_> = images.iter().map(|i| i.id.to_string()).collect();
@@ -238,7 +240,7 @@ fn get_image_target(
             return Ok(target);
         }
     }
-    let mut command = cross::docker::subcommand(engine, "inspect");
+    let mut command = engine.subcommand("inspect");
     command.args([
         "--format",
         &format!(
@@ -332,7 +334,7 @@ fn remove_images(
     force: bool,
     execute: bool,
 ) -> cross::Result<()> {
-    let mut command = docker::subcommand(engine, "rmi");
+    let mut command = engine.subcommand("rmi");
     if force {
         command.arg("--force");
     }

--- a/src/docker/custom.rs
+++ b/src/docker/custom.rs
@@ -205,7 +205,7 @@ impl<'a> Dockerfile<'a> {
                 "{}{package_name}:{target_triple}-{path_hash}{custom}",
                 CROSS_CUSTOM_DOCKERFILE_IMAGE_PREFIX,
                 package_name = docker_package_name(metadata),
-                path_hash = path_hash(&metadata.workspace_root, 5)?,
+                path_hash = path_hash(&metadata.workspace_root, docker::PATH_HASH_SHORT)?,
                 custom = if matches!(self, Self::File { .. }) {
                     ""
                 } else {

--- a/src/docker/custom.rs
+++ b/src/docker/custom.rs
@@ -205,7 +205,7 @@ impl<'a> Dockerfile<'a> {
                 "{}{package_name}:{target_triple}-{path_hash}{custom}",
                 CROSS_CUSTOM_DOCKERFILE_IMAGE_PREFIX,
                 package_name = docker_package_name(metadata),
-                path_hash = path_hash(&metadata.workspace_root)?,
+                path_hash = path_hash(&metadata.workspace_root, 5)?,
                 custom = if matches!(self, Self::File { .. }) {
                     ""
                 } else {

--- a/src/docker/local.rs
+++ b/src/docker/local.rs
@@ -30,10 +30,10 @@ pub(crate) fn run(
     let toolchain_dirs = paths.directories.toolchain_directories();
     let package_dirs = paths.directories.package_directories();
 
-    let mut cmd = cargo_safe_command(options.cargo_variant);
+    let mut cmd = options.cargo_variant.safe_command();
     cmd.args(args);
 
-    let mut docker = subcommand(engine, "run");
+    let mut docker = engine.subcommand("run");
     docker_userns(&mut docker);
 
     options

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -40,36 +40,360 @@ fn subcommand_or_exit(engine: &Engine, cmd: &str) -> Result<Command> {
     Ok(subcommand(engine, cmd))
 }
 
-fn create_volume_dir(
-    engine: &Engine,
-    container: &str,
-    dir: &Path,
-    msg_info: &mut MessageInfo,
-) -> Result<ExitStatus> {
-    // make our parent directory if needed
-    subcommand_or_exit(engine, "exec")?
-        .arg(container)
-        .args([
-            "sh",
-            "-c",
-            &format!("mkdir -p '{}'", dir.as_posix_absolute()?),
-        ])
-        .run_and_get_status(msg_info, false)
+#[derive(Debug)]
+pub struct DataVolume<'a, 'b, 'c> {
+    engine: &'a Engine,
+    container: &'b str,
+    toolchain_dirs: &'c ToolchainDirectories,
 }
 
-// copy files for a docker volume, for remote host support
-fn copy_volume_files(
-    engine: &Engine,
-    container: &str,
-    src: &Path,
-    dst: &Path,
-    msg_info: &mut MessageInfo,
-) -> Result<ExitStatus> {
-    subcommand_or_exit(engine, "cp")?
-        .arg("-a")
-        .arg(src.to_utf8()?)
-        .arg(format!("{container}:{}", dst.as_posix_absolute()?))
-        .run_and_get_status(msg_info, false)
+impl<'a, 'b, 'c> DataVolume<'a, 'b, 'c> {
+    pub const fn new(
+        engine: &'a Engine,
+        container: &'b str,
+        toolchain_dirs: &'c ToolchainDirectories,
+    ) -> Self {
+        Self {
+            engine,
+            container,
+            toolchain_dirs,
+        }
+    }
+
+    fn create_dir(&self, dir: &Path, msg_info: &mut MessageInfo) -> Result<ExitStatus> {
+        // make our parent directory if needed
+        subcommand_or_exit(self.engine, "exec")?
+            .arg(self.container)
+            .args([
+                "sh",
+                "-c",
+                &format!("mkdir -p '{}'", dir.as_posix_absolute()?),
+            ])
+            .run_and_get_status(msg_info, false)
+    }
+
+    // copy files for a docker volume, for remote host support
+    fn copy_files(&self, src: &Path, dst: &Path, msg_info: &mut MessageInfo) -> Result<ExitStatus> {
+        subcommand_or_exit(self.engine, "cp")?
+            .arg("-a")
+            .arg(src.to_utf8()?)
+            .arg(format!("{}:{}", self.container, dst.as_posix_absolute()?))
+            .run_and_get_status(msg_info, false)
+    }
+
+    // copy files for a docker volume, for remote host support
+    fn copy_files_nocache(
+        &self,
+        src: &Path,
+        dst: &Path,
+        copy_symlinks: bool,
+        msg_info: &mut MessageInfo,
+    ) -> Result<ExitStatus> {
+        // avoid any cached directories when copying
+        // see https://bford.info/cachedir/
+        // SAFETY: safe, single-threaded execution.
+        let tempdir = unsafe { temp::TempDir::new()? };
+        let temppath = tempdir.path();
+        let had_symlinks = copy_dir(src, temppath, copy_symlinks, 0, |e, _| is_cachedir(e))?;
+        warn_symlinks(had_symlinks, msg_info)?;
+        self.copy_files(temppath, dst, msg_info)
+    }
+
+    // copy files for a docker volume, for remote host support
+    // provides a list of files relative to src.
+    fn copy_file_list(
+        &self,
+        src: &Path,
+        dst: &Path,
+        files: &[&str],
+        msg_info: &mut MessageInfo,
+    ) -> Result<ExitStatus> {
+        // SAFETY: safe, single-threaded execution.
+        let tempdir = unsafe { temp::TempDir::new()? };
+        let temppath = tempdir.path();
+        for file in files {
+            let src_path = src.join(file);
+            let dst_path = temppath.join(file);
+            file::create_dir_all(dst_path.parent().expect("must have parent"))?;
+            fs::copy(&src_path, &dst_path)?;
+        }
+        self.copy_files(temppath, dst, msg_info)
+    }
+
+    // removed files from a docker volume, for remote host support
+    // provides a list of files relative to src.
+    fn remove_file_list(
+        &self,
+        dst: &Path,
+        files: &[&str],
+        msg_info: &mut MessageInfo,
+    ) -> Result<ExitStatus> {
+        const PATH: &str = "/tmp/remove_list";
+        let mut script = vec![];
+        if msg_info.is_verbose() {
+            script.push("set -x".to_owned());
+        }
+        script.push(format!(
+            "cat \"{PATH}\" | while read line; do
+        rm -f \"${{line}}\"
+    done
+
+    rm \"{PATH}\"
+    "
+        ));
+
+        // SAFETY: safe, single-threaded execution.
+        let mut tempfile = unsafe { temp::TempFile::new()? };
+        for file in files {
+            writeln!(tempfile.file(), "{}", dst.join(file).as_posix_relative()?)?;
+        }
+
+        // need to avoid having hundreds of files on the command, so
+        // just provide a single file name.
+        subcommand_or_exit(self.engine, "cp")?
+            .arg(tempfile.path())
+            .arg(format!("{}:{PATH}", self.container))
+            .run_and_get_status(msg_info, true)?;
+
+        subcommand_or_exit(self.engine, "exec")?
+            .arg(self.container)
+            .args(["sh", "-c", &script.join("\n")])
+            .run_and_get_status(msg_info, true)
+    }
+
+    fn container_path_exists(&self, path: &Path, msg_info: &mut MessageInfo) -> Result<bool> {
+        Ok(subcommand_or_exit(self.engine, "exec")?
+            .arg(self.container)
+            .args([
+                "bash",
+                "-c",
+                &format!("[[ -d '{}' ]]", path.as_posix_absolute()?),
+            ])
+            .run_and_get_status(msg_info, true)?
+            .success())
+    }
+
+    pub fn copy_xargo(&self, mount_prefix: &Path, msg_info: &mut MessageInfo) -> Result<()> {
+        let dirs = &self.toolchain_dirs;
+        let dst = mount_prefix.join(&dirs.xargo_mount_path_relative()?);
+        if dirs.xargo().exists() {
+            self.create_dir(
+                dst.parent().expect("destination should have a parent"),
+                msg_info,
+            )?;
+            self.copy_files(dirs.xargo(), &dst, msg_info)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn copy_cargo(
+        &self,
+        mount_prefix: &Path,
+        copy_registry: bool,
+        msg_info: &mut MessageInfo,
+    ) -> Result<()> {
+        let dirs = &self.toolchain_dirs;
+        let dst = mount_prefix.join(&dirs.cargo_mount_path_relative()?);
+        let copy_registry = env::var("CROSS_REMOTE_COPY_REGISTRY")
+            .map(|s| bool_from_envvar(&s))
+            .unwrap_or(copy_registry);
+
+        if copy_registry {
+            self.copy_files(dirs.cargo(), &dst, msg_info)?;
+        } else {
+            // can copy a limit subset of files: the rest is present.
+            self.create_dir(&dst, msg_info)?;
+            for entry in fs::read_dir(dirs.cargo())
+                .wrap_err_with(|| format!("when reading directory {:?}", dirs.cargo()))?
+            {
+                let file = entry?;
+                let basename = file
+                    .file_name()
+                    .to_utf8()
+                    .wrap_err_with(|| format!("when reading file {file:?}"))?
+                    .to_owned();
+                if !basename.starts_with('.') && !matches!(basename.as_ref(), "git" | "registry") {
+                    self.copy_files(&file.path(), &dst, msg_info)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    // copy over files needed for all targets in the toolchain that should never change
+    fn copy_rust_base(&self, mount_prefix: &Path, msg_info: &mut MessageInfo) -> Result<()> {
+        let dirs = &self.toolchain_dirs;
+
+        // the rust toolchain is quite large, but most of it isn't needed
+        // we need the bin, libexec, and etc directories, and part of the lib directory.
+        let dst = mount_prefix.join(&dirs.sysroot_mount_path_relative()?);
+        let rustlib = Path::new("lib").join("rustlib");
+        self.create_dir(&dst.join(&rustlib), msg_info)?;
+        for basename in ["bin", "libexec", "etc"] {
+            let file = dirs.get_sysroot().join(basename);
+            self.copy_files(&file, &dst, msg_info)?;
+        }
+
+        // the lib directories are rather large, so we want only a subset.
+        // now, we use a temp directory for everything else in the libdir
+        // we can pretty safely assume we don't have symlinks here.
+
+        // first, copy the shared libraries inside lib, all except rustlib.
+        // SAFETY: safe, single-threaded execution.
+        let tempdir = unsafe { temp::TempDir::new()? };
+        let temppath = tempdir.path();
+        file::create_dir_all(&temppath.join(&rustlib))?;
+        let mut had_symlinks = copy_dir(
+            &dirs.get_sysroot().join("lib"),
+            &temppath.join("lib"),
+            true,
+            0,
+            |e, d| d == 0 && e.file_name() == "rustlib",
+        )?;
+
+        // next, copy the src/etc directories inside rustlib
+        had_symlinks |= copy_dir(
+            &dirs.get_sysroot().join(&rustlib),
+            &temppath.join(&rustlib),
+            true,
+            0,
+            |e, d| d == 0 && !(e.file_name() == "src" || e.file_name() == "etc"),
+        )?;
+        self.copy_files(&temppath.join("lib"), &dst, msg_info)?;
+
+        warn_symlinks(had_symlinks, msg_info)
+    }
+
+    fn copy_rust_manifest(&self, mount_prefix: &Path, msg_info: &mut MessageInfo) -> Result<()> {
+        let dirs = &self.toolchain_dirs;
+
+        // copy over all the manifest files in rustlib
+        // these are small text files containing names/paths to toolchains
+        let dst = mount_prefix.join(&dirs.sysroot_mount_path_relative()?);
+        let rustlib = Path::new("lib").join("rustlib");
+
+        // SAFETY: safe, single-threaded execution.
+        let tempdir = unsafe { temp::TempDir::new()? };
+        let temppath = tempdir.path();
+        file::create_dir_all(&temppath.join(&rustlib))?;
+        let had_symlinks = copy_dir(
+            &dirs.get_sysroot().join(&rustlib),
+            &temppath.join(&rustlib),
+            true,
+            0,
+            |e, d| d != 0 || e.file_type().map(|t| !t.is_file()).unwrap_or(true),
+        )?;
+        self.copy_files(&temppath.join("lib"), &dst, msg_info)?;
+
+        warn_symlinks(had_symlinks, msg_info)
+    }
+
+    // copy over the toolchain for a specific triple
+    fn copy_rust_triple(
+        &self,
+        target_triple: &TargetTriple,
+        mount_prefix: &Path,
+        skip_exists: bool,
+        msg_info: &mut MessageInfo,
+    ) -> Result<()> {
+        let dirs = &self.toolchain_dirs;
+
+        // copy over the files for a specific triple
+        let dst = mount_prefix.join(&dirs.sysroot_mount_path_relative()?);
+        let rustlib = Path::new("lib").join("rustlib");
+        let dst_rustlib = dst.join(&rustlib);
+        let src_toolchain = dirs
+            .get_sysroot()
+            .join(&rustlib)
+            .join(target_triple.triple());
+        let dst_toolchain = dst_rustlib.join(target_triple.triple());
+
+        // skip if the toolchain target component already exists. for the host toolchain
+        // or the first run of the target toolchain, we know it doesn't exist.
+        let mut skip = false;
+        if skip_exists {
+            skip = self.container_path_exists(&dst_toolchain, msg_info)?;
+        }
+        if !skip {
+            self.copy_files(&src_toolchain, &dst_rustlib, msg_info)?;
+        }
+        if !skip && skip_exists {
+            // this means we have a persistent data volume and we have a
+            // new target, meaning we might have new manifests as well.
+            self.copy_rust_manifest(mount_prefix, msg_info)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn copy_rust(
+        &self,
+        target_triple: Option<&TargetTriple>,
+        mount_prefix: &Path,
+        msg_info: &mut MessageInfo,
+    ) -> Result<()> {
+        let dirs = &self.toolchain_dirs;
+
+        self.copy_rust_base(mount_prefix, msg_info)?;
+        self.copy_rust_manifest(mount_prefix, msg_info)?;
+        self.copy_rust_triple(dirs.host_target(), mount_prefix, false, msg_info)?;
+        if let Some(target_triple) = target_triple {
+            if target_triple.triple() != dirs.host_target().triple() {
+                self.copy_rust_triple(target_triple, mount_prefix, false, msg_info)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn copy_mount(
+        &self,
+        src: &Path,
+        dst: &Path,
+        volume: &VolumeId,
+        copy_cache: bool,
+        msg_info: &mut MessageInfo,
+    ) -> Result<()> {
+        let copy_all = |info: &mut MessageInfo| {
+            if copy_cache {
+                self.copy_files(src, dst, info)
+            } else {
+                self.copy_files_nocache(src, dst, true, info)
+            }
+        };
+        match volume {
+            VolumeId::Keep(_) => {
+                let parent = temp::dir()?;
+                file::create_dir_all(&parent)?;
+                let fingerprint = parent.join(self.container);
+                let current = get_project_fingerprint(src, copy_cache)?;
+                // need to check if the container path exists, otherwise we might
+                // have stale data: the persistent volume was deleted & recreated.
+                if fingerprint.exists() && self.container_path_exists(dst, msg_info)? {
+                    let previous = parse_project_fingerprint(&fingerprint)?;
+                    let (changed, removed) = get_fingerprint_difference(&previous, &current);
+                    write_project_fingerprint(&fingerprint, &current)?;
+
+                    if !changed.is_empty() {
+                        self.copy_file_list(src, dst, &changed, msg_info)?;
+                    }
+                    if !removed.is_empty() {
+                        self.remove_file_list(dst, &removed, msg_info)?;
+                    }
+                } else {
+                    write_project_fingerprint(&fingerprint, &current)?;
+                    copy_all(msg_info)?;
+                }
+            }
+            VolumeId::Discard => {
+                copy_all(msg_info)?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 fn is_cachedir_tag(path: &Path) -> Result<bool> {
@@ -89,99 +413,6 @@ fn is_cachedir(entry: &fs::DirEntry) -> bool {
     } else {
         false
     }
-}
-
-fn container_path_exists(
-    engine: &Engine,
-    container: &str,
-    path: &Path,
-    msg_info: &mut MessageInfo,
-) -> Result<bool> {
-    Ok(subcommand_or_exit(engine, "exec")?
-        .arg(container)
-        .args([
-            "bash",
-            "-c",
-            &format!("[[ -d '{}' ]]", path.as_posix_absolute()?),
-        ])
-        .run_and_get_status(msg_info, true)?
-        .success())
-}
-
-// copy files for a docker volume, for remote host support
-fn copy_volume_files_nocache(
-    engine: &Engine,
-    container: &str,
-    src: &Path,
-    dst: &Path,
-    copy_symlinks: bool,
-    msg_info: &mut MessageInfo,
-) -> Result<ExitStatus> {
-    // avoid any cached directories when copying
-    // see https://bford.info/cachedir/
-    // SAFETY: safe, single-threaded execution.
-    let tempdir = unsafe { temp::TempDir::new()? };
-    let temppath = tempdir.path();
-    let had_symlinks = copy_dir(src, temppath, copy_symlinks, 0, |e, _| is_cachedir(e))?;
-    warn_symlinks(had_symlinks, msg_info)?;
-    copy_volume_files(engine, container, temppath, dst, msg_info)
-}
-
-pub fn copy_volume_container_xargo(
-    engine: &Engine,
-    container: &str,
-    dirs: &ToolchainDirectories,
-    mount_prefix: &Path,
-    msg_info: &mut MessageInfo,
-) -> Result<()> {
-    let dst = mount_prefix.join(&dirs.xargo_mount_path_relative()?);
-    if dirs.xargo().exists() {
-        create_volume_dir(
-            engine,
-            container,
-            dst.parent().expect("destination should have a parent"),
-            msg_info,
-        )?;
-        copy_volume_files(engine, container, dirs.xargo(), &dst, msg_info)?;
-    }
-
-    Ok(())
-}
-
-pub fn copy_volume_container_cargo(
-    engine: &Engine,
-    container: &str,
-    dirs: &ToolchainDirectories,
-    mount_prefix: &Path,
-    copy_registry: bool,
-    msg_info: &mut MessageInfo,
-) -> Result<()> {
-    let dst = mount_prefix.join(&dirs.cargo_mount_path_relative()?);
-    let copy_registry = env::var("CROSS_REMOTE_COPY_REGISTRY")
-        .map(|s| bool_from_envvar(&s))
-        .unwrap_or(copy_registry);
-
-    if copy_registry {
-        copy_volume_files(engine, container, dirs.cargo(), &dst, msg_info)?;
-    } else {
-        // can copy a limit subset of files: the rest is present.
-        create_volume_dir(engine, container, &dst, msg_info)?;
-        for entry in fs::read_dir(dirs.cargo())
-            .wrap_err_with(|| format!("when reading directory {:?}", dirs.cargo()))?
-        {
-            let file = entry?;
-            let basename = file
-                .file_name()
-                .to_utf8()
-                .wrap_err_with(|| format!("when reading file {file:?}"))?
-                .to_owned();
-            if !basename.starts_with('.') && !matches!(basename.as_ref(), "git" | "registry") {
-                copy_volume_files(engine, container, &file.path(), &dst, msg_info)?;
-            }
-        }
-    }
-
-    Ok(())
 }
 
 // recursively copy a directory into another
@@ -249,156 +480,6 @@ fn warn_symlinks(had_symlinks: bool, msg_info: &mut MessageInfo) -> Result<()> {
     } else {
         Ok(())
     }
-}
-
-// copy over files needed for all targets in the toolchain that should never change
-fn copy_volume_container_rust_base(
-    engine: &Engine,
-    container: &str,
-    dirs: &ToolchainDirectories,
-    mount_prefix: &Path,
-    msg_info: &mut MessageInfo,
-) -> Result<()> {
-    // the rust toolchain is quite large, but most of it isn't needed
-    // we need the bin, libexec, and etc directories, and part of the lib directory.
-    let dst = mount_prefix.join(&dirs.sysroot_mount_path_relative()?);
-    let rustlib = Path::new("lib").join("rustlib");
-    create_volume_dir(engine, container, &dst.join(&rustlib), msg_info)?;
-    for basename in ["bin", "libexec", "etc"] {
-        let file = dirs.get_sysroot().join(basename);
-        copy_volume_files(engine, container, &file, &dst, msg_info)?;
-    }
-
-    // the lib directories are rather large, so we want only a subset.
-    // now, we use a temp directory for everything else in the libdir
-    // we can pretty safely assume we don't have symlinks here.
-
-    // first, copy the shared libraries inside lib, all except rustlib.
-    // SAFETY: safe, single-threaded execution.
-    let tempdir = unsafe { temp::TempDir::new()? };
-    let temppath = tempdir.path();
-    file::create_dir_all(&temppath.join(&rustlib))?;
-    let mut had_symlinks = copy_dir(
-        &dirs.get_sysroot().join("lib"),
-        &temppath.join("lib"),
-        true,
-        0,
-        |e, d| d == 0 && e.file_name() == "rustlib",
-    )?;
-
-    // next, copy the src/etc directories inside rustlib
-    had_symlinks |= copy_dir(
-        &dirs.get_sysroot().join(&rustlib),
-        &temppath.join(&rustlib),
-        true,
-        0,
-        |e, d| d == 0 && !(e.file_name() == "src" || e.file_name() == "etc"),
-    )?;
-    copy_volume_files(engine, container, &temppath.join("lib"), &dst, msg_info)?;
-
-    warn_symlinks(had_symlinks, msg_info)
-}
-
-fn copy_volume_container_rust_manifest(
-    engine: &Engine,
-    container: &str,
-    dirs: &ToolchainDirectories,
-    mount_prefix: &Path,
-    msg_info: &mut MessageInfo,
-) -> Result<()> {
-    // copy over all the manifest files in rustlib
-    // these are small text files containing names/paths to toolchains
-    let dst = mount_prefix.join(&dirs.sysroot_mount_path_relative()?);
-    let rustlib = Path::new("lib").join("rustlib");
-
-    // SAFETY: safe, single-threaded execution.
-    let tempdir = unsafe { temp::TempDir::new()? };
-    let temppath = tempdir.path();
-    file::create_dir_all(&temppath.join(&rustlib))?;
-    let had_symlinks = copy_dir(
-        &dirs.get_sysroot().join(&rustlib),
-        &temppath.join(&rustlib),
-        true,
-        0,
-        |e, d| d != 0 || e.file_type().map(|t| !t.is_file()).unwrap_or(true),
-    )?;
-    copy_volume_files(engine, container, &temppath.join("lib"), &dst, msg_info)?;
-
-    warn_symlinks(had_symlinks, msg_info)
-}
-
-// copy over the toolchain for a specific triple
-pub fn copy_volume_container_rust_triple(
-    engine: &Engine,
-    container: &str,
-    dirs: &ToolchainDirectories,
-    target_triple: &TargetTriple,
-    mount_prefix: &Path,
-    skip_exists: bool,
-    msg_info: &mut MessageInfo,
-) -> Result<()> {
-    // copy over the files for a specific triple
-    let dst = mount_prefix.join(&dirs.sysroot_mount_path_relative()?);
-    let rustlib = Path::new("lib").join("rustlib");
-    let dst_rustlib = dst.join(&rustlib);
-    let src_toolchain = dirs
-        .get_sysroot()
-        .join(&rustlib)
-        .join(target_triple.triple());
-    let dst_toolchain = dst_rustlib.join(target_triple.triple());
-
-    // skip if the toolchain target component already exists. for the host toolchain
-    // or the first run of the target toolchain, we know it doesn't exist.
-    let mut skip = false;
-    if skip_exists {
-        skip = container_path_exists(engine, container, &dst_toolchain, msg_info)?;
-    }
-    if !skip {
-        copy_volume_files(engine, container, &src_toolchain, &dst_rustlib, msg_info)?;
-    }
-    if !skip && skip_exists {
-        // this means we have a persistent data volume and we have a
-        // new target, meaning we might have new manifests as well.
-        copy_volume_container_rust_manifest(engine, container, dirs, mount_prefix, msg_info)?;
-    }
-
-    Ok(())
-}
-
-pub fn copy_volume_container_rust(
-    engine: &Engine,
-    container: &str,
-    dirs: &ToolchainDirectories,
-    target_triple: Option<&TargetTriple>,
-    mount_prefix: &Path,
-    msg_info: &mut MessageInfo,
-) -> Result<()> {
-    copy_volume_container_rust_base(engine, container, dirs, mount_prefix, msg_info)?;
-    copy_volume_container_rust_manifest(engine, container, dirs, mount_prefix, msg_info)?;
-    copy_volume_container_rust_triple(
-        engine,
-        container,
-        dirs,
-        dirs.host_target(),
-        mount_prefix,
-        false,
-        msg_info,
-    )?;
-    if let Some(target_triple) = target_triple {
-        if target_triple.triple() != dirs.host_target().triple() {
-            copy_volume_container_rust_triple(
-                engine,
-                container,
-                dirs,
-                target_triple,
-                mount_prefix,
-                false,
-                msg_info,
-            )?;
-        }
-    }
-
-    Ok(())
 }
 
 type FingerprintMap = BTreeMap<String, time::SystemTime>;
@@ -482,118 +563,6 @@ fn get_fingerprint_difference<'a, 'b>(
         .map(|(k, _)| k.as_str())
         .collect();
     (changed, removed)
-}
-
-// copy files for a docker volume, for remote host support
-// provides a list of files relative to src.
-fn copy_volume_file_list(
-    engine: &Engine,
-    container: &str,
-    src: &Path,
-    dst: &Path,
-    files: &[&str],
-    msg_info: &mut MessageInfo,
-) -> Result<ExitStatus> {
-    // SAFETY: safe, single-threaded execution.
-    let tempdir = unsafe { temp::TempDir::new()? };
-    let temppath = tempdir.path();
-    for file in files {
-        let src_path = src.join(file);
-        let dst_path = temppath.join(file);
-        file::create_dir_all(dst_path.parent().expect("must have parent"))?;
-        fs::copy(&src_path, &dst_path)?;
-    }
-    copy_volume_files(engine, container, temppath, dst, msg_info)
-}
-
-// removed files from a docker volume, for remote host support
-// provides a list of files relative to src.
-fn remove_volume_file_list(
-    engine: &Engine,
-    container: &str,
-    dst: &Path,
-    files: &[&str],
-    msg_info: &mut MessageInfo,
-) -> Result<ExitStatus> {
-    const PATH: &str = "/tmp/remove_list";
-    let mut script = vec![];
-    if msg_info.is_verbose() {
-        script.push("set -x".to_owned());
-    }
-    script.push(format!(
-        "cat \"{PATH}\" | while read line; do
-    rm -f \"${{line}}\"
-done
-
-rm \"{PATH}\"
-"
-    ));
-
-    // SAFETY: safe, single-threaded execution.
-    let mut tempfile = unsafe { temp::TempFile::new()? };
-    for file in files {
-        writeln!(tempfile.file(), "{}", dst.join(file).as_posix_relative()?)?;
-    }
-
-    // need to avoid having hundreds of files on the command, so
-    // just provide a single file name.
-    subcommand_or_exit(engine, "cp")?
-        .arg(tempfile.path())
-        .arg(format!("{container}:{PATH}"))
-        .run_and_get_status(msg_info, true)?;
-
-    subcommand_or_exit(engine, "exec")?
-        .arg(container)
-        .args(["sh", "-c", &script.join("\n")])
-        .run_and_get_status(msg_info, true)
-}
-
-fn copy_volume_container_project(
-    engine: &Engine,
-    container: &str,
-    src: &Path,
-    dst: &Path,
-    volume: &VolumeId,
-    copy_cache: bool,
-    msg_info: &mut MessageInfo,
-) -> Result<()> {
-    let copy_all = |info: &mut MessageInfo| {
-        if copy_cache {
-            copy_volume_files(engine, container, src, dst, info)
-        } else {
-            copy_volume_files_nocache(engine, container, src, dst, true, info)
-        }
-    };
-    match volume {
-        VolumeId::Keep(_) => {
-            let parent = temp::dir()?;
-            file::create_dir_all(&parent)?;
-            let fingerprint = parent.join(container);
-            let current = get_project_fingerprint(src, copy_cache)?;
-            // need to check if the container path exists, otherwise we might
-            // have stale data: the persistent volume was deleted & recreated.
-            if fingerprint.exists() && container_path_exists(engine, container, dst, msg_info)? {
-                let previous = parse_project_fingerprint(&fingerprint)?;
-                let (changed, removed) = get_fingerprint_difference(&previous, &current);
-                write_project_fingerprint(&fingerprint, &current)?;
-
-                if !changed.is_empty() {
-                    copy_volume_file_list(engine, container, src, dst, &changed, msg_info)?;
-                }
-                if !removed.is_empty() {
-                    remove_volume_file_list(engine, container, dst, &removed, msg_info)?;
-                }
-            } else {
-                write_project_fingerprint(&fingerprint, &current)?;
-                copy_all(msg_info)?;
-            }
-        }
-        VolumeId::Discard => {
-            copy_all(msg_info)?;
-        }
-    }
-
-    Ok(())
 }
 
 impl QualifiedToolchain {
@@ -766,56 +735,29 @@ pub(crate) fn run(
     docker.run_and_get_status(msg_info, true)?;
 
     // 4. copy all mounted volumes over
+    let data_volume = DataVolume::new(engine, &container, toolchain_dirs);
     let copy_cache = env::var("CROSS_REMOTE_COPY_CACHE")
         .map(|s| bool_from_envvar(&s))
         .unwrap_or_default();
     let copy = |src, dst: &PathBuf, info: &mut MessageInfo| {
-        if copy_cache {
-            copy_volume_files(engine, &container, src, dst, info)
-        } else {
-            copy_volume_files_nocache(engine, &container, src, dst, true, info)
-        }
+        data_volume.copy_mount(src, dst, &volume, copy_cache, info)
     };
     let mount_prefix_path = mount_prefix.as_ref();
     if let VolumeId::Discard = volume {
-        copy_volume_container_xargo(
-            engine,
-            &container,
-            toolchain_dirs,
-            mount_prefix_path,
-            msg_info,
-        )
-        .wrap_err("when copying xargo")?;
-        copy_volume_container_cargo(
-            engine,
-            &container,
-            toolchain_dirs,
-            mount_prefix_path,
-            false,
-            msg_info,
-        )
-        .wrap_err("when copying cargo")?;
-        copy_volume_container_rust(
-            engine,
-            &container,
-            toolchain_dirs,
-            Some(target.target()),
-            mount_prefix_path,
-            msg_info,
-        )
-        .wrap_err("when copying rust")?;
+        data_volume
+            .copy_xargo(mount_prefix_path, msg_info)
+            .wrap_err("when copying xargo")?;
+        data_volume
+            .copy_cargo(mount_prefix_path, false, msg_info)
+            .wrap_err("when copying cargo")?;
+        data_volume
+            .copy_rust(Some(target.target()), mount_prefix_path, msg_info)
+            .wrap_err("when copying rust")?;
     } else {
         // need to copy over the target triple if it hasn't been previously copied
-        copy_volume_container_rust_triple(
-            engine,
-            &container,
-            toolchain_dirs,
-            target.target(),
-            mount_prefix_path,
-            true,
-            msg_info,
-        )
-        .wrap_err("when copying rust target files")?;
+        data_volume
+            .copy_rust_triple(target.target(), mount_prefix_path, true, msg_info)
+            .wrap_err("when copying rust target files")?;
     }
     // cannot panic: absolute unix path, must have root
     let rel_mount_root = package_dirs
@@ -824,26 +766,16 @@ pub(crate) fn run(
         .expect("mount root should be absolute");
     let mount_root = mount_prefix_path.join(rel_mount_root);
     if !rel_mount_root.is_empty() {
-        create_volume_dir(
-            engine,
-            &container,
-            mount_root
-                .parent()
-                .expect("mount root should have a parent directory"),
-            msg_info,
-        )
-        .wrap_err("when creating mount root")?;
+        data_volume
+            .create_dir(
+                mount_root
+                    .parent()
+                    .expect("mount root should have a parent directory"),
+                msg_info,
+            )
+            .wrap_err("when creating mount root")?;
     }
-    copy_volume_container_project(
-        engine,
-        &container,
-        package_dirs.host_root(),
-        &mount_root,
-        &volume,
-        copy_cache,
-        msg_info,
-    )
-    .wrap_err("when copying project")?;
+    copy(package_dirs.host_root(), &mount_root, msg_info).wrap_err("when copying project")?;
     let sysroot = toolchain_dirs.get_sysroot().to_owned();
     let mut copied = vec![
         (
@@ -871,7 +803,7 @@ pub(crate) fn run(
         if copy_cache {
             copy(package_dirs.target(), &target_dir, msg_info)?;
         } else {
-            create_volume_dir(engine, &container, &target_dir, msg_info)?;
+            data_volume.create_dir(&target_dir, msg_info)?;
         }
 
         copied.push((package_dirs.target(), target_dir.clone()));
@@ -891,9 +823,7 @@ pub(crate) fn run(
                 .expect("destination should be absolute");
             let mount_dst = mount_prefix_path.join(rel_dst);
             if !rel_dst.is_empty() {
-                create_volume_dir(
-                    engine,
-                    &container,
+                data_volume.create_dir(
                     mount_dst
                         .parent()
                         .expect("destination should have a parent directory"),
@@ -996,7 +926,7 @@ symlink_recurse \"${{prefix}}\"
         .map(|s| bool_from_envvar(&s))
         .unwrap_or_default();
     bail_container_exited!();
-    if !skip_artifacts && container_path_exists(engine, &container, &target_dir, msg_info)? {
+    if !skip_artifacts && data_volume.container_path_exists(&target_dir, msg_info)? {
         subcommand_or_exit(engine, "cp")?
             .arg("-a")
             .arg(&format!("{container}:{}", target_dir.as_posix_absolute()?))

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -71,7 +71,7 @@ impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
         let temppath = tempdir.path();
         let had_symlinks = copy_dir(src, temppath, copy_symlinks, 0, |e, _| is_cachedir(e))?;
         warn_symlinks(had_symlinks, msg_info)?;
-        self.copy_files(temppath, dst, msg_info)
+        self.copy_files(&temppath.join("."), dst, msg_info)
     }
 
     // copy files for a docker volume, for remote host support
@@ -567,7 +567,7 @@ impl QualifiedToolchain {
             .file_name()
             .expect("should be able to get toolchain name")
             .to_utf8()?;
-        let toolchain_hash = path_hash(self.get_sysroot(), 5)?;
+        let toolchain_hash = path_hash(self.get_sysroot(), PATH_HASH_SHORT)?;
         Ok(format!(
             "{VOLUME_PREFIX}{toolchain_name}-{toolchain_hash}-{commit_hash}"
         ))
@@ -577,7 +577,7 @@ impl QualifiedToolchain {
     // be generated outside a rust package and run multiple times.
     pub fn unique_container_identifier(&self, triple: &TargetTriple) -> Result<String> {
         let toolchain_id = self.unique_toolchain_identifier()?;
-        let cwd_path = path_hash(&env::current_dir()?, 5)?;
+        let cwd_path = path_hash(&env::current_dir()?, PATH_HASH_SHORT)?;
         let system_time = now_as_millis()?;
         Ok(format!("{toolchain_id}-{triple}-{cwd_path}-{system_time}"))
     }
@@ -585,7 +585,7 @@ impl QualifiedToolchain {
     // unique identifier for a given mounted volume
     pub fn unique_mount_identifier(&self, path: &Path) -> Result<String> {
         let toolchain_id = self.unique_toolchain_identifier()?;
-        let mount_hash = path_hash(path, 10)?;
+        let mount_hash = path_hash(path, PATH_HASH_UNIQUE)?;
         Ok(format!("{toolchain_id}-{mount_hash}"))
     }
 }

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -31,7 +31,7 @@ macro_rules! bail_container_exited {
 
 fn subcommand_or_exit(engine: &Engine, cmd: &str) -> Result<Command> {
     bail_container_exited!();
-    Ok(subcommand(engine, cmd))
+    Ok(engine.subcommand(cmd))
 }
 
 impl<'a, 'b, 'c> ContainerDataVolume<'a, 'b, 'c> {
@@ -663,7 +663,7 @@ pub(crate) fn run(
     // if we're using a discarded volume.
 
     // 3. create our start container command here
-    let mut docker = subcommand(engine, "run");
+    let mut docker = engine.subcommand("run");
     docker_userns(&mut docker);
     options
         .image
@@ -853,7 +853,7 @@ pub(crate) fn run(
         final_args.push("--target-dir".to_owned());
         final_args.push(target_dir_string);
     }
-    let mut cmd = cargo_safe_command(options.cargo_variant);
+    let mut cmd = options.cargo_variant.safe_command();
     cmd.args(final_args);
 
     // 5. create symlinks for copied data
@@ -901,7 +901,7 @@ symlink_recurse \"${{prefix}}\"
         .wrap_err("when creating symlinks to provide consistent host/mount paths")?;
 
     // 6. execute our cargo command inside the container
-    let mut docker = subcommand(engine, "exec");
+    let mut docker = engine.subcommand("exec");
     docker_user_id(&mut docker, engine.kind);
     docker_envvars(&mut docker, &options, toolchain_dirs, msg_info)?;
     docker_cwd(&mut docker, &paths)?;

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -1443,6 +1443,13 @@ impl MountFinder {
     }
 }
 
+/// Short hash for identifiers with minimal risk of collision.
+pub const PATH_HASH_SHORT: usize = 5;
+
+/// Longer hash to minimize risk of random collisions
+/// Collision chance is ~10^-6
+pub const PATH_HASH_UNIQUE: usize = 10;
+
 fn path_digest(path: &Path) -> Result<const_sha1::Digest> {
     let buffer = const_sha1::ConstBuffer::from_slice(path.to_utf8()?.as_bytes());
     Ok(const_sha1::sha1(&buffer))

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -1417,11 +1417,11 @@ fn path_digest(path: &Path) -> Result<const_sha1::Digest> {
     Ok(const_sha1::sha1(&buffer))
 }
 
-pub fn path_hash(path: &Path) -> Result<String> {
+pub fn path_hash(path: &Path, count: usize) -> Result<String> {
     Ok(path_digest(path)?
         .to_string()
-        .get(..5)
-        .expect("sha1 is expected to be at least 5 characters long")
+        .get(..count)
+        .unwrap_or_else(|| panic!("sha1 is expected to be at least {count} characters long"))
         .to_owned())
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -102,7 +102,7 @@ unsafe fn termination_handler() {
     // however, we'd need to store the engine path and the argument list as
     // a global CString and `Vec<CString>`, respectively. this atomic guard
     // makes this safe regardless.
-    docker::CONTAINER.terminate();
+    docker::CHILD_CONTAINER.terminate();
 
     // all termination exit codes are 128 + signal code. the exit code is
     // 130 for Ctrl+C or SIGINT (signal code 2) for linux, macos, and windows.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -704,7 +704,7 @@ To override the toolchain mounted in the image, set `target.{}.image.toolchain =
                     && target.needs_interpreter()
                     && !interpreter::is_registered(&target)?
                 {
-                    docker::register(&engine, &target, msg_info)?;
+                    engine.register_binfmt(&target, msg_info)?;
                 }
 
                 let paths = docker::DockerPaths::create(&engine, metadata, cwd, toolchain.clone())?;

--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -182,7 +182,7 @@ pub fn build_docker_image(
         } else {
             msg_info.note(format_args!("Build {target} for {}", platform.target))?;
         }
-        let mut docker_build = docker::command(engine);
+        let mut docker_build = engine.command();
         let has_buildkit = docker::Engine::has_buildkit();
         match has_buildkit {
             true => docker_build.args(["buildx", "build"]),
@@ -319,7 +319,7 @@ pub fn build_docker_image(
         }
 
         if let Some(opts) = &build_opts {
-            docker_build.args(docker::parse_docker_opts(opts)?);
+            docker_build.args(docker::Engine::parse_opts(opts)?);
         }
 
         if target.needs_workspace_root_context() {

--- a/xtask/src/target_info.rs
+++ b/xtask/src/target_info.rs
@@ -48,7 +48,7 @@ fn image_info(
         pull_image(engine, image, msg_info)?;
     }
 
-    let mut command = docker::command(engine);
+    let mut command = engine.command();
     command.arg("run");
     command.arg("--rm");
     command.args(["-e", &format!("TARGET={}", target.name)]);

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -133,7 +133,7 @@ pub fn pull_image(
     image: &str,
     msg_info: &mut MessageInfo,
 ) -> cross::Result<()> {
-    let mut command = docker::subcommand(engine, "pull");
+    let mut command = engine.subcommand("pull");
     command.arg(image);
     let out = command.run_and_get_output(msg_info)?;
     command.status_result(msg_info, out.status, Some(&out))?;


### PR DESCRIPTION
This fixes copying files into a directory inside a docker data volume, where previously we copied the entire temp directory into the volume itself. This meant that `tmp.tmpLkX8M3` would be copied to `"${volume}/tmp.tmpLkX8M3"`, rather than its contents being copied into `"${volume}"`. This also contains numerous other bugs fixes and changes internally, which have been submitted each as separate commits.

This fixes a regression in #1054 to re-enable fingerprinting to work, since previously the fingerprint file name was based off the container name. Since #1054 changes the container names to rely on the system time, this ensures the fingerprints are specific for only the toolchain and the path of directory.

This also simplifies the internals of the docker module substantially. Most free functions have been modified to become methods of structs to simplify their function signatures. Some structs have also been renamed to make it clearer what their purpose is.

Closes #1016.