### PR TITLE
fix is_bare_metal

### DIFF
--- a/.changes/1246.json
+++ b/.changes/1246.json
@@ -1,0 +1,4 @@
+{
+    "description": "fix support for bare metal targets other than thumb",
+    "type": "fixed"
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,10 @@ impl Target {
     }
 
     fn is_bare_metal(&self) -> bool {
-        self.triple().contains("thumb")
+        self.triple().ends_with("-none")
+            || self.triple().ends_with("-none-elf")
+            || self.triple().ends_with("-none-eabi")
+            || self.triple().ends_with("-none-eabihf")
     }
 
     fn is_builtin(&self) -> bool {


### PR DESCRIPTION
This makes cross usable with other bare metal targets (e.g. mips, riscv) with a custom image. Without this change, cross will always fallback to host cargo because `needs_docker` returns `false`.

---

Thumb is not necessarily bare metal, it can also be windows/linux/android:

```
thumbv7a-pc-windows-msvc
thumbv7a-uwp-windows-msvc
thumbv7neon-linux-androideabi
thumbv7neon-unknown-linux-gnueabihf
thumbv7neon-unknown-linux-musleabihf
```

But thumb bare metal targets are `-none-eabi` or `-none-eabihf`.