### PR TITLE
CI: Fix most deprecation warnings from GitHub Actions

### DIFF
--- a/.github/actions/cargo-install-upload-artifacts/action.yml
+++ b/.github/actions/cargo-install-upload-artifacts/action.yml
@@ -14,7 +14,7 @@ runs:
         metadata="$(cargo metadata --format-version 1 --no-deps)"
 
         package_name="cross"
-        echo "::set-output name=package-name::${package_name}"
+        echo "package-name=${package_name}" >> $GITHUB_OUTPUT
 
         out_dir="$(mktemp -d)"
         artifacts_dir="$(mktemp -d)"
@@ -24,8 +24,8 @@ runs:
           artifacts_dir="$(cygpath -w "${artifacts_dir}")"
         fi
 
-        echo "::set-output name=out-dir::${out_dir}"
-        echo "::set-output name=artifacts-dir::${artifacts_dir}"
+        echo "out-dir=${out_dir}" >> $GITHUB_OUTPUT
+        echo "artifacts-dir=${artifacts_dir}" >> $GITHUB_OUTPUT
       shell: bash
     - run: rm -rf .git
       shell: bash
@@ -66,8 +66,8 @@ runs:
           artifact_path="$(cygpath -w "${artifact_path}")"
         fi
 
-        echo "::set-output name=name::${artifact_name}"
-        echo "::set-output name=path::${artifact_path}"
+        echo "name=${artifact_name}" >> $GITHUB_OUTPUT
+        echo "path=${artifact_path}" >> $GITHUB_OUTPUT
       env:
         package_name: ${{ steps.metadata.outputs.package-name }}
         out_dir: ${{ steps.metadata.outputs.out-dir }}

--- a/.github/actions/cargo-llvm-cov/action.yml
+++ b/.github/actions/cargo-llvm-cov/action.yml
@@ -31,7 +31,7 @@ runs:
           echo LLVM_PROFILE_FILE="${pwd}/target/cross-%m.profraw" >> $GITHUB_ENV
           echo CARGO_INCREMENTAL="0" >> $GITHUB_ENV
           echo RUST_TEST_THREADS="1" >> $GITHUB_ENV
-          echo "::set-output name=artifact-name::_coverage-${name}"
+          echo "artifact-name=_coverage-${name}" >> $GITHUB_OUTPUT
         post: |
           # XXX(emilgardis): Upload early?
           pwd=$(pwd)

--- a/.github/actions/cargo-publish/action.yml
+++ b/.github/actions/cargo-publish/action.yml
@@ -13,7 +13,7 @@ runs:
   steps:
     - name: Read changelog
       id: changelog-reader
-      uses: mindsers/changelog-reader-action@v2.0.0
+      uses: mindsers/changelog-reader-action@v2
       with:
         # validation_depth: 10
         version: ${{ (github.ref_type == 'tag' && !contains(github.ref_name, '-') && github.ref_name) || 'Unreleased' }}

--- a/.github/actions/post/main.js
+++ b/.github/actions/post/main.js
@@ -21,6 +21,6 @@ if (process.env[`STATE_POST`] != undefined) {
   run(process.env.INPUT_POST);
 } else {
   // Otherwise, this is the main step
-  console.log(`::save-state name=POST::true`);
+  console.log(`POST=true >> $GITHUB_STATE`);
   run(process.env.INPUT_MAIN);
 }

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -26,4 +26,4 @@ runs:
       run: echo "::add-matcher::.github/actions/setup-rust/rust.json"
       shell: bash
 
-    - uses: Swatinem/rust-cache@v2.1.0
+    - uses: Swatinem/rust-cache@v2.2.0

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ inputs.toolchain }}
         target: ${{ inputs.target }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,19 +14,19 @@ jobs:
 
       - name: Get Changed Files
         id: files
-        uses: Ana06/get-changed-files@v2.1.0
+        uses: tj-actions/changed-files@v34
         with:
-          # use JSON so we don't have to worry about filenames with spaces
-          format: 'json'
-          filter: '.changes/*.json'
+          separator: ';'
+          files: |
+            .changes/*.json
 
       - name: Validate Changelog Files
         id: changelog
         run: |
           set -x
           set -e
-          readarray -t added_modified < <(jq -r '.[]' <<<'${{ steps.files.outputs.added_modified }}')
-          readarray -t removed < <(jq -r '.[]' <<<'${{ steps.files.outputs.removed }}')
+          readarray -d ';' -t added_modified <<< '${{ steps.files.outputs.all_changed_files }}'
+          readarray -d ';' -t removed <<< '${{ steps.files.outputs.deleted_files }}'
           added_count=${#added_modified[@]}
           removed_count=${#removed[@]}
           if ${{ !contains(github.event.pull_request.labels.*.name, 'no changelog' ) }}; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run ShellCheck
-        uses: azohra/shell-linter@v0.3.0
+        uses: azohra/shell-linter@v0.6.0
 
   cargo-deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: steps.prepare-meta.outputs.has-image
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: runner.os == 'Linux'
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build xtask
         run: cargo build -p xtask

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,7 @@ jobs:
         with:
           path: ${{ runner.temp }}/artifacts
       - name: Grab PR number
-        run: echo "::set-output name=pr::"$(echo $commit_message | sed -ne  's/.*\#\(.*\):/\1/p')
+        run: echo "pr=$(echo ${commit_message} | sed -ne 's/.*#\(.*\):/\1/p')" >> $GITHUB_OUTPUT
         id: pr-number
         if: ${{ !github.event.pull_request.number }}
         env:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-rust
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Build xtask
         run: cargo build -p xtask
       - name: Build Docker image

--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -324,8 +324,8 @@ pub fn build_docker_image(
             }
         }
         if gha {
-            gha_output("image", &tags[0]);
-            gha_output("images", &format!("'{}'", serde_json::to_string(&tags)?));
+            gha_output("image", &tags[0])?;
+            gha_output("images", &format!("'{}'", serde_json::to_string(&tags)?))?;
             if targets.len() > 1 {
                 gha_print("::endgroup::");
             }

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -63,7 +63,7 @@ pub fn ci(args: CiJob, metadata: CargoMetadata) -> cross::Result<()> {
                 chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
             ));
 
-            gha_output("labels", &serde_json::to_string(&labels.join("\n"))?);
+            gha_output("labels", &serde_json::to_string(&labels.join("\n"))?)?;
 
             let version = cross_meta.version.clone();
 
@@ -78,15 +78,15 @@ pub fn ci(args: CiJob, metadata: CargoMetadata) -> cross::Result<()> {
                     false,
                     &version,
                 )?[0],
-            );
+            )?;
 
             if target.has_ci_image() {
-                gha_output("has-image", "true")
+                gha_output("has-image", "true")?
             }
             if target.is_standard_target_image() {
-                gha_output("test-variant", "default")
+                gha_output("test-variant", "default")?
             } else {
-                gha_output("test-variant", &target.name)
+                gha_output("test-variant", &target.name)?
             }
         }
         CiJob::Check { ref_type, ref_name } => {
@@ -110,7 +110,7 @@ pub fn ci(args: CiJob, metadata: CargoMetadata) -> cross::Result<()> {
                         .ok_or_else(|| eyre::eyre!("cargo search returned unexpected data"))?,
                 )?;
                 if version >= latest_version && version.pre.is_empty() {
-                    gha_output("is-latest", "true")
+                    gha_output("is-latest", "true")?
                 }
             }
         }

--- a/xtask/src/ci/target_matrix.rs
+++ b/xtask/src/ci/target_matrix.rs
@@ -45,7 +45,7 @@ pub(crate) fn run(message: String, author: String) -> Result<(), color_eyre::Rep
 
     let json = serde_json::to_string(&matrix)?;
     gha_print(&json);
-    gha_output("matrix", &json);
+    gha_output("matrix", &json)?;
     Ok(())
 }
 


### PR DESCRIPTION
This fixes most deprecation warnings from GitHub Actions.

Changes:

- CI: Replace deprecated `::set-output` command
- CI: Replace deprecated `::save-state` command
- CI: Bump [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) from `v1` to `master`
- CI: Replace [`Ana06/get-changed-files`](https://github.com/Ana06/get-changed-files) by [`tj-actions/changed-files`](https://github.com/tj-actions/changed-files)

Fixes #1074