### PR TITLE
Remove duplicated entry from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,6 @@ terminate.
 | `i686-linux-android` [1]             | 9.0.8  | 9.0.8   | ✓   | 6.1.0 |   ✓    |
 | `i686-pc-windows-gnu`                | N/A    | 9.4     | ✓   | N/A   |   ✓    |
 | `i686-unknown-linux-gnu`             | 2.31   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
-| `mips-unknown-linux-musl`            | 1.1.24 | 9.2.0   | ✓   | 6.1.0 |   ✓    |
 | `mips-unknown-linux-gnu`             | 2.30   | 9.4.0   | ✓   | 6.1.0 |   ✓    |
 | `mips-unknown-linux-musl`            | 1.1.24  | 9.2.0   | ✓   | 6.1.0 |   ✓    |
 | `mips64-unknown-linux-gnuabi64`      | 2.30   | 9.4.0   | ✓   | 6.1.0 |   ✓    |


### PR DESCRIPTION
Remove the duplicated entry `mips-unknown-linux-musl` in the README.