### PR TITLE
Fixes custom toolchain support without rustup.

### DIFF
--- a/.changes/1085.json
+++ b/.changes/1085.json
@@ -1,0 +1,4 @@
+{
+    "type": "added",
+    "description": "support custom toolchains without rustup."
+}

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -1625,6 +1625,7 @@ mod tests {
                 &None,
                 &image_platform,
                 &sysroot,
+                false,
             ))
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -578,11 +578,10 @@ To override the toolchain mounted in the image, set `target.{}.image.toolchain =
             // set the sysroot explicitly to the toolchain
             let mut is_nightly = toolchain.channel.contains("nightly");
 
-            let installed_toolchains = rustup::installed_toolchains(msg_info)?;
-
-            if !installed_toolchains
-                .into_iter()
-                .any(|t| t == toolchain.to_string())
+            if !toolchain.is_custom
+                && !rustup::installed_toolchains(msg_info)?
+                    .into_iter()
+                    .any(|t| t == toolchain.to_string())
             {
                 rustup::install_toolchain(&toolchain, msg_info)?;
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -86,6 +86,7 @@ release: {version}
                     &None,
                     &ImagePlatform::from_const_target(TargetTriple::X86_64UnknownLinuxGnu),
                     Path::new("/toolchains/xxxx-x86_64-unknown-linux-gnu"),
+                    false,
                 ),
                 &target_meta.0,
                 &target_meta.1,


### PR DESCRIPTION
Avoids checking for installed toolchains, and also prevents renaming the sysroot based on the toolchain full name, since this may be in a directory completely different than the target name.