### PR TITLE
Fix error when using certain config values in Cargo.toml

### DIFF
--- a/.changes/1183.json
+++ b/.changes/1183.json
@@ -1,0 +1,5 @@
+{
+    "description": "resolve issue when using `pre-build` and `image.toolchain` in `Cargo.toml`",
+    "type": "fixed",
+    "issues": [1182]
+}

--- a/src/cross_toml.rs
+++ b/src/cross_toml.rs
@@ -856,6 +856,29 @@ mod tests {
     }
 
     #[test]
+    pub fn fully_populated_roundtrip() -> Result<()> {
+        let cfg = r#"
+            [target.a]
+            xargo = false
+            build-std = true
+            image.name = "local"
+            image.toolchain = ["x86_64-unknown-linux-gnu"]
+            dockerfile.file = "Dockerfile"
+            dockerfile.context = ".."
+            pre-build = ["sh"]
+            zig = true
+
+            [target.b]
+            pre-build = "sh"
+            zig = "2.17"
+        "#;
+
+        let (cfg, _) = CrossToml::parse_from_cross(cfg, &mut m!())?;
+        serde_json::from_value::<CrossToml>(serde_json::to_value(cfg)?)?;
+        Ok(())
+    }
+
+    #[test]
     pub fn merge() -> Result<()> {
         let cfg1_str = r#"
             [target.aarch64-unknown-linux-gnu]

--- a/src/docker/image.rs
+++ b/src/docker/image.rs
@@ -104,8 +104,8 @@ impl std::fmt::Display for PossibleImage {
 /// The architecture/platform to use in the image
 ///
 /// https://github.com/containerd/containerd/blob/release/1.6/platforms/platforms.go#L63
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(try_from = "&str")]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[serde(try_from = "String")]
 pub struct ImagePlatform {
     /// CPU architecture, x86_64, aarch64 etc
     pub architecture: Architecture,
@@ -141,11 +141,17 @@ impl Default for ImagePlatform {
     }
 }
 
-impl TryFrom<&str> for ImagePlatform {
+impl TryFrom<String> for ImagePlatform {
     type Error = <Self as std::str::FromStr>::Err;
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    fn try_from(value: String) -> Result<Self, Self::Error> {
         value.parse()
+    }
+}
+
+impl Serialize for ImagePlatform {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&format!("{}={}", self.docker_platform(), self.target))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,8 @@ pub use self::rustc::{TargetList, VersionMetaExt};
 pub const CROSS_LABEL_DOMAIN: &str = "org.cross-rs";
 
 #[allow(non_camel_case_types)]
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Hash, Serialize)]
-#[serde(from = "&str")]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Hash)]
+#[serde(from = "&str", into = "String")]
 #[serde(rename_all = "snake_case")]
 pub enum TargetTriple {
     Other(String),
@@ -258,6 +258,12 @@ impl std::fmt::Display for TargetTriple {
 impl From<String> for TargetTriple {
     fn from(s: String) -> TargetTriple {
         s.as_str().into()
+    }
+}
+
+impl Serialize for TargetTriple {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.triple())
     }
 }
 

--- a/src/tests/toml.rs
+++ b/src/tests/toml.rs
@@ -61,14 +61,17 @@ fn toml_check() -> Result<(), Box<dyn std::error::Error>> {
                 text_line_no(&contents, fence.range().start),
             );
             let mut msg_info = crate::shell::MessageInfo::default();
-            assert!(if !cargo {
+            let toml = if !cargo {
                 crate::cross_toml::CrossToml::parse_from_cross(&fence_content, &mut msg_info)?
             } else {
                 crate::cross_toml::CrossToml::parse_from_cargo(&fence_content, &mut msg_info)?
                     .unwrap_or_default()
-            }
-            .1
-            .is_empty());
+            };
+            assert!(toml.1.is_empty());
+
+            // TODO: Add serde_path_to_error
+            // Check if roundtrip works, needed for merging Cross.toml and Cargo.toml
+            serde_json::from_value::<crate::cross_toml::CrossToml>(serde_json::to_value(toml.0)?)?;
         }
     }
     Ok(())


### PR DESCRIPTION
`pre-build = "file"` and `image.toolchain` had a bad serialization, this fixes that

Closes #1182
