### PR TITLE
Use MinGW GCC with POSIX thread support when linking.

### DIFF
--- a/.changes/1123.json
+++ b/.changes/1123.json
@@ -1,0 +1,6 @@
+{
+    "description": "support external C/C++ dependencies using C11/C++11 threads for MinGW targets by switching linkers from `*-gcc` to `*gcc-posix`.",
+    "type": "added",
+    "issues": [1122],
+    "breaking": true
+}

--- a/.changes/591-1095.json
+++ b/.changes/591-1095.json
@@ -17,7 +17,7 @@
     },
     {
         "type": "changed",
-        "description": "updated powerpc64, riscv64, and sparc64 *-linux-gnu images to use a 6.x kernel instead of a 4.x kernel.",
+        "description": "updated powerpc64, riscv64, and sparc64 `*-linux-gnu` images to use a 6.x kernel instead of a 4.x kernel.",
         "breaking": true,
         "issues": [1094]
     }

--- a/docker/Dockerfile.i686-pc-windows-gnu
+++ b/docker/Dockerfile.i686-pc-windows-gnu
@@ -34,9 +34,11 @@ RUN mkdir -p /usr/lib/binfmt-support/ && \
 COPY windows-entry.sh /
 ENTRYPOINT ["/windows-entry.sh"]
 
+# for why we always link with pthread support, see:
+# https://github.com/cross-rs/cross/pull/1123#issuecomment-1312287148
 ENV CROSS_TOOLCHAIN_PREFIX=i686-w64-mingw32-
 ENV CROSS_SYSROOT=/usr/i686-w64-mingw32
-ENV CARGO_TARGET_I686_PC_WINDOWS_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
+ENV CARGO_TARGET_I686_PC_WINDOWS_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc-posix \
     CARGO_TARGET_I686_PC_WINDOWS_GNU_RUNNER=wine \
     CC_i686_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc-posix \
     CXX_i686_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"g++-posix \

--- a/docker/Dockerfile.x86_64-pc-windows-gnu
+++ b/docker/Dockerfile.x86_64-pc-windows-gnu
@@ -32,9 +32,11 @@ RUN mkdir -p /usr/lib/binfmt-support/ && \
 COPY windows-entry.sh /
 ENTRYPOINT ["/windows-entry.sh"]
 
+# for why we always link with pthread support, see:
+# https://github.com/cross-rs/cross/pull/1123#issuecomment-1312287148
 ENV CROSS_TOOLCHAIN_PREFIX=x86_64-w64-mingw32-
 ENV CROSS_SYSROOT=/usr/x86_64-w64-mingw32
-ENV CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
+ENV CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc-posix \
     CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER=wine \
     CC_x86_64_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc-posix \
     CXX_x86_64_pc_windows_gnu="$CROSS_TOOLCHAIN_PREFIX"g++-posix \

--- a/docker/wine.sh
+++ b/docker/wine.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 . lib.sh
 
 main() {
+    local version="7.0.1~focal-1"
     install_packages wget
 
     dpkg --add-architecture i386
@@ -26,9 +27,14 @@ main() {
     mv winehq-focal.sources /etc/apt/sources.list.d/
     sed -i s@/usr/share/keyrings/@/etc/apt/keyrings/@ /etc/apt/sources.list.d/winehq-focal.sources || true
 
+    # winehq requires all the dependencies to be manually specified
+    # if we're not using the latest version of a given major version.
     apt-get update
     apt install --no-install-recommends --assume-yes \
-        "winehq-stable=7.0.0.0~focal-1"
+        "wine-stable=${version}" \
+        "wine-stable-amd64=${version}" \
+        "wine-stable-i386=${version}" \
+        "winehq-stable=${version}"
 
     purge_packages
 }


### PR DESCRIPTION
This changes from using WIN32 threads to POSIX threads when linking. MinGW (when using `libstdc++`) doesn't support C11 and C++11 threading support with WIN32 threads. This PR also makes WINE builds more resilient. Note that this will not affect any multi-threaded Rust code, which uses the Win32 API, calling `CreateThread` and `WaitForSingleObject` directly.

Closes #1122.