### PR TITLE
Bugfix: custom image tag can't end with neither a `-` nor `.`

### DIFF
--- a/src/docker/custom.rs
+++ b/src/docker/custom.rs
@@ -247,11 +247,12 @@ fn docker_tag_name(file_name: &str) -> String {
         }
     }
 
+    // in case our result ends in an invalid last char `-` or `.`
+    // we remove
+    result = result.trim_end_matches(&['.', '-']).to_owned();
+
     // in case all characters were invalid or we had all non-ASCII
-    // characters followed by a `-`, we use a non-empty filename
-    if result.ends_with('-') {
-        result.pop();
-    }
+    // characters followed by a `-` or `.`, we use a non-empty filename
     if result.is_empty() {
         result = "empty".to_owned();
     }


### PR DESCRIPTION
The original bug fix solved the problem of a image name ending in a single `-` character (which docker doesn't permit). However, docker also doesn't permit names ending in a `.`, so we need to handle that case too.

Also, removing just the last char is insufficient, as names may end up ending with multiple consecutive `-` or `.` characters, so we need to loop until they're all gone.