### PR TITLE
Podman doesn't support SELinux labels

### DIFF
--- a/.changes/1260.json
+++ b/.changes/1260.json
@@ -1,0 +1,6 @@
+{
+    "description": "fix podman bind mounts on macOS by removing SELinux labels.",
+    "issues": [756],
+    "type": "fixed",
+    "breaking": false
+}


### PR DESCRIPTION
This PR adds SELinux labels to volume mounts on other engines than Podman.

Fixes #756