### PR TITLE
Bugfix: use current target_dir path when copying build artifacts back

### DIFF
--- a/.changes/1199.json
+++ b/.changes/1199.json
@@ -1,5 +1,5 @@
 {
     "type": "fixed",
-    "description": "use corrent target_dir path when copying build artifacts back",
+    "description": "use current target_dir path when copying build artifacts back",
     "issues": [1103]
 }

--- a/.changes/1199.json
+++ b/.changes/1199.json
@@ -1,0 +1,5 @@
+{
+    "type": "fixed",
+    "description": "use corrent target_dir path when copying build artifacts back",
+    "issues": [1103]
+}

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -954,10 +954,13 @@ symlink_recurse \"${{prefix}}\"
         .map(|s| bool_from_envvar(&s))
         .unwrap_or_default();
     bail_container_exited!();
-    if !skip_artifacts && data_volume.container_path_exists(&target_dir, mount_prefix, msg_info)? {
+    let mount_target_dir = format!("{}/{}", package_dirs.mount_root(), target_dir);
+    if !skip_artifacts
+        && data_volume.container_path_exists(&mount_target_dir, mount_prefix, msg_info)?
+    {
         subcommand_or_exit(engine, "cp")?
             .arg("-a")
-            .arg(&format!("{container_id}:{target_dir}",))
+            .arg(&format!("{container_id}:{mount_target_dir}",))
             .arg(
                 package_dirs
                     .target()


### PR DESCRIPTION
Closes #1103 