### PR TITLE
Fix ImagePlatform resolution

### DIFF
--- a/src/docker/image.rs
+++ b/src/docker/image.rs
@@ -360,7 +360,7 @@ impl ImagePlatform {
                 target,
             },
             TargetTriple::Aarch64UnknownLinuxMusl => ImagePlatform {
-                architecture: Architecture::Arm,
+                architecture: Architecture::Arm64,
                 os: Os::Linux,
                 variant: None,
                 target,


### PR DESCRIPTION
Fix ImagePlatform resolution for `Aarch64UnknownLinuxMusl` to set the `architecture` to `Architecture::Arm64`.

This fixes #1253