### PR TITLE
Customize `--cache-to`, `--cache-from` options for `build-docker-image`

### DIFF
--- a/.changes/1248.json
+++ b/.changes/1248.json
@@ -1,4 +1,4 @@
 {
     "description": "customize `--cache-from` and `--cache-to` options for `build-docker-image`",
-    "type": "added"
+    "type": "internal"
 }

--- a/.changes/1248.json
+++ b/.changes/1248.json
@@ -1,0 +1,4 @@
+{
+    "description": "customize `--cache-from` and `--cache-to` options for `build-docker-image`",
+    "type": "added"
+}

--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -63,7 +63,7 @@ pub struct BuildDockerImage {
     /// Option `--cache-to` for docker, only would work if push is not set to true
     ///
     /// Additionally you can use {base_name} to replace with base name of the image
-    /// If not specified, would not be passed to docker
+    /// If not specified, would not be passed to docker unless `--push` is used
     #[clap(long)]
     pub cache_to: Option<String>,
     /// Option `--cache-from` for docker, would only work if engine supports cache from type and no_cache is not set to true

--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -277,10 +277,8 @@ pub fn build_docker_image(
 
         if push {
             docker_build.args(["--cache-to", "type=inline"]);
-        } else {
-            if let Some(ref cache_to) = cache_to {
-                docker_build.args(["--cache-to", cache_to]);
-            }
+        } else if let Some(ref cache_to) = cache_to {
+            docker_build.args(["--cache-to", cache_to]);
         }
 
         for tag in &tags {

--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -60,12 +60,17 @@ pub struct BuildDockerImage {
     /// Do not load from cache when building the image.
     #[clap(long)]
     pub no_cache: bool,
-    /// Cache to option for docker, only would work if push is not set to true
+    /// Option `--cache-to` for docker, only would work if push is not set to true
+    ///
+    /// Additionally you can use {base_name} to replace with base name of the image
+    /// If not specified, would not be passed to docker
     #[clap(long)]
     pub cache_to: Option<String>,
-    /// Cache from option for docker, would only work if engine supports cache from type and no_cache is not set to true
-    #[clap(long)]
-    pub cache_from: Option<String>,
+    /// Option `--cache-from` for docker, would only work if engine supports cache from type and no_cache is not set to true
+    ///
+    /// Additionally you can use {base_name} to replace with base name of the image
+    #[clap(long, default_value = "type=registry,ref={base_name}:main")]
+    pub cache_from: String,
     /// Continue building images even if an image fails to build.
     #[clap(long)]
     pub no_fastfail: bool,
@@ -256,14 +261,10 @@ pub fn build_docker_image(
         if no_cache {
             docker_build.arg("--no-cache");
         } else if engine.kind.supports_cache_from_type() {
-            if let Some(ref cache_from) = cache_from {
-                docker_build.args(["--cache-from", cache_from]);
-            } else {
-                docker_build.args([
-                    "--cache-from",
-                    &format!("type=registry,ref={base_name}:main"),
-                ]);
-            }
+            docker_build.args([
+                "--cache-from",
+                &cache_from.replace("{base_name}", &base_name),
+            ]);
         } else {
             // we can't use `image_name` since podman doesn't support tags
             // with `--cache-from`. podman only supports an image format
@@ -278,7 +279,7 @@ pub fn build_docker_image(
         if push {
             docker_build.args(["--cache-to", "type=inline"]);
         } else if let Some(ref cache_to) = cache_to {
-            docker_build.args(["--cache-to", cache_to]);
+            docker_build.args(["--cache-to", &cache_to.replace("{base_name}", &base_name)]);
         }
 
         for tag in &tags {


### PR DESCRIPTION
Additional Dockerfiles for some of targets (f.e MacOS) require building docker images from [cross-toolchains](https://github.com/cross-rs/cross-toolchains) repositoriy, which is supported by `build-docker-image` command.

When running build-docker-image on CI environments, such as Github Actions, the process could be made greatly faster if cache from previous build is stored. The official support of buildx system includes f.e. possibility to use Github Actions Cache directly - https://docs.docker.com/build/cache/backends/gha/ , or for other CI systems it is also possible to use local cache in folder - https://docs.docker.com/build/cache/backends/local/ . However, such configurations require passing `--cache-to` and `--cache-from` options to docker build command, which is currently not customizeable by `build-docker-image` command supplied by `cross`.

This PR intends to fix this issue by introducing two new options for  `build-docker-image`, namely  `--cache-to` and `--cache-from`. Option names match those of docker CLI and only used unless other configurations do not contradict these new options, f.e. when push is specified to true, cache-to would still be using inline cache, as it used to before these changes. Same goes for `--cache-from`, which will not be used in case if no_cache is set to true or if engine does not support cache from type. 