### PR TITLE
CI: Fix changelog check

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,8 +25,8 @@ jobs:
         run: |
           set -x
           set -e
-          readarray -d ';' -t added_modified <<< '${{ steps.files.outputs.all_changed_files }}'
-          readarray -d ';' -t removed <<< '${{ steps.files.outputs.deleted_files }}'
+          IFS=';' read -a added_modified <<< '${{ steps.files.outputs.all_changed_files }}'
+          IFS=';' read -a removed <<< '${{ steps.files.outputs.deleted_files }}'
           added_count=${#added_modified[@]}
           removed_count=${#removed[@]}
           if ${{ !contains(github.event.pull_request.labels.*.name, 'no changelog' ) }}; then


### PR DESCRIPTION
`readarray` is supposed to be used with actual files, so replace it with `read` and also configure bash's internal field separator (IFS) to use the `;` character as the delimiter.

This allows for the list of files to be properly split.