### PR TITLE
Fix mount paths on Windows.

### DIFF
--- a/.changes/1057.json
+++ b/.changes/1057.json
@@ -1,0 +1,5 @@
+{
+    "description": "fix mount paths outside of the workspace mount directory on Windows and those provided as a WSL path.",
+    "type": "fixed",
+    "issues": [1145, 1156]
+}

--- a/ci/shared.sh
+++ b/ci/shared.sh
@@ -48,3 +48,20 @@ function mkcargotemp {
     ' > "$CARGO_TMP_DIR"/Cargo.toml
     echo "$td"
 }
+
+function binary_path() {
+    local binary="${1}"
+    local home="${2}"
+    local build_mode="${3}"
+    local cross="${home}/target/${build_mode}/${binary}"
+
+    case "$OSTYPE" in
+        msys*|cygwin*)
+            cross="${cross}.exe"
+            ;;
+        *)
+            ;;
+    esac
+
+    echo "${cross}"
+}

--- a/ci/test-bisect.sh
+++ b/ci/test-bisect.sh
@@ -22,7 +22,8 @@ main() {
     retry cargo fetch
     cargo build
     cargo install cargo-bisect-rustc --debug
-    export CROSS="${PROJECT_HOME}/target/debug/cross"
+    CROSS=$(binary_path cross "${PROJECT_HOME}" debug)
+    export CROSS
 
     td="$(mktemp -d)"
     git clone --depth 1 https://github.com/cross-rs/rust-cpp-hello-word "${td}"

--- a/ci/test-foreign-toolchain.sh
+++ b/ci/test-foreign-toolchain.sh
@@ -15,7 +15,8 @@ main() {
 
     retry cargo fetch
     cargo build
-    export CROSS="${PROJECT_HOME}/target/debug/cross"
+    CROSS=$(binary_path cross "${PROJECT_HOME}" debug)
+    export CROSS
 
     td="$(mkcargotemp -d)"
 
@@ -31,7 +32,7 @@ image.name = "alpine:edge"
 image.toolchain = ["x86_64-unknown-linux-musl"]
 pre-build = ["apk add --no-cache gcc musl-dev"]' >"${CARGO_TMP_DIR}"/Cross.toml
 
-    "$CROSS" run -v
+    "${CROSS}" run -v
 
     local tmp_basename
     tmp_basename=$(basename "${CARGO_TMP_DIR}")
@@ -59,7 +60,7 @@ name = "ubuntu:20.04"
 toolchain = ["aarch64-unknown-linux-gnu"]
     ' >"${CARGO_TMP_DIR}"/Cross.toml
 
-    "$CROSS" build -v
+    "${CROSS}" build -v
 
     "${CROSS_ENGINE}" images --format '{{.Repository}}:{{.Tag}}' --filter 'label=org.cross-rs.for-cross-target' | grep "cross-custom-${tmp_basename}" | xargs "${CROSS_ENGINE}" rmi
 

--- a/ci/test-podman.sh
+++ b/ci/test-podman.sh
@@ -22,7 +22,8 @@ main() {
 
     retry cargo fetch
     cargo build
-    export CROSS="${PROJECT_HOME}/target/debug/cross"
+    CROSS=$(binary_path cross "${PROJECT_HOME}" debug)
+    export CROSS
 
     td="$(mkcargotemp -d)"
     parent=$(dirname "${td}")

--- a/ci/test-remote.sh
+++ b/ci/test-remote.sh
@@ -20,8 +20,10 @@ main() {
 
     retry cargo fetch
     cargo build
-    export CROSS="${PROJECT_HOME}/target/debug/cross"
-    export CROSS_UTIL="${PROJECT_HOME}/target/debug/cross-util"
+    CROSS=$(binary_path cross "${PROJECT_HOME}" debug)
+    export CROSS
+    CROSS_UTIL=$(binary_path cross-util "${PROJECT_HOME}" debug)
+    export CROSS_UTIL
 
     # if the create volume fails, ensure it exists.
     if ! err=$("${CROSS_UTIL}" volumes create 2>&1 >/dev/null); then

--- a/ci/test-zig-image.sh
+++ b/ci/test-zig-image.sh
@@ -34,7 +34,8 @@ main() {
 
     retry cargo fetch
     cargo build
-    export CROSS="${PROJECT_HOME}/target/debug/cross"
+    CROSS=$(binary_path cross "${PROJECT_HOME}" debug)
+    export CROSS
 
     td="$(mktemp -d)"
     git clone --depth 1 https://github.com/cross-rs/rust-cpp-hello-word "${td}"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -31,7 +31,8 @@ main() {
     export QEMU_STRACE=1
 
     # ensure we have the proper toolchain and optional rust flags
-    export CROSS=("${PROJECT_HOME}/target/debug/cross")
+    CROSS=$(binary_path cross "${PROJECT_HOME}" debug)
+    export CROSS=("${CROSS}")
     export CROSS_FLAGS="-v"
     if (( ${BUILD_STD:-0} )); then
         # use build-std instead of xargo, due to xargo being

--- a/src/docker/local.rs
+++ b/src/docker/local.rs
@@ -78,6 +78,7 @@ pub(crate) fn run(
         ])
         // Prevent `bin` from being mounted inside the Docker container.
         .args(["-v", &format!("{}/bin", toolchain_dirs.cargo_mount_path())]);
+
     docker.args([
         "-v",
         &format!(


### PR DESCRIPTION
Fixes mount paths outside of the workspace mount directory on Windows and those provided as a WSL path. This also adds unittests for Windows outside of WSL2.

Closes #1145.
Closes #1156.