### PR TITLE
Update README.md for centos image target notes [5] and [7]

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ terminate.
 
 [6] libc = emscripten and GCC = clang
 
-[7] Must change `image = "aarch64-unknown-linux-gnu:main-centos"` in `Cross.toml` for `[target.aarch64-unknown-linux-gnu]` to use the CentOS7-compatible target.
+[7] Must change `image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main-centos"` in `Cross.toml` for `[target.aarch64-unknown-linux-gnu]` to use the CentOS7-compatible target.
 
 <!--[7] libc = emscripten and GCC = clang. The Docker images for these targets are currently not built automatically
 due to a [compiler bug](https://github.com/rust-lang/rust/issues/98216), you will have to build them yourself for now.-->

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ terminate.
 
 [4] libc = newlib
 
-[5] Must change `image = "x86_64-unknown-linux-gnu:main-centos"` in `Cross.toml` for `[target.x86_64-unknown-linux-gnu]` to use the CentOS7-compatible target.
+[5] Must change `image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos"` in `Cross.toml` for `[target.x86_64-unknown-linux-gnu]` to use the CentOS7-compatible target.
 
 [6] libc = emscripten and GCC = clang
 


### PR DESCRIPTION
Based on https://github.com/cross-rs/cross/issues/680, it is stated to add `ghcr.io/cross-rs/...` before the image tag. However, this is not stated in the README.md file, resulting in the error "docker login" being needed. 
With this update, the problem is fixed.