### PR TITLE
Fix CMake Support and Enhance Newlib Targets

### DIFF
--- a/.changes/1112.json
+++ b/.changes/1112.json
@@ -1,0 +1,11 @@
+[
+    {
+        "description": "fixed CMake support for Android and newlib targets.",
+        "type": "fixed",
+        "issues": [1110]
+    },
+    {
+        "description": "added C++ support for newlib targets.",
+        "type": "added"
+    }
+]

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -68,12 +68,10 @@ main() {
         retry cargo fetch
         # don't use xargo: should have native support just from rustc
         rustup toolchain add nightly
-        "${CROSS[@]}" build --lib --target "${TARGET}" ${CROSS_FLAGS}
+        cross_build --lib --target "${TARGET}"
         popd
 
         rm -rf "${td}"
-
-        return
     fi
 
     # `cross build` test for the other targets
@@ -83,7 +81,7 @@ main() {
         pushd "${td}"
         cargo init --lib --name foo .
         retry cargo fetch
-        "${CROSS[@]}" build --target "${TARGET}" ${CROSS_FLAGS}
+        cross_build --target "${TARGET}"
         popd
 
         rm -rf "${td}"
@@ -94,7 +92,7 @@ main() {
         # test that linking works
         cargo init --bin --name hello .
         retry cargo fetch
-        "${CROSS[@]}" build --target "${TARGET}" ${CROSS_FLAGS}
+        cross_build --target "${TARGET}"
         popd
 
         rm -rf "${td}"
@@ -166,8 +164,22 @@ main() {
 
     fi
 
-    # Test C++ support
+    # Test C++ support in a no_std context
     if (( ${CPP:-0} )); then
+        td="$(mkcargotemp -d)"
+
+        git clone --depth 1 https://github.com/cross-rs/rust-cpp-accumulate "${td}"
+
+        pushd "${td}"
+        retry cargo fetch
+        cross_build --target "${TARGET}"
+        popd
+
+        rm -rf "${td}"
+    fi
+
+    # Test C++ support
+    if (( ${STD:-0} )) && (( ${CPP:-0} )); then
         td="$(mkcargotemp -d)"
 
         git clone --depth 1 https://github.com/cross-rs/rust-cpp-hello-word "${td}"
@@ -177,7 +189,7 @@ main() {
         if (( ${RUN:-0} )); then
             cross_run --target "${TARGET}"
         else
-            "${CROSS[@]}" build --target "${TARGET}" ${CROSS_FLAGS}
+            cross_build --target "${TARGET}"
         fi
         popd
 
@@ -193,11 +205,44 @@ main() {
         cargo init --bin --name hello .
         retry cargo fetch
         RUSTFLAGS="-C target-feature=-crt-static" \
-            "${CROSS[@]}" build --target "${TARGET}" ${CROSS_FLAGS}
+            cross_build --target "${TARGET}"
         popd
 
         rm -rf "${td}"
     fi
+
+    # test cmake support
+    td="$(mkcargotemp -d)"
+
+    git clone \
+        --recursive \
+        --depth 1 \
+        https://github.com/cross-rs/rust-cmake-hello-world "${td}"
+
+    pushd "${td}"
+    retry cargo fetch
+    if [[ "${TARGET}" == "arm-linux-androideabi" ]]; then
+        # ARMv5te isn't supported anymore by Android, which produces missing
+        # symbol errors with re2 like `__libcpp_signed_lock_free`.
+        cross_run --target "${TARGET}" --features=tryrun
+    elif (( ${STD:-0} )) && (( ${RUN:-0} )) && (( ${CPP:-0} )); then
+        cross_run --target "${TARGET}" --features=re2,tryrun
+    elif (( ${STD:-0} )) && (( ${CPP:-0} )); then
+        cross_build --target "${TARGET}" --features=re2
+    elif (( ${STD:-0} )) && (( ${RUN:-0} )); then
+        cross_run --target "${TARGET}" --features=tryrun
+    elif (( ${STD:-0} )); then
+        cross_build --target "${TARGET}" --features=tryrun
+    else
+        cross_build --lib --target "${TARGET}"
+    fi
+    popd
+
+    rm -rf "${td}"
+}
+
+cross_build() {
+    "${CROSS[@]}" build "$@" ${CROSS_FLAGS}
 }
 
 cross_run() {

--- a/docker/Dockerfile.aarch64-linux-android
+++ b/docker/Dockerfile.aarch64-linux-android
@@ -34,15 +34,18 @@ RUN /android-system.sh arm64
 
 ENV CROSS_TOOLCHAIN_PREFIX=aarch64-linux-android-
 ENV CROSS_SYSROOT=/android-ndk/sysroot
+ENV CROSS_ANDROID_SDK=$ANDROID_SDK
 COPY android-symlink.sh /
 RUN /android-symlink.sh aarch64 aarch64-linux-android
 
 COPY android-runner /
+COPY android.cmake /opt/toolchain.cmake
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
+ENV CROSS_TARGET_RUNNER="/android-runner aarch64"
 ENV CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_AARCH64_LINUX_ANDROID_RUNNER="/android-runner aarch64" \
+    CARGO_TARGET_AARCH64_LINUX_ANDROID_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_aarch64_linux_android="$CROSS_TOOLCHAIN_PREFIX"ar \
     AS_aarch64_linux_android="$CROSS_TOOLCHAIN_PREFIX"as \
     CC_aarch64_linux_android="$CROSS_TOOLCHAIN_PREFIX"gcc \
@@ -56,6 +59,7 @@ ENV CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     SIZE_aarch64_linux_android="$CROSS_TOOLCHAIN_PREFIX"size \
     STRINGS_aarch64_linux_android="$CROSS_TOOLCHAIN_PREFIX"strings \
     STRIP_aarch64_linux_android="$CROSS_TOOLCHAIN_PREFIX"strip \
+    CMAKE_TOOLCHAIN_FILE_aarch64_linux_android=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_aarch64_linux_android="--sysroot=$CROSS_SYSROOT" \
     DEP_Z_INCLUDE="$CROSS_SYSROOT/usr/include"/ \
     RUST_TEST_THREADS=1 \
@@ -63,4 +67,8 @@ ENV CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     TMPDIR=/tmp/ \
     ANDROID_DATA=/ \
     ANDROID_DNS_MODE=local \
-    ANDROID_ROOT=/system
+    ANDROID_ROOT=/system \
+    CROSS_CMAKE_SYSTEM_NAME=Android \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=aarch64 \
+    CROSS_CMAKE_CRT=android \
+    CROSS_CMAKE_OBJECT_FLAGS="-DANDROID -ffunction-sections -fdata-sections -fPIC"

--- a/docker/Dockerfile.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu
@@ -29,15 +29,22 @@ COPY linux-image.sh /
 RUN /linux-image.sh aarch64
 
 COPY linux-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=aarch64-linux-gnu-
 ENV CROSS_SYSROOT=/usr/aarch64-linux-gnu
+ENV CROSS_TARGET_RUNNER="/linux-runner aarch64"
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner aarch64" \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_aarch64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_aarch64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_aarch64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_aarch64_unknown_linux_gnu=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/aarch64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/aarch64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=aarch64 \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC"

--- a/docker/Dockerfile.aarch64-unknown-linux-gnu.centos
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu.centos
@@ -30,13 +30,21 @@ COPY linux-runner base-runner.sh /
 COPY aarch64-linux-gnu-glibc.sh /
 RUN /aarch64-linux-gnu-glibc.sh
 
+COPY toolchain.cmake /opt/toolchain.cmake
+
 ENV CROSS_TOOLCHAIN_PREFIX=aarch64-linux-gnu-
 ENV CROSS_SYSROOT=/usr/aarch64-linux-gnu
+ENV CROSS_TARGET_RUNNER="/linux-runner aarch64"
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner aarch64" \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_aarch64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_aarch64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_aarch64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_aarch64_unknown_linux_gnu=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
-    RUST_TEST_THREADS=1
+    RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=aarch64 \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC"

--- a/docker/Dockerfile.aarch64-unknown-linux-musl
+++ b/docker/Dockerfile.aarch64-unknown-linux-musl
@@ -23,13 +23,20 @@ RUN /musl-symlink.sh $CROSS_SYSROOT aarch64
 
 COPY musl-gcc.sh /usr/bin/"$CROSS_TOOLCHAIN_PREFIX"gcc.sh
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
+ENV CROSS_TARGET_RUNNER="/qemu-runner aarch64"
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc.sh \
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER="/qemu-runner aarch64" \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_aarch64_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_aarch64_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_aarch64_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_aarch64_unknown_linux_musl=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_musl="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=aarch64 \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC" \
     CROSS_BUILTINS_PATCHED_MINOR_VERSION=48

--- a/docker/Dockerfile.arm-linux-androideabi
+++ b/docker/Dockerfile.arm-linux-androideabi
@@ -34,15 +34,18 @@ RUN /android-system.sh arm
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-androideabi-
 ENV CROSS_SYSROOT=/android-ndk/sysroot
+ENV CROSS_ANDROID_SDK=$ANDROID_SDK
 COPY android-symlink.sh /
 RUN /android-symlink.sh arm arm-linux-androideabi
 
 COPY android-runner /
+COPY android.cmake /opt/toolchain.cmake
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
+ENV CROSS_TARGET_RUNNER="/android-runner arm"
 ENV CARGO_TARGET_ARM_LINUX_ANDROIDEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_ARM_LINUX_ANDROIDEABI_RUNNER="/android-runner arm" \
+    CARGO_TARGET_ARM_LINUX_ANDROIDEABI_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_arm_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     AS_arm_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"as \
     CC_arm_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"gcc \
@@ -56,6 +59,7 @@ ENV CARGO_TARGET_ARM_LINUX_ANDROIDEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     SIZE_arm_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"size \
     STRINGS_arm_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"strings \
     STRIP_arm_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"strip \
+    CMAKE_TOOLCHAIN_FILE_arm_linux_androideabi=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_arm_linux_androideabi="--sysroot=$CROSS_SYSROOT" \
     DEP_Z_INCLUDE="$CROSS_SYSROOT/usr/include/" \
     RUST_TEST_THREADS=1 \
@@ -63,4 +67,8 @@ ENV CARGO_TARGET_ARM_LINUX_ANDROIDEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     TMPDIR=/tmp/ \
     ANDROID_DATA=/ \
     ANDROID_DNS_MODE=local \
-    ANDROID_ROOT=/system
+    ANDROID_ROOT=/system \
+    CROSS_CMAKE_SYSTEM_NAME=Android \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=armv5te \
+    CROSS_CMAKE_CRT=android \
+    CROSS_CMAKE_OBJECT_FLAGS="--target=arm-linux-androideabi -DANDROID -ffunction-sections -fdata-sections -fPIC --target=arm-linux-androideabi"

--- a/docker/Dockerfile.arm-unknown-linux-gnueabi
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabi
@@ -23,15 +23,22 @@ COPY qemu.sh /
 RUN /qemu.sh arm
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabi-
 ENV CROSS_SYSROOT=/usr/arm-linux-gnueabi
+ENV CROSS_TARGET_RUNNER="/qemu-runner arm"
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_RUNNER="/qemu-runner arm" \
+    CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_arm_unknown_linux_gnueabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_arm_unknown_linux_gnueabi="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_arm_unknown_linux_gnueabi="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_arm_unknown_linux_gnueabi=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_arm_unknown_linux_gnueabi="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabi/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabi/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=arm \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -march=armv6 -marm -mfloat-abi=soft"

--- a/docker/Dockerfile.arm-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabihf
@@ -24,14 +24,21 @@ COPY qemu.sh /
 RUN /qemu.sh arm
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-unknown-linux-gnueabihf-
 ENV CROSS_SYSROOT=/x-tools/arm-unknown-linux-gnueabihf/arm-unknown-linux-gnueabihf/sysroot/
+ENV CROSS_TARGET_RUNNER="/qemu-runner armhf"
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUNNER="/qemu-runner armhf" \
+    CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_arm_unknown_linux_gnueabihf="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_arm_unknown_linux_gnueabihf="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_arm_unknown_linux_gnueabihf="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_arm_unknown_linux_gnueabihf=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_arm_unknown_linux_gnueabihf="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
-    RUST_TEST_THREADS=1
+    RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=arm \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -march=armv6 -marm -mfpu=vfp"

--- a/docker/Dockerfile.arm-unknown-linux-musleabi
+++ b/docker/Dockerfile.arm-unknown-linux-musleabi
@@ -26,12 +26,19 @@ COPY musl-symlink.sh /
 RUN /musl-symlink.sh $CROSS_SYSROOT arm
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
+ENV CROSS_TARGET_RUNNER="/qemu-runner arm"
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABI_RUNNER="/qemu-runner arm" \
+    CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABI_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_arm_unknown_linux_musleabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_arm_unknown_linux_musleabi="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_arm_unknown_linux_musleabi="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_arm_unknown_linux_musleabi=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_arm_unknown_linux_musleabi="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
-    RUST_TEST_THREADS=1
+    RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=arm \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -march=armv6 -marm -mfloat-abi=soft"

--- a/docker/Dockerfile.arm-unknown-linux-musleabihf
+++ b/docker/Dockerfile.arm-unknown-linux-musleabihf
@@ -27,12 +27,19 @@ COPY musl-symlink.sh /
 RUN /musl-symlink.sh $CROSS_SYSROOT armhf
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
+ENV CROSS_TARGET_RUNNER="/qemu-runner armhf"
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUNNER="/qemu-runner armhf" \
+    CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_arm_unknown_linux_musleabihf="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_arm_unknown_linux_musleabihf="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_arm_unknown_linux_musleabihf="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_arm_unknown_linux_musleabihf=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_arm_unknown_linux_musleabihf="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
-    RUST_TEST_THREADS=1
+    RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=arm \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -march=armv6 -marm -mfpu=vfp"

--- a/docker/Dockerfile.armv5te-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-gnueabi
@@ -24,15 +24,22 @@ COPY qemu.sh /
 RUN /qemu.sh arm
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabi-
 ENV CROSS_SYSROOT=/usr/arm-linux-gnueabi
+ENV CROSS_TARGET_RUNNER="/qemu-runner arm"
 ENV CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_GNUEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_GNUEABI_RUNNER="/qemu-runner arm" \
+    CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_GNUEABI_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_armv5te_unknown_linux_gnueabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_armv5te_unknown_linux_gnueabi="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_armv5te_unknown_linux_gnueabi="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_armv5te_unknown_linux_gnueabi=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_armv5te_unknown_linux_gnueabi="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabi/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabi/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=arm \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -march=armv5te -marm -mfloat-abi=soft"

--- a/docker/Dockerfile.armv5te-unknown-linux-musleabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-musleabi
@@ -27,13 +27,20 @@ RUN /musl-symlink.sh $CROSS_SYSROOT arm
 
 COPY musl-gcc.sh /usr/bin/"$CROSS_TOOLCHAIN_PREFIX"gcc.sh
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
+ENV CROSS_TARGET_RUNNER="/qemu-runner arm"
 ENV CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc.sh \
-    CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_RUNNER="/qemu-runner arm" \
+    CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_armv5te_unknown_linux_musleabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_armv5te_unknown_linux_musleabi="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_armv5te_unknown_linux_musleabi="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_armv5te_unknown_linux_musleabi=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_armv5te_unknown_linux_musleabi="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=arm \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -march=armv5te -marm -mfloat-abi=soft" \
     CROSS_BUILTINS_PATCHED_MINOR_VERSION=65

--- a/docker/Dockerfile.armv7-linux-androideabi
+++ b/docker/Dockerfile.armv7-linux-androideabi
@@ -34,15 +34,18 @@ RUN /android-system.sh arm
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-androideabi-
 ENV CROSS_SYSROOT=/android-ndk/sysroot
+ENV CROSS_ANDROID_SDK=$ANDROID_SDK
 COPY android-symlink.sh /
 RUN /android-symlink.sh arm arm-linux-androideabi
 
 COPY android-runner /
+COPY android.cmake /opt/toolchain.cmake
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
+ENV CROSS_TARGET_RUNNER="/android-runner arm"
 ENV CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_RUNNER="/android-runner arm" \
+    CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_armv7_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     AS_armv7_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"as \
     CC_armv7_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"gcc \
@@ -56,6 +59,7 @@ ENV CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     SIZE_armv7_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"size \
     STRINGS_armv7_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"strings \
     STRIP_armv7_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"strip \
+    CMAKE_TOOLCHAIN_FILE_armv7_linux_androideabi=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_armv7_linux_androideabi="--sysroot=$CROSS_SYSROOT" \
     DEP_Z_INCLUDE="$CROSS_SYSROOT/usr/include/" \
     RUST_TEST_THREADS=1 \
@@ -63,4 +67,8 @@ ENV CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     TMPDIR=/tmp/ \
     ANDROID_DATA=/ \
     ANDROID_DNS_MODE=local \
-    ANDROID_ROOT=/system
+    ANDROID_ROOT=/system \
+    CROSS_CMAKE_SYSTEM_NAME=Android \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=armv7-a \
+    CROSS_CMAKE_CRT=android \
+    CROSS_CMAKE_OBJECT_FLAGS="--target=arm-linux-androideabi -DANDROID -ffunction-sections -fdata-sections -fPIC --target=armv7-linux-androideabi"

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabi
@@ -18,15 +18,22 @@ COPY qemu.sh /
 RUN /qemu.sh arm
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabi-
 ENV CROSS_SYSROOT=/usr/arm-linux-gnueabi
+ENV CROSS_TARGET_RUNNER="/qemu-runner armv7"
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABI_RUNNER="/qemu-runner armv7" \
+    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABI_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_armv7_unknown_linux_gnueabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_armv7_unknown_linux_gnueabi="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_armv7_unknown_linux_gnueabi="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_armv7_unknown_linux_gnueabi=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_gnueabi="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabi/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabi/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=arm \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -march=armv7-a"

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -29,15 +29,22 @@ COPY linux-image.sh /
 RUN /linux-image.sh armv7
 
 COPY linux-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabihf-
 ENV CROSS_SYSROOT=/usr/arm-linux-gnueabihf
+ENV CROSS_TARGET_RUNNER="/linux-runner armv7hf"
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUNNER="/linux-runner armv7hf" \
+    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_armv7_unknown_linux_gnueabihf="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_armv7_unknown_linux_gnueabihf="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_armv7_unknown_linux_gnueabihf="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_armv7_unknown_linux_gnueabihf=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_gnueabihf="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabihf/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabihf/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=arm \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -march=armv7-a -mfpu=vfpv3-d16"

--- a/docker/Dockerfile.armv7-unknown-linux-musleabi
+++ b/docker/Dockerfile.armv7-unknown-linux-musleabi
@@ -27,12 +27,19 @@ COPY musl-symlink.sh /
 RUN /musl-symlink.sh $CROSS_SYSROOT arm
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
+ENV CROSS_TARGET_RUNNER="/qemu-runner armv7"
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABI_RUNNER="/qemu-runner armv7" \
+    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABI_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_armv7_unknown_linux_musleabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_armv7_unknown_linux_musleabi="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_armv7_unknown_linux_musleabi="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_armv7_unknown_linux_musleabi=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_musleabi="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
-    RUST_TEST_THREADS=1
+    RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=arm \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -march=armv7-a"

--- a/docker/Dockerfile.armv7-unknown-linux-musleabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-musleabihf
@@ -27,12 +27,19 @@ COPY musl-symlink.sh /
 RUN /musl-symlink.sh $CROSS_SYSROOT armhf
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
+ENV CROSS_TARGET_RUNNER="/qemu-runner armv7hf"
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_RUNNER="/qemu-runner armv7hf" \
+    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_armv7_unknown_linux_musleabihf="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_armv7_unknown_linux_musleabihf="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_armv7_unknown_linux_musleabihf="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_armv7_unknown_linux_musleabihf=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_armv7_unknown_linux_musleabihf="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
-    RUST_TEST_THREADS=1
+    RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=arm \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -march=armv7-a -mfpu=vfpv3-d16"

--- a/docker/Dockerfile.asmjs-unknown-emscripten
+++ b/docker/Dockerfile.asmjs-unknown-emscripten
@@ -17,5 +17,7 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
 
 ENV CROSS_TOOLCHAIN_PREFIX=em
 ENV CROSS_SYSROOT=/emsdk/upstream/emscripten/cache/sysroot
-ENV CARGO_TARGET_ASMJS_UNKNOWN_EMSCRIPTEN_RUNNER=node \
-    BINDGEN_EXTRA_CLANG_ARGS_asmjs_unknown_emscripten="--sysroot=$CROSS_SYSROOT"
+ENV CROSS_TARGET_RUNNER="node"
+ENV CARGO_TARGET_ASMJS_UNKNOWN_EMSCRIPTEN_RUNNER="$CROSS_TARGET_RUNNER" \
+    BINDGEN_EXTRA_CLANG_ARGS_asmjs_unknown_emscripten="--sysroot=$CROSS_SYSROOT" \
+    CMAKE_TOOLCHAIN_FILE_asmjs_unknown_emscripten=/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake

--- a/docker/Dockerfile.i586-unknown-linux-gnu
+++ b/docker/Dockerfile.i586-unknown-linux-gnu
@@ -23,15 +23,22 @@ COPY qemu.sh /
 RUN /qemu.sh i386
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=i686-linux-gnu-
 ENV CROSS_SYSROOT=/usr/i686-linux-gnu
+ENV CROSS_TARGET_RUNNER="/qemu-runner i586"
 ENV CARGO_TARGET_I586_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_I586_UNKNOWN_LINUX_GNU_RUNNER="/qemu-runner i586" \
+    CARGO_TARGET_I586_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_i586_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_i586_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_i586_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_i586_unknown_linux_gnu=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_i586_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/i386-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/i386-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=x86 \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m32 -march=pentium"

--- a/docker/Dockerfile.i586-unknown-linux-musl
+++ b/docker/Dockerfile.i586-unknown-linux-musl
@@ -22,11 +22,18 @@ COPY musl-symlink.sh /
 RUN /musl-symlink.sh $CROSS_SYSROOT i386
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
+ENV CROSS_TARGET_RUNNER="/qemu-runner i586"
 ENV CARGO_TARGET_I586_UNKNOWN_LINUX_MUSL_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_I586_UNKNOWN_LINUX_MUSL_RUNNER="/qemu-runner i586" \
+    CARGO_TARGET_I586_UNKNOWN_LINUX_MUSL_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_i586_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_i586_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_i586_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_i586_unknown_linux_musl=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_i586_unknown_linux_musl="--sysroot=$CROSS_SYSROOT" \
-    QEMU_LD_PREFIX="$CROSS_SYSROOT"
+    QEMU_LD_PREFIX="$CROSS_SYSROOT" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=x86 \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m32 -march=pentium -Wl,-melf_i386"

--- a/docker/Dockerfile.i686-linux-android
+++ b/docker/Dockerfile.i686-linux-android
@@ -42,15 +42,18 @@ RUN /android-system.sh x86
 
 ENV CROSS_TOOLCHAIN_PREFIX=i686-linux-android-
 ENV CROSS_SYSROOT=/android-ndk/sysroot
+ENV CROSS_ANDROID_SDK=$ANDROID_SDK
 COPY android-symlink.sh /
 RUN /android-symlink.sh i386 i686-linux-android
 
 COPY android-runner /
+COPY android.cmake /opt/toolchain.cmake
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
+ENV CROSS_TARGET_RUNNER="/android-runner i686"
 ENV CARGO_TARGET_I686_LINUX_ANDROID_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_I686_LINUX_ANDROID_RUNNER="/android-runner i686" \
+    CARGO_TARGET_I686_LINUX_ANDROID_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_i686_linux_android="$CROSS_TOOLCHAIN_PREFIX"ar \
     AS_i686_linux_android="$CROSS_TOOLCHAIN_PREFIX"as \
     CC_i686_linux_android="$CROSS_TOOLCHAIN_PREFIX"gcc \
@@ -64,6 +67,7 @@ ENV CARGO_TARGET_I686_LINUX_ANDROID_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     SIZE_i686_linux_android="$CROSS_TOOLCHAIN_PREFIX"size \
     STRINGS_i686_linux_android="$CROSS_TOOLCHAIN_PREFIX"strings \
     STRIP_i686_linux_android="$CROSS_TOOLCHAIN_PREFIX"strip \
+    CMAKE_TOOLCHAIN_FILE_i686_linux_android=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_i686_linux_android="--sysroot=$CROSS_SYSROOT" \
     DEP_Z_INCLUDE="$CROSS_SYSROOT/usr/include/" \
     LIBZ_SYS_STATIC=1 \
@@ -72,4 +76,8 @@ ENV CARGO_TARGET_I686_LINUX_ANDROID_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     TMPDIR=/tmp/ \
     ANDROID_DATA=/ \
     ANDROID_DNS_MODE=local \
-    ANDROID_ROOT=/system
+    ANDROID_ROOT=/system \
+    CROSS_CMAKE_SYSTEM_NAME=Android \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=i686 \
+    CROSS_CMAKE_CRT=android \
+    CROSS_CMAKE_OBJECT_FLAGS="--target=i686-linux-android -DANDROID -ffunction-sections -fdata-sections -fPIC --target=i686-linux-android"

--- a/docker/Dockerfile.i686-pc-windows-gnu
+++ b/docker/Dockerfile.i686-pc-windows-gnu
@@ -34,13 +34,22 @@ RUN mkdir -p /usr/lib/binfmt-support/ && \
 COPY windows-entry.sh /
 ENTRYPOINT ["/windows-entry.sh"]
 
+COPY toolchain.cmake /opt/toolchain.cmake
+
 # for why we always link with pthread support, see:
 # https://github.com/cross-rs/cross/pull/1123#issuecomment-1312287148
 ENV CROSS_TOOLCHAIN_PREFIX=i686-w64-mingw32-
+ENV CROSS_TOOLCHAIN_SUFFIX=-posix
 ENV CROSS_SYSROOT=/usr/i686-w64-mingw32
-ENV CARGO_TARGET_I686_PC_WINDOWS_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc-posix \
-    CARGO_TARGET_I686_PC_WINDOWS_GNU_RUNNER=wine \
+ENV CROSS_TARGET_RUNNER="wine"
+ENV CARGO_TARGET_I686_PC_WINDOWS_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc"$CROSS_TOOLCHAIN_SUFFIX" \
+    CARGO_TARGET_I686_PC_WINDOWS_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_i686_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
-    CC_i686_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc-posix \
-    CXX_i686_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"g++-posix \
-    BINDGEN_EXTRA_CLANG_ARGS_i686_pc_windows_gnu="--sysroot=$CROSS_SYSROOT"
+    CC_i686_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc"$CROSS_TOOLCHAIN_SUFFIX" \
+    CXX_i686_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"g++"$CROSS_TOOLCHAIN_SUFFIX" \
+    CMAKE_TOOLCHAIN_FILE_i686_pc_windows_gnu=/opt/toolchain.cmake \
+    BINDGEN_EXTRA_CLANG_ARGS_i686_pc_windows_gnu="--sysroot=$CROSS_SYSROOT" \
+    CROSS_CMAKE_SYSTEM_NAME=Windows \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=x86 \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -m32"

--- a/docker/Dockerfile.i686-unknown-freebsd
+++ b/docker/Dockerfile.i686-unknown-freebsd
@@ -23,10 +23,16 @@ ENV CROSS_TOOLCHAIN_PREFIX=i686-unknown-freebsd12-
 ENV CROSS_SYSROOT=/usr/local/i686-unknown-freebsd12
 
 COPY freebsd-gcc.sh /usr/bin/"$CROSS_TOOLCHAIN_PREFIX"gcc.sh
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CARGO_TARGET_I686_UNKNOWN_FREEBSD_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc.sh \
     AR_i686_unknown_freebsd="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_i686_unknown_freebsd="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_i686_unknown_freebsd="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_i686_unknown_freebsd=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_i686_unknown_freebsd="--sysroot=$CROSS_SYSROOT" \
-    I686_UNKNOWN_FREEBSD_OPENSSL_DIR="$CROSS_SYSROOT"
+    I686_UNKNOWN_FREEBSD_OPENSSL_DIR="$CROSS_SYSROOT" \
+    CROSS_CMAKE_SYSTEM_NAME=FreeBSD \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=x86 \
+    CROSS_CMAKE_CRT=freebsd \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m32"

--- a/docker/Dockerfile.i686-unknown-linux-gnu
+++ b/docker/Dockerfile.i686-unknown-linux-gnu
@@ -29,15 +29,22 @@ COPY linux-image.sh /
 RUN /linux-image.sh i686
 
 COPY linux-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=i686-linux-gnu-
 ENV CROSS_SYSROOT=/usr/i686-linux-gnu
+ENV CROSS_TARGET_RUNNER="/linux-runner i686"
 ENV CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner i686" \
+    CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_i686_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_i686_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_i686_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_i686_unknown_linux_gnu=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_i686_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/i386-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/i386-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=x86 \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m32 -march=i686"

--- a/docker/Dockerfile.i686-unknown-linux-musl
+++ b/docker/Dockerfile.i686-unknown-linux-musl
@@ -22,11 +22,18 @@ COPY musl-symlink.sh /
 RUN /musl-symlink.sh $CROSS_SYSROOT i386
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
+ENV CROSS_TARGET_RUNNER="/qemu-runner i686"
 ENV CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_RUNNER="/qemu-runner i686" \
+    CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_i686_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_i686_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_i686_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_i686_unknown_linux_musl=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_i686_unknown_linux_musl="--sysroot=$CROSS_SYSROOT" \
-    QEMU_LD_PREFIX="$CROSS_SYSROOT"
+    QEMU_LD_PREFIX="$CROSS_SYSROOT" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=x86 \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m32 -march=i686 -Wl,-melf_i386"

--- a/docker/Dockerfile.mips-unknown-linux-gnu
+++ b/docker/Dockerfile.mips-unknown-linux-gnu
@@ -18,15 +18,22 @@ COPY qemu.sh /
 RUN /qemu.sh mips
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=mips-linux-gnu-
 ENV CROSS_SYSROOT=/usr/mips-linux-gnu
+ENV CROSS_TARGET_RUNNER="/qemu-runner mips"
 ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER="/qemu-runner mips" \
+    CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_mips_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_mips_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_mips_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_mips_unknown_linux_gnu=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_mips_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/mips-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/mips-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=mips \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC"

--- a/docker/Dockerfile.mips-unknown-linux-musl
+++ b/docker/Dockerfile.mips-unknown-linux-musl
@@ -26,12 +26,19 @@ COPY musl-symlink.sh /
 RUN /musl-symlink.sh $CROSS_SYSROOT mips-sf
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
+ENV CROSS_TARGET_RUNNER="/qemu-runner mips"
 ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_RUNNER="/qemu-runner mips" \
+    CARGO_TARGET_MIPS_UNKNOWN_LINUX_MUSL_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_mips_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_mips_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_mips_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_mips_unknown_linux_musl=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_mips_unknown_linux_musl="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
-    RUST_TEST_THREADS=1
+    RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=mips \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC"

--- a/docker/Dockerfile.mips64-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-gnuabi64
@@ -23,15 +23,22 @@ COPY qemu.sh /
 RUN /qemu.sh mips64
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=mips64-linux-gnuabi64-
 ENV CROSS_SYSROOT=/usr/mips64-linux-gnuabi64
+ENV CROSS_TARGET_RUNNER="/qemu-runner mips64"
 ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_RUNNER="/qemu-runner mips64" \
+    CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_mips64_unknown_linux_gnuabi64="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_mips64_unknown_linux_gnuabi64="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_mips64_unknown_linux_gnuabi64="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_mips64_unknown_linux_gnuabi64=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_mips64_unknown_linux_gnuabi64="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/mips64-linux-gnuabi64/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/mips64-linux-gnuabi64/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=mips64 \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC"

--- a/docker/Dockerfile.mips64-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-muslabi64
@@ -30,13 +30,20 @@ RUN ln -s $CROSS_SYSROOT/usr/lib/libc.so.1 $CROSS_SYSROOT/usr/lib64/libc.so.1
 
 COPY musl-gcc.sh /usr/bin/"$CROSS_TOOLCHAIN_PREFIX"gcc.sh
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
+ENV CROSS_TARGET_RUNNER="/qemu-runner mips64"
 ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc.sh \
-    CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_RUNNER="/qemu-runner mips64" \
+    CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_mips64_unknown_linux_muslabi64="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_mips64_unknown_linux_muslabi64="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_mips64_unknown_linux_muslabi64="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_mips64_unknown_linux_muslabi64=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_mips64_unknown_linux_muslabi64="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=mips64 \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC" \
     CROSS_BUILTINS_PATCHED_MINOR_VERSION=65

--- a/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
@@ -29,15 +29,22 @@ COPY linux-image.sh /
 RUN /linux-image.sh mips64el
 
 COPY linux-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=mips64el-linux-gnuabi64-
 ENV CROSS_SYSROOT=/usr/mips64el-linux-gnuabi64
+ENV CROSS_TARGET_RUNNER="/linux-runner mips64el"
 ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_RUNNER="/linux-runner mips64el" \
+    CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_mips64el_unknown_linux_gnuabi64="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_mips64el_unknown_linux_gnuabi64="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_mips64el_unknown_linux_gnuabi64="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_mips64el_unknown_linux_gnuabi64=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_mips64el_unknown_linux_gnuabi64="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/mips64el-linux-gnuabi64/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/mips64el-linux-gnuabi64/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=mips64 \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC"

--- a/docker/Dockerfile.mips64el-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-muslabi64
@@ -30,13 +30,20 @@ RUN ln -s $CROSS_SYSROOT/usr/lib/libc.so.1 $CROSS_SYSROOT/usr/lib64/libc.so.1
 
 COPY musl-gcc.sh /usr/bin/"$CROSS_TOOLCHAIN_PREFIX"gcc.sh
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
+ENV CROSS_TARGET_RUNNER="/qemu-runner mips64el"
 ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc.sh \
-    CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_RUNNER="/qemu-runner mips64el" \
+    CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_mips64el_unknown_linux_muslabi64="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_mips64el_unknown_linux_muslabi64="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_mips64el_unknown_linux_muslabi64="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_mips64el_unknown_linux_muslabi64=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_mips64el_unknown_linux_muslabi64="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=mips64 \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC" \
     CROSS_BUILTINS_PATCHED_MINOR_VERSION=65

--- a/docker/Dockerfile.mipsel-unknown-linux-gnu
+++ b/docker/Dockerfile.mipsel-unknown-linux-gnu
@@ -29,15 +29,22 @@ COPY linux-image.sh /
 RUN /linux-image.sh mipsel
 
 COPY linux-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=mipsel-linux-gnu-
 ENV CROSS_SYSROOT=/usr/mipsel-linux-gnu
+ENV CROSS_TARGET_RUNNER="/linux-runner mipsel"
 ENV CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner mipsel" \
+    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_mipsel_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_mipsel_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_mipsel_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_mipsel_unknown_linux_gnu=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_mipsel_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/mipsel-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/mipsel-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=mips \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC"

--- a/docker/Dockerfile.mipsel-unknown-linux-musl
+++ b/docker/Dockerfile.mipsel-unknown-linux-musl
@@ -26,12 +26,19 @@ COPY musl-symlink.sh /
 RUN /musl-symlink.sh $CROSS_SYSROOT mipsel-sf
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
+ENV CROSS_TARGET_RUNNER="/qemu-runner mipsel"
 ENV CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_RUNNER="/qemu-runner mipsel" \
+    CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_MUSL_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_mipsel_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_mipsel_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_mipsel_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_mipsel_unknown_linux_musl=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_mipsel_unknown_linux_musl="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
-    RUST_TEST_THREADS=1
+    RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=mips \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC"

--- a/docker/Dockerfile.powerpc-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc-unknown-linux-gnu
@@ -29,15 +29,22 @@ COPY linux-image.sh /
 RUN /linux-image.sh powerpc
 
 COPY linux-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=powerpc-linux-gnu-
 ENV CROSS_SYSROOT=/usr/powerpc-linux-gnu
+ENV CROSS_TARGET_RUNNER="/linux-runner powerpc"
 ENV CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner powerpc" \
+    CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_powerpc_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_powerpc_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_powerpc_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_powerpc_unknown_linux_gnu=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_powerpc_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/powerpc-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/powerpc-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=ppc \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC"

--- a/docker/Dockerfile.powerpc64-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64-unknown-linux-gnu
@@ -29,15 +29,22 @@ COPY linux-image.sh /
 RUN /linux-image.sh powerpc64
 
 COPY linux-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=powerpc64-linux-gnu-
 ENV CROSS_SYSROOT=/usr/powerpc64-linux-gnu
+ENV CROSS_TARGET_RUNNER="/linux-runner powerpc64"
 ENV CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner powerpc64" \
+    CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_powerpc64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_powerpc64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_powerpc64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_powerpc64_unknown_linux_gnu=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_powerpc64_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/powerpc64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/powerpc64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=ppc64 \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m64"

--- a/docker/Dockerfile.powerpc64le-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64le-unknown-linux-gnu
@@ -29,15 +29,22 @@ COPY linux-image.sh /
 RUN /linux-image.sh powerpc64le
 
 COPY linux-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=powerpc64le-linux-gnu-
 ENV CROSS_SYSROOT=/usr/powerpc64le-linux-gnu
+ENV CROSS_TARGET_RUNNER="/linux-runner powerpc64le"
 ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner powerpc64le" \
+    CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_powerpc64le_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_powerpc64le_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_powerpc64le_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_powerpc64le_unknown_linux_gnu=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_powerpc64le_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/powerpc64le-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/powerpc64le-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=ppc64 \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m64"

--- a/docker/Dockerfile.riscv64gc-unknown-linux-gnu
+++ b/docker/Dockerfile.riscv64gc-unknown-linux-gnu
@@ -29,15 +29,22 @@ COPY linux-image.sh /
 RUN /linux-image.sh riscv64
 
 COPY linux-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=riscv64-linux-gnu-
 ENV CROSS_SYSROOT=/usr/riscv64-linux-gnu
+ENV CROSS_TARGET_RUNNER="/linux-runner riscv64"
 ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner riscv64" \
+    CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_riscv64gc_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_riscv64gc_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_riscv64gc_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_riscv64gc_unknown_linux_gnu=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_riscv64gc_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/riscv64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/riscv64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=riscv64 \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -march=rv64gc -mabi=lp64d -mcmodel=medany"

--- a/docker/Dockerfile.s390x-unknown-linux-gnu
+++ b/docker/Dockerfile.s390x-unknown-linux-gnu
@@ -29,15 +29,22 @@ COPY linux-image.sh /
 RUN /linux-image.sh s390x
 
 COPY linux-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=s390x-linux-gnu-
 ENV CROSS_SYSROOT=/usr/s390x-linux-gnu
+ENV CROSS_TARGET_RUNNER="/linux-runner s390x"
 ENV CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner s390x" \
+    CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_s390x_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_s390x_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_s390x_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_s390x_unknown_linux_gnu=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_s390x_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/s390x-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/s390x-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=s390x \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC"

--- a/docker/Dockerfile.sparc64-unknown-linux-gnu
+++ b/docker/Dockerfile.sparc64-unknown-linux-gnu
@@ -29,15 +29,22 @@ COPY linux-image.sh /
 RUN /linux-image.sh sparc64
 
 COPY linux-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=sparc64-linux-gnu-
 ENV CROSS_SYSROOT=/usr/sparc64-linux-gnu
+ENV CROSS_TARGET_RUNNER="/linux-runner sparc64"
 ENV CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner sparc64" \
+    CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_sparc64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_sparc64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_sparc64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_sparc64_unknown_linux_gnu=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_sparc64_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/sparc64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/sparc64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=sparc64 \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC"

--- a/docker/Dockerfile.sparcv9-sun-solaris
+++ b/docker/Dockerfile.sparcv9-sun-solaris
@@ -13,10 +13,17 @@ RUN /xargo.sh
 COPY solaris.sh /
 RUN /solaris.sh sparcv9
 
+COPY toolchain.cmake /opt/toolchain.cmake
+
 ENV CROSS_TOOLCHAIN_PREFIX=sparcv9-sun-solaris2.10-
 ENV CROSS_SYSROOT=/usr/local/sparcv9-sun-solaris2.10
 ENV CARGO_TARGET_SPARCV9_SUN_SOLARIS_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     AR_sparcv9_sun_solaris="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_sparcv9_sun_solaris="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_sparcv9_sun_solaris="$CROSS_TOOLCHAIN_PREFIX"g++ \
-    BINDGEN_EXTRA_CLANG_ARGS_sparcv9_sun_solaris="--sysroot=$CROSS_SYSROOT"
+    CMAKE_TOOLCHAIN_FILE_sparcv9_sun_solaris=/opt/toolchain.cmake \
+    BINDGEN_EXTRA_CLANG_ARGS_sparcv9_sun_solaris="--sysroot=$CROSS_SYSROOT" \
+    CROSS_CMAKE_SYSTEM_NAME=SunOS \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=sparc64 \
+    CROSS_CMAKE_CRT=solaris \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC"

--- a/docker/Dockerfile.thumbv6m-none-eabi
+++ b/docker/Dockerfile.thumbv6m-none-eabi
@@ -10,15 +10,26 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-COPY qemu.sh /
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
-    libnewlib-arm-none-eabi && \
-    /qemu.sh arm
+    libnewlib-arm-none-eabi \
+    libstdc++-arm-none-eabi-newlib
+
+COPY qemu.sh /
+RUN /qemu.sh arm
+
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-none-eabi-
-ENV QEMU_CPU=cortex-m3 \
+ENV CROSS_SYSROOT="/usr/lib/arm-none-eabi"
+ENV CROSS_TARGET_RUNNER=qemu-arm
+ENV QEMU_CPU=cortex-m1 \
     AR_thumbv6m_none_eabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_thumbv6m_none_eabi="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_thumbv6m_none_eabi="$CROSS_TOOLCHAIN_PREFIX"g++ \
-    CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER=qemu-arm
+    CMAKE_TOOLCHAIN_FILE_thumbv6m_none_eabi=/opt/toolchain.cmake \
+    CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER="$CROSS_TARGET_RUNNER" \
+    CROSS_CMAKE_SYSTEM_NAME=Generic \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=armv6-m \
+    CROSS_CMAKE_CRT=newlib \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -mthumb -march=armv6s-m"

--- a/docker/Dockerfile.thumbv7em-none-eabi
+++ b/docker/Dockerfile.thumbv7em-none-eabi
@@ -10,15 +10,26 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-COPY qemu.sh /
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
-    libnewlib-arm-none-eabi && \
-    /qemu.sh arm
+    libnewlib-arm-none-eabi \
+    libstdc++-arm-none-eabi-newlib
+
+COPY qemu.sh /
+RUN /qemu.sh arm
+
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-none-eabi-
+ENV CROSS_SYSROOT="/usr/lib/arm-none-eabi"
+ENV CROSS_TARGET_RUNNER=qemu-arm
 ENV QEMU_CPU=cortex-m4 \
     AR_thumbv7em_none_eabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_thumbv7em_none_eabi="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_thumbv7em_none_eabi="$CROSS_TOOLCHAIN_PREFIX"g++ \
-    CARGO_TARGET_THUMBV7EM_NONE_EABI_RUNNER=qemu-arm
+    CMAKE_TOOLCHAIN_FILE_thumbv7em_none_eabi=/opt/toolchain.cmake \
+    CARGO_TARGET_THUMBV7EM_NONE_EABI_RUNNER="$CROSS_TARGET_RUNNER" \
+    CROSS_CMAKE_SYSTEM_NAME=Generic \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=armv7e-m \
+    CROSS_CMAKE_CRT=newlib \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -mthumb -march=armv7e-m"

--- a/docker/Dockerfile.thumbv7em-none-eabihf
+++ b/docker/Dockerfile.thumbv7em-none-eabihf
@@ -10,15 +10,26 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-COPY qemu.sh /
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
-    libnewlib-arm-none-eabi && \
-    /qemu.sh arm
+    libnewlib-arm-none-eabi \
+    libstdc++-arm-none-eabi-newlib
+
+COPY qemu.sh /
+RUN /qemu.sh arm
+
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-none-eabi-
+ENV CROSS_SYSROOT="/usr/lib/arm-none-eabi"
+ENV CROSS_TARGET_RUNNER=qemu-arm
 ENV QEMU_CPU=cortex-m4 \
     AR_thumbv7em_none_eabihf="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_thumbv7em_none_eabihf="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_thumbv7em_none_eabihf="$CROSS_TOOLCHAIN_PREFIX"g++ \
-    CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER=qemu-arm
+    CMAKE_TOOLCHAIN_FILE_thumbv7em_none_eabihf=/opt/toolchain.cmake \
+    CARGO_TARGET_THUMBV7EM_NONE_EABIHF_RUNNER="$CROSS_TARGET_RUNNER" \
+    CROSS_CMAKE_SYSTEM_NAME=Generic \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=armv7e-m \
+    CROSS_CMAKE_CRT=newlib \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -mthumb -mfloat-abi=hard -march=armv7e-m -mfpu=fpv4-sp-d16"

--- a/docker/Dockerfile.thumbv7m-none-eabi
+++ b/docker/Dockerfile.thumbv7m-none-eabi
@@ -10,15 +10,26 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-COPY qemu.sh /
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
-    libnewlib-arm-none-eabi && \
-    /qemu.sh arm
+    libnewlib-arm-none-eabi \
+    libstdc++-arm-none-eabi-newlib
+
+COPY qemu.sh /
+RUN /qemu.sh arm
+
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-none-eabi-
+ENV CROSS_SYSROOT="/usr/lib/arm-none-eabi"
+ENV CROSS_TARGET_RUNNER=qemu-arm
 ENV QEMU_CPU=cortex-m3 \
     AR_thumbv7m_none_eabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_thumbv7m_none_eabi="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_thumbv7m_none_eabi="$CROSS_TOOLCHAIN_PREFIX"g++ \
-    CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER=qemu-arm
+    CMAKE_TOOLCHAIN_FILE_thumbv7m_none_eabi=/opt/toolchain.cmake \
+    CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER="$CROSS_TARGET_RUNNER" \
+    CROSS_CMAKE_SYSTEM_NAME=Generic \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=armv7-m \
+    CROSS_CMAKE_CRT=newlib \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -mthumb -march=armv7-m"

--- a/docker/Dockerfile.thumbv7neon-linux-androideabi
+++ b/docker/Dockerfile.thumbv7neon-linux-androideabi
@@ -34,18 +34,21 @@ RUN /android-system.sh arm
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-androideabi-
 ENV CROSS_SYSROOT=/android-ndk/sysroot
+ENV CROSS_ANDROID_SDK=$ANDROID_SDK
 COPY android-symlink.sh /
 RUN /android-symlink.sh arm arm-linux-androideabi
 
 COPY android-runner /
+COPY android.cmake /opt/toolchain.cmake
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
 # likewise, the toolchains expect the prefix `thumbv7neon-linux-androideabi`,
 # which we don't have, so just export every possible variable, such as AR.
 # Also export all target binutils just in case required.
+ENV CROSS_TARGET_RUNNER="/android-runner arm"
 ENV CARGO_TARGET_THUMBV7NEON_LINUX_ANDROIDEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_THUMBV7NEON_LINUX_ANDROIDEABI_RUNNER="/android-runner arm" \
+    CARGO_TARGET_THUMBV7NEON_LINUX_ANDROIDEABI_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_thumbv7neon_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     AS_thumbv7neon_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"as \
     CC_thumbv7neon_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"gcc \
@@ -59,6 +62,7 @@ ENV CARGO_TARGET_THUMBV7NEON_LINUX_ANDROIDEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"g
     SIZE_thumbv7neon_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"size \
     STRINGS_thumbv7neon_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"strings \
     STRIP_thumbv7neon_linux_androideabi="$CROSS_TOOLCHAIN_PREFIX"strip \
+    CMAKE_TOOLCHAIN_FILE_thumbv7neon_linux_androideabi=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_thumbv7neon_linux_androideabi="--sysroot=$CROSS_SYSROOT" \
     DEP_Z_INCLUDE="$CROSS_SYSROOT/usr/include/" \
     RUST_TEST_THREADS=1 \
@@ -66,5 +70,8 @@ ENV CARGO_TARGET_THUMBV7NEON_LINUX_ANDROIDEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"g
     TMPDIR=/tmp/ \
     ANDROID_DATA=/ \
     ANDROID_DNS_MODE=local \
-    ANDROID_ROOT=/system
-
+    ANDROID_ROOT=/system \
+    CROSS_CMAKE_SYSTEM_NAME=Android \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=armv7-a \
+    CROSS_CMAKE_CRT=android \
+    CROSS_CMAKE_OBJECT_FLAGS="--target=arm-linux-androideabi -DANDROID -ffunction-sections -fdata-sections -fPIC --target=thumbv7neon-linux-androideabi"

--- a/docker/Dockerfile.thumbv7neon-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.thumbv7neon-unknown-linux-gnueabihf
@@ -24,12 +24,14 @@ COPY linux-image.sh /
 RUN /linux-image.sh armv7
 
 COPY linux-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 # Export all target binutils just in case required.
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabihf-
 ENV CROSS_SYSROOT=/usr/arm-linux-gnueabihf
+ENV CROSS_TARGET_RUNNER="/linux-runner armv7hf"
 ENV CARGO_TARGET_THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF_RUNNER="/linux-runner armv7hf" \
+    CARGO_TARGET_THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_thumbv7neon_unknown_linux_gnueabihf="$CROSS_TOOLCHAIN_PREFIX"ar \
     AS_thumbv7neon_unknown_linux_gnueabihf="$CROSS_TOOLCHAIN_PREFIX"as \
     CC_thumbv7neon_unknown_linux_gnueabihf="$CROSS_TOOLCHAIN_PREFIX"gcc \
@@ -43,7 +45,12 @@ ENV CARGO_TARGET_THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF_LINKER="$CROSS_TOOLCHAIN_PR
     SIZE_thumbv7neon_unknown_linux_gnueabihf="$CROSS_TOOLCHAIN_PREFIX"size \
     STRINGS_thumbv7neon_unknown_linux_gnueabihf="$CROSS_TOOLCHAIN_PREFIX"strings \
     STRIP_thumbv7neon_unknown_linux_gnueabihf="$CROSS_TOOLCHAIN_PREFIX"strip \
+    CMAKE_TOOLCHAIN_FILE_thumbv7neon_unknown_linux_gnueabihf=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_thumbv7neon_unknown_linux_gnueabihf="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabihf/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/arm-linux-gnueabihf/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=arm \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -march=armv7-a -mfpu=vfpv3-d16 -mfpu=neon-vfpv4 -mthumb -mfloat-abi=hard"

--- a/docker/Dockerfile.thumbv8m.base-none-eabi
+++ b/docker/Dockerfile.thumbv8m.base-none-eabi
@@ -10,15 +10,27 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-COPY qemu.sh /
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
-    libnewlib-arm-none-eabi && \
-    /qemu.sh arm
+    libnewlib-arm-none-eabi \
+    libstdc++-arm-none-eabi-newlib
+
+COPY qemu.sh /
+RUN /qemu.sh arm
+
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-none-eabi-
+ENV CROSS_SYSROOT="/usr/lib/arm-none-eabi"
+ENV CROSS_TARGET_RUNNER=qemu-arm
 ENV QEMU_CPU=cortex-m23 \
     AR_thumbv8m.base_none_eabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_thumbv8m.base_none_eabi="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_thumbv8m.base_none_eabi="$CROSS_TOOLCHAIN_PREFIX"g++ \
-    CARGO_TARGET_THUMBV8M.BASE_NONE_EABI_RUNNER=qemu-arm
+    # cmake-rs does not accept CMAKE_TOOLCHAIN_FILE_thumbv8m.base_none_eabi
+    TARGET_CMAKE_TOOLCHAIN_FILE=/opt/toolchain.cmake \
+    CARGO_TARGET_THUMBV8M.BASE_NONE_EABI_RUNNER="$CROSS_TARGET_RUNNER" \
+    CROSS_CMAKE_SYSTEM_NAME=Generic \
+    CROSS_CMAKE_SYSTEM_PROCESSOR="armv8-m.base" \
+    CROSS_CMAKE_CRT=newlib \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -mthumb -march=armv8-m.base"

--- a/docker/Dockerfile.thumbv8m.main-none-eabi
+++ b/docker/Dockerfile.thumbv8m.main-none-eabi
@@ -10,15 +10,27 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-COPY qemu.sh /
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
-    libnewlib-arm-none-eabi && \
-    /qemu.sh arm
+    libnewlib-arm-none-eabi \
+    libstdc++-arm-none-eabi-newlib
+
+COPY qemu.sh /
+RUN /qemu.sh arm
+
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-none-eabi-
+ENV CROSS_SYSROOT="/usr/lib/arm-none-eabi"
+ENV CROSS_TARGET_RUNNER=qemu-arm
 ENV QEMU_CPU=cortex-m33 \
     AR_thumbv8m.main_none_eabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_thumbv8m.main_none_eabi="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_thumbv8m.main_none_eabi="$CROSS_TOOLCHAIN_PREFIX"g++ \
-    CARGO_TARGET_THUMBV8M.MAIN_NONE_EABI_RUNNER=qemu-arm
+    # cmake-rs does not accept CMAKE_TOOLCHAIN_FILE_thumbv8m.main_none_eabi
+    TARGET_CMAKE_TOOLCHAIN_FILE=/opt/toolchain.cmake \
+    CARGO_TARGET_THUMBV8M.BASE_NONE_EABI_RUNNER="$CROSS_TARGET_RUNNER" \
+    CROSS_CMAKE_SYSTEM_NAME=Generic \
+    CROSS_CMAKE_SYSTEM_PROCESSOR="armv8-m.main" \
+    CROSS_CMAKE_CRT=newlib \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -mthumb -march=armv8-m.main"

--- a/docker/Dockerfile.thumbv8m.main-none-eabihf
+++ b/docker/Dockerfile.thumbv8m.main-none-eabihf
@@ -10,15 +10,27 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-COPY qemu.sh /
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     gcc-arm-none-eabi \
-    libnewlib-arm-none-eabi && \
-    /qemu.sh arm
+    libnewlib-arm-none-eabi \
+    libstdc++-arm-none-eabi-newlib
+
+COPY qemu.sh /
+RUN /qemu.sh arm
+
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=arm-none-eabi-
+ENV CROSS_SYSROOT="/usr/lib/arm-none-eabi"
+ENV CROSS_TARGET_RUNNER=qemu-arm
 ENV QEMU_CPU=cortex-m33 \
     AR_thumbv8m.main_none_eabihf="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_thumbv8m.main_none_eabihf="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_thumbv8m.main_none_eabihf="$CROSS_TOOLCHAIN_PREFIX"g++ \
-    CARGO_TARGET_THUMBV8M.MAIN_NONE_EABIHF_RUNNER=qemu-arm
+    # cmake-rs does not accept CMAKE_TOOLCHAIN_FILE_thumbv8m.main_none_eabihf
+    TARGET_CMAKE_TOOLCHAIN_FILE=/opt/toolchain.cmake \
+    CARGO_TARGET_THUMBV8M.BASE_NONE_EABI_RUNNER="$CROSS_TARGET_RUNNER" \
+    CROSS_CMAKE_SYSTEM_NAME=Generic \
+    CROSS_CMAKE_SYSTEM_PROCESSOR="armv8-m.main" \
+    CROSS_CMAKE_CRT=newlib \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -mthumb -mfloat-abi=hard -march=armv8-m.main -mfpu=fpv5-sp-d16"

--- a/docker/Dockerfile.wasm32-unknown-emscripten
+++ b/docker/Dockerfile.wasm32-unknown-emscripten
@@ -17,5 +17,7 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
 
 ENV CROSS_TOOLCHAIN_PREFIX=em
 ENV CROSS_SYSROOT=/emsdk/upstream/emscripten/cache/sysroot
-ENV CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUNNER=node \
-    BINDGEN_EXTRA_CLANG_ARGS_wasm32_unknown_emscripten="--sysroot=$CROSS_SYSROOT"
+ENV CROSS_TARGET_RUNNER="node"
+ENV CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUNNER="$CROSS_TARGET_RUNNER" \
+    BINDGEN_EXTRA_CLANG_ARGS_wasm32_unknown_emscripten="--sysroot=$CROSS_SYSROOT" \
+    CMAKE_TOOLCHAIN_FILE_wasm32_unknown_emscripten=/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake

--- a/docker/Dockerfile.x86_64-linux-android
+++ b/docker/Dockerfile.x86_64-linux-android
@@ -35,15 +35,18 @@ RUN /android-system.sh x86_64
 
 ENV CROSS_TOOLCHAIN_PREFIX=x86_64-linux-android-
 ENV CROSS_SYSROOT=/android-ndk/sysroot
+ENV CROSS_ANDROID_SDK=$ANDROID_SDK
 COPY android-symlink.sh /
 RUN /android-symlink.sh x86_64 x86_64-linux-android
 
 COPY android-runner /
+COPY android.cmake /opt/toolchain.cmake
 
 # Libz is distributed in the android ndk, but for some unknown reason it is not
 # found in the build process of some crates, so we explicit set the DEP_Z_ROOT
+ENV CROSS_TARGET_RUNNER="/android-runner x86_64"
 ENV CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_X86_64_LINUX_ANDROID_RUNNER="/android-runner x86_64" \
+    CARGO_TARGET_X86_64_LINUX_ANDROID_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_x86_64_linux_android="$CROSS_TOOLCHAIN_PREFIX"ar \
     AS_x86_64_linux_android="$CROSS_TOOLCHAIN_PREFIX"as \
     CC_x86_64_linux_android="$CROSS_TOOLCHAIN_PREFIX"gcc \
@@ -57,6 +60,7 @@ ENV CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     SIZE_x86_64_linux_android="$CROSS_TOOLCHAIN_PREFIX"size \
     STRINGS_x86_64_linux_android="$CROSS_TOOLCHAIN_PREFIX"strings \
     STRIP_x86_64_linux_android="$CROSS_TOOLCHAIN_PREFIX"strip \
+    CMAKE_TOOLCHAIN_FILE_x86_64_linux_android=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_x86_64_linux_android="--sysroot=$CROSS_SYSROOT" \
     DEP_Z_INCLUDE="$CROSS_SYSROOT/usr/include/" \
     RUST_TEST_THREADS=1 \
@@ -64,4 +68,8 @@ ENV CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     TMPDIR=/tmp/ \
     ANDROID_DATA=/ \
     ANDROID_DNS_MODE=local \
-    ANDROID_ROOT=/system
+    ANDROID_ROOT=/system \
+    CROSS_CMAKE_SYSTEM_NAME=Android \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=x86_64 \
+    CROSS_CMAKE_CRT=android \
+    CROSS_CMAKE_OBJECT_FLAGS="--target=x86_64-linux-android -DANDROID -ffunction-sections -fdata-sections -fPIC --target=x86_64-linux-android"

--- a/docker/Dockerfile.x86_64-pc-windows-gnu
+++ b/docker/Dockerfile.x86_64-pc-windows-gnu
@@ -32,13 +32,22 @@ RUN mkdir -p /usr/lib/binfmt-support/ && \
 COPY windows-entry.sh /
 ENTRYPOINT ["/windows-entry.sh"]
 
+COPY toolchain.cmake /opt/toolchain.cmake
+
 # for why we always link with pthread support, see:
 # https://github.com/cross-rs/cross/pull/1123#issuecomment-1312287148
 ENV CROSS_TOOLCHAIN_PREFIX=x86_64-w64-mingw32-
+ENV CROSS_TOOLCHAIN_SUFFIX=-posix
 ENV CROSS_SYSROOT=/usr/x86_64-w64-mingw32
-ENV CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc-posix \
-    CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER=wine \
+ENV CROSS_TARGET_RUNNER="wine"
+ENV CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc"$CROSS_TOOLCHAIN_SUFFIX" \
+    CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_x86_64_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
-    CC_x86_64_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc-posix \
-    CXX_x86_64_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"g++-posix \
-    BINDGEN_EXTRA_CLANG_ARGS_x86_64_pc_windows_gnu="--sysroot=$CROSS_SYSROOT"
+    CC_x86_64_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc"$CROSS_TOOLCHAIN_SUFFIX" \
+    CXX_x86_64_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"g++"$CROSS_TOOLCHAIN_SUFFIX" \
+    CMAKE_TOOLCHAIN_FILE_x86_64_pc_windows_gnu=/opt/toolchain.cmake \
+    BINDGEN_EXTRA_CLANG_ARGS_x86_64_pc_windows_gnu="--sysroot=$CROSS_SYSROOT" \
+    CROSS_CMAKE_SYSTEM_NAME=Windows \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=AMD64 \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -m64"

--- a/docker/Dockerfile.x86_64-sun-solaris
+++ b/docker/Dockerfile.x86_64-sun-solaris
@@ -13,10 +13,17 @@ RUN /xargo.sh
 COPY solaris.sh /
 RUN /solaris.sh x86_64
 
+COPY toolchain.cmake /opt/toolchain.cmake
+
 ENV CROSS_TOOLCHAIN_PREFIX=x86_64-sun-solaris2.10-
 ENV CROSS_SYSROOT=/usr/local/x86_64-sun-solaris2.10
 ENV CARGO_TARGET_X86_64_SUN_SOLARIS_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     AR_x86_64_sun_solaris="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_x86_64_sun_solaris="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_x86_64_sun_solaris="$CROSS_TOOLCHAIN_PREFIX"g++ \
-    BINDGEN_EXTRA_CLANG_ARGS_x86_64_sun_solaris="--sysroot=$CROSS_SYSROOT"
+    CMAKE_TOOLCHAIN_FILE_x86_64_sun_solaris=/opt/toolchain.cmake \
+    BINDGEN_EXTRA_CLANG_ARGS_x86_64_sun_solaris="--sysroot=$CROSS_SYSROOT" \
+    CROSS_CMAKE_SYSTEM_NAME=SunOS \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=x86_64 \
+    CROSS_CMAKE_CRT=solaris \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m64"

--- a/docker/Dockerfile.x86_64-unknown-dragonfly
+++ b/docker/Dockerfile.x86_64-unknown-dragonfly
@@ -13,10 +13,17 @@ RUN /xargo.sh
 COPY dragonfly.sh /
 RUN /dragonfly.sh 5
 
+COPY toolchain.cmake /opt/toolchain.cmake
+
 ENV CROSS_TOOLCHAIN_PREFIX=x86_64-unknown-dragonfly-
 ENV CROSS_SYSROOT=/usr/local/x86_64-unknown-dragonfly
 ENV CARGO_TARGET_X86_64_UNKNOWN_DRAGONFLY_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     AR_x86_64_unknown_dragonfly="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_x86_64_unknown_dragonfly="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_x86_64_unknown_dragonfly="$CROSS_TOOLCHAIN_PREFIX"g++ \
-    BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_dragonfly="--sysroot=$CROSS_SYSROOT"
+    CMAKE_TOOLCHAIN_FILE_x86_64_unknown_dragonfly=/opt/toolchain.cmake \
+    BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_dragonfly="--sysroot=$CROSS_SYSROOT" \
+    CROSS_CMAKE_SYSTEM_NAME=DragonFly \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=x86_64 \
+    CROSS_CMAKE_CRT=dragonfly \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m64"

--- a/docker/Dockerfile.x86_64-unknown-freebsd
+++ b/docker/Dockerfile.x86_64-unknown-freebsd
@@ -23,10 +23,16 @@ ENV CROSS_TOOLCHAIN_PREFIX=x86_64-unknown-freebsd12-
 ENV CROSS_SYSROOT=/usr/local/x86_64-unknown-freebsd12
 
 COPY freebsd-gcc.sh /usr/bin/"$CROSS_TOOLCHAIN_PREFIX"gcc.sh
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc.sh \
     AR_x86_64_unknown_freebsd="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_x86_64_unknown_freebsd="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_x86_64_unknown_freebsd="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_x86_64_unknown_freebsd=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_freebsd="--sysroot=$CROSS_SYSROOT" \
-    X86_64_UNKNOWN_FREEBSD_OPENSSL_DIR="$CROSS_SYSROOT"
+    X86_64_UNKNOWN_FREEBSD_OPENSSL_DIR="$CROSS_SYSROOT" \
+    CROSS_CMAKE_SYSTEM_NAME=FreeBSD \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=amd64 \
+    CROSS_CMAKE_CRT=freebsd \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m64"

--- a/docker/Dockerfile.x86_64-unknown-illumos
+++ b/docker/Dockerfile.x86_64-unknown-illumos
@@ -12,6 +12,8 @@ RUN /xargo.sh
 COPY illumos.sh /
 RUN /illumos.sh x86_64
 
+COPY toolchain.cmake /opt/toolchain.cmake
+
 ENV CROSS_TOOLCHAIN_PREFIX=x86_64-unknown-illumos-
 ENV CROSS_SYSROOT=/usr/local/x86_64-unknown-illumos/sysroot
 ENV PATH=$PATH:/usr/local/x86_64-unknown-illumos/bin/ \
@@ -19,4 +21,9 @@ ENV PATH=$PATH:/usr/local/x86_64-unknown-illumos/bin/ \
     AR_x86_64_unknown_illumos="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_x86_64_unknown_illumos="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_x86_64_unknown_illumos="$CROSS_TOOLCHAIN_PREFIX"g++ \
-    BINDGEN_EXTRA_CLANG_ARGS_sparcv9_sun_solaris="--sysroot=$CROSS_SYSROOT"
+    CMAKE_TOOLCHAIN_FILE_x86_64_unknown_illumos=/opt/toolchain.cmake \
+    BINDGEN_EXTRA_CLANG_ARGS_sparcv9_sun_solaris="--sysroot=$CROSS_SYSROOT" \
+    CROSS_CMAKE_SYSTEM_NAME=illumos \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=x86_64 \
+    CROSS_CMAKE_CRT=solaris \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m64"

--- a/docker/Dockerfile.x86_64-unknown-linux-gnu
+++ b/docker/Dockerfile.x86_64-unknown-linux-gnu
@@ -29,15 +29,22 @@ COPY linux-image.sh /
 RUN /linux-image.sh x86_64
 
 COPY linux-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=x86_64-linux-gnu-
 ENV CROSS_SYSROOT=/usr/x86_64-linux-gnu
+ENV CROSS_TARGET_RUNNER="/linux-runner x86_64"
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="/linux-runner x86_64" \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_x86_64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_x86_64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_x86_64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_x86_64_unknown_linux_gnu=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT" \
     QEMU_LD_PREFIX="$CROSS_SYSROOT" \
     RUST_TEST_THREADS=1 \
-    PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
+    PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=x86_64 \
+    CROSS_CMAKE_CRT=gnu \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m64"

--- a/docker/Dockerfile.x86_64-unknown-linux-musl
+++ b/docker/Dockerfile.x86_64-unknown-linux-musl
@@ -22,11 +22,18 @@ COPY musl-symlink.sh /
 RUN /musl-symlink.sh $CROSS_SYSROOT x86_64
 
 COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
 
+ENV CROSS_TARGET_RUNNER="/qemu-runner x86_64"
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
-    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUNNER="/qemu-runner x86_64" \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_x86_64_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_x86_64_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_x86_64_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_x86_64_unknown_linux_musl=/opt/toolchain.cmake \
     BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_musl="--sysroot=$CROSS_SYSROOT" \
-    QEMU_LD_PREFIX="$CROSS_SYSROOT"
+    QEMU_LD_PREFIX="$CROSS_SYSROOT" \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=x86_64 \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m64"

--- a/docker/Dockerfile.x86_64-unknown-netbsd
+++ b/docker/Dockerfile.x86_64-unknown-netbsd
@@ -13,10 +13,17 @@ RUN /xargo.sh
 COPY netbsd.sh /
 RUN /netbsd.sh
 
+COPY toolchain.cmake /opt/toolchain.cmake
+
 ENV CROSS_TOOLCHAIN_PREFIX=x86_64-unknown-netbsd-
 ENV CROSS_SYSROOT=/usr/local/x86_64-unknown-netbsd
 ENV CARGO_TARGET_X86_64_UNKNOWN_NETBSD_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     AR_x86_64_unknown_netbsd="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_x86_64_unknown_netbsd="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_x86_64_unknown_netbsd="$CROSS_TOOLCHAIN_PREFIX"g++ \
-    BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_netbsd="--sysroot=$CROSS_SYSROOT"
+    CMAKE_TOOLCHAIN_FILE_x86_64_unknown_netbsd=/opt/toolchain.cmake \
+    BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_netbsd="--sysroot=$CROSS_SYSROOT" \
+    CROSS_CMAKE_SYSTEM_NAME=NetBSD \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=x86_64 \
+    CROSS_CMAKE_CRT=netbsd \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m64"

--- a/docker/android.cmake
+++ b/docker/android.cmake
@@ -1,0 +1,25 @@
+# toolchain file for android targets, see #1110
+
+set(CMAKE_SYSTEM_NAME "$ENV{CROSS_CMAKE_SYSTEM_NAME}")
+set(CMAKE_SYSTEM_PROCESSOR "$ENV{CROSS_CMAKE_SYSTEM_PROCESSOR}")
+set(CMAKE_ANDROID_STANDALONE_TOOLCHAIN /android-ndk)
+set(CMAKE_ANDROID_API "$ENV{CROSS_ANDROID_SDK}")
+if(DEFINED ENV{CROSS_TARGET_RUNNER})
+    set(runner "$ENV{CROSS_TARGET_RUNNER}")
+    separate_arguments(runner)
+    set(CMAKE_CROSSCOMPILING_EMULATOR ${runner})
+endif()
+
+# these are cached so any build system that compiled outside of the rust
+# build system, such as a third-party cmake build and install of a shared
+# library, will still work. however, cmake-rs can override these values
+if(DEFINED ENV{CROSS_CMAKE_OBJECT_FLAGS})
+    set(CMAKE_C_FLAGS "$ENV{CROSS_CMAKE_OBJECT_FLAGS}" CACHE STRING "C Compiler options")
+    set(CMAKE_CXX_FLAGS "$ENV{CROSS_CMAKE_OBJECT_FLAGS}" CACHE STRING "C++ Compiler options")
+    set(CMAKE_ASM_FLAGS "$ENV{CROSS_CMAKE_OBJECT_FLAGS}" CACHE STRING "ASM Compiler options")
+endif()
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)

--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -186,6 +186,8 @@ main() {
     cp -r "${td}/freebsd/lib/"* "${destdir}/lib"
     cp "${td}/freebsd/usr/lib/libc++.so.1" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib/libc++.a" "${destdir}/lib"
+    cp "${td}/freebsd/usr/lib/libcxxrt.a" "${destdir}/lib"
+    cp "${td}/freebsd/usr/lib/libcompiler_rt.a" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/lib{c,util,m,ssp_nonshared,memstat}.a "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/lib{rt,execinfo,procstat}.so.1 "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/libmemstat.so.3 "${destdir}/lib"

--- a/docker/toolchain.cmake
+++ b/docker/toolchain.cmake
@@ -1,0 +1,57 @@
+# default toolchain file for targets, see #1110
+# required so CMAKE_CROSSCOMPILING_EMULATOR is set,
+# as well for embedded systems and other targets.
+#
+# all embedded systems without an OS should set the system name to generic
+# https://cmake.org/cmake/help/book/mastering-cmake/chapter/Cross%20Compiling%20With%20CMake.html
+
+set(CMAKE_SYSTEM_NAME "$ENV{CROSS_CMAKE_SYSTEM_NAME}")
+set(CMAKE_SYSTEM_PROCESSOR "$ENV{CROSS_CMAKE_SYSTEM_PROCESSOR}")
+if(DEFINED ENV{CROSS_TARGET_RUNNER})
+    set(runner "$ENV{CROSS_TARGET_RUNNER}")
+    separate_arguments(runner)
+    set(CMAKE_CROSSCOMPILING_EMULATOR ${runner})
+endif()
+
+# not all of these are standard, however, they're common enough
+# that it's good practice to define them.
+set(prefix "$ENV{CROSS_TOOLCHAIN_PREFIX}")
+set(suffix "$ENV{CROSS_TOOLCHAIN_SUFFIX}")
+set(CMAKE_C_COMPILER "${prefix}gcc${suffix}")
+set(CMAKE_ASM_COMPILER "${prefix}gcc${suffix}")
+set(CMAKE_CXX_COMPILER "${prefix}g++${suffix}")
+set(CMAKE_AR "${prefix}ar")
+set(CMAKE_LINKER "${prefix}ld")
+set(CMAKE_NM "${prefix}nm")
+set(CMAKE_OBJCOPY "${prefix}objcopy")
+set(CMAKE_OBJDUMP "${prefix}objdump")
+set(CMAKE_RANLIB "${prefix}ranlib")
+set(CMAKE_STRIP "${prefix}strip")
+
+# these are cached so any build system that compiled outside of the rust
+# build system, such as a third-party cmake build and install of a shared
+# library, will still work. however, cmake-rs can override these values
+if(DEFINED ENV{CROSS_CMAKE_OBJECT_FLAGS})
+    set(CMAKE_C_FLAGS "$ENV{CROSS_CMAKE_OBJECT_FLAGS}" CACHE STRING "C Compiler options")
+    set(CMAKE_CXX_FLAGS "$ENV{CROSS_CMAKE_OBJECT_FLAGS}" CACHE STRING "C++ Compiler options")
+    set(CMAKE_ASM_FLAGS "$ENV{CROSS_CMAKE_OBJECT_FLAGS}" CACHE STRING "ASM Compiler options")
+endif()
+
+# if cross-compiling, we need to disable where the root path
+# is found and also provide our own sysroot
+if(DEFINED ENV{CROSS_SYSROOT})
+    set(CMAKE_FIND_ROOT_PATH "$ENV{CROSS_SYSROOT}" "${CMAKE_PREFIX_PATH}")
+    set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+    set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+endif()
+
+set(crt "$ENV{CROSS_CMAKE_CRT}")
+if(crt STREQUAL "newlib")
+    # cmake normally tries to test the C and C++ compilers by building and
+    # running a binary, but this fails for bare-metal targets, since
+    # they are missing start files and potentially other symbols.
+    # choosing to make a static library causes cmake to skip the check.
+    set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+endif()

--- a/targets.toml
+++ b/targets.toml
@@ -440,34 +440,44 @@ std = true
 [[target]]
 target = "thumbv6m-none-eabi"
 os = "ubuntu-latest"
-std = true
+cpp = true
+std = false
 
 [[target]]
 target = "thumbv7em-none-eabi"
 os = "ubuntu-latest"
-std = true
+cpp = true
+std = false
 
 [[target]]
 target = "thumbv7em-none-eabihf"
 os = "ubuntu-latest"
-std = true
+cpp = true
+std = false
 
 [[target]]
 target = "thumbv7m-none-eabi"
 os = "ubuntu-latest"
-std = true
+cpp = true
+std = false
 
 [[target]]
 target = "thumbv8m.base-none-eabi"
 os = "ubuntu-latest"
+cpp = true
+std = false
 
 [[target]]
 target = "thumbv8m.main-none-eabi"
 os = "ubuntu-latest"
+cpp = true
+std = false
 
 [[target]]
 target = "thumbv8m.main-none-eabihf"
 os = "ubuntu-latest"
+cpp = true
+std = false
 
 [[target]]
 target = "cross"


### PR DESCRIPTION
Fix CMake Support and Enhance Newlib Targets

Fix CMake support for Android targets by providing a toolchain file that specifies the API level and the standalone toolchain path, and ensuring that compiler detection is forcibly disabled. Fix CMake support for newlib targets by providing a toolchain file that signals to CMake it is compiling for an embedded target, providing correct C, C++, and ASM flags even when invoked externally, and ensuring CMake skips testing if the C and C++ compilers work by running a binary file. Also add C++ support to bare-metal newlib targets, by also installing `libstdc++-arm-none-eabi-newlib`. Finally, `targets.toml` was updated to ensure newlib targets do not have `std` support.

Other minor changes including using the Cortex-M1 CPU for `thumbv6m-none-eabi` rather than the Cortex-M3 (an ARMv7-M CPU) for the Qemu runner.

To ensure these work, test suites for CMake using C+11 features, CMake's `try_run` feature (checking [CMAKE_CROSSCOMPILING_EMULATOR](https://cmake.org/cmake/help/latest/variable/CMAKE_CROSSCOMPILING_EMULATOR.html) is set), and a `no_std` package with a C++ dependency have been added.

Closes #1110.
Closes #1113.