### PR TITLE
freebsd: include memstat in build image

### DIFF
--- a/.changes/1166.json
+++ b/.changes/1166.json
@@ -1,0 +1,4 @@
+{
+    "description": "freebsd: include memstat in build image to fix build with libc 0.2.138 and up.",
+    "type": "fixed"
+}

--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -186,8 +186,9 @@ main() {
     cp -r "${td}/freebsd/lib/"* "${destdir}/lib"
     cp "${td}/freebsd/usr/lib/libc++.so.1" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib/libc++.a" "${destdir}/lib"
-    cp "${td}/freebsd/usr/lib"/lib{c,util,m,ssp_nonshared}.a "${destdir}/lib"
+    cp "${td}/freebsd/usr/lib"/lib{c,util,m,ssp_nonshared,memstat}.a "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/lib{rt,execinfo,procstat}.so.1 "${destdir}/lib"
+    cp "${td}/freebsd/usr/lib"/libmemstat.so.3 "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/{crt1,Scrt1,crti,crtn}.o "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/libkvm.a "${destdir}/lib"
 


### PR DESCRIPTION
libc 0.2.138 added memstat_* functions, but the build with cross fails because the build image does not contain the corresponding library. See https://github.com/rust-lang/libc/issues/3025 for more context. See also https://github.com/rust-lang/rust/pull/105222 which is the same fix to rust-lang/rust's build image.
