### PR TITLE
feat: add aarch64-unknown-freebsd image

### DIFF
--- a/.changes/1271.json
+++ b/.changes/1271.json
@@ -1,0 +1,5 @@
+{
+    "description": "add aarch64-unknown-freebsd image.",
+    "type": "added",
+    "breaking": false
+}

--- a/.github/ISSUE_TEMPLATE/b_issue_report.yml
+++ b/.github/ISSUE_TEMPLATE/b_issue_report.yml
@@ -33,6 +33,7 @@ body:
         - aarch64-linux-android
         - aarch64-unknown-linux-gnu
         - aarch64-unknown-linux-musl
+        - aarch64-unknown-freebsd
         - arm-linux-androideabi
         - arm-unknown-linux-gnueabi
         - arm-unknown-linux-gnueabihf

--- a/docker/Dockerfile.aarch64-unknown-freebsd
+++ b/docker/Dockerfile.aarch64-unknown-freebsd
@@ -1,0 +1,38 @@
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY common.sh lib.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+RUN echo "export ARCH=aarch64" > /freebsd-arch.sh
+COPY freebsd-common.sh /
+COPY freebsd.sh /
+RUN /freebsd.sh
+
+COPY freebsd-install.sh /
+COPY freebsd-extras.sh /
+RUN /freebsd-extras.sh
+
+ENV CROSS_TOOLCHAIN_PREFIX=aarch64-unknown-freebsd12-
+ENV CROSS_SYSROOT=/usr/local/aarch64-unknown-freebsd12
+
+COPY freebsd-gcc.sh /usr/bin/"$CROSS_TOOLCHAIN_PREFIX"gcc.sh
+COPY toolchain.cmake /opt/toolchain.cmake
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_FREEBSD_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc.sh \
+    AR_aarch64_unknown_freebsd="$CROSS_TOOLCHAIN_PREFIX"ar \
+    CC_aarch64_unknown_freebsd="$CROSS_TOOLCHAIN_PREFIX"gcc \
+    CXX_aarch64_unknown_freebsd="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_aarch64_unknown_freebsd=/opt/toolchain.cmake \
+    BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_freebsd="--sysroot=$CROSS_SYSROOT" \
+    AARCH64_UNKNOWN_FREEBSD_OPENSSL_DIR="$CROSS_SYSROOT" \
+    CROSS_CMAKE_SYSTEM_NAME=FreeBSD \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=amd64 \
+    CROSS_CMAKE_CRT=freebsd \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m64"

--- a/docker/freebsd-common.sh
+++ b/docker/freebsd-common.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 
 export FREEBSD_ARCH=
 case "${ARCH}" in
+    aarch64) # releases are under http://ftp.freebsd.org/pub/FreeBSD/releases/
+        FREEBSD_ARCH=arm64 # http://ftp.freebsd.org/pub/FreeBSD/releases/arm64/
+        ;;
     x86_64)
         FREEBSD_ARCH=amd64
         ;;

--- a/docker/freebsd-extras.sh
+++ b/docker/freebsd-extras.sh
@@ -10,6 +10,12 @@ set -euo pipefail
 # shellcheck disable=SC1091
 . freebsd-install.sh
 
+case "${FREEBSD_ARCH}" in
+    arm64) # extras mirrors are under https://pkg.freebsd.org/
+        FREEBSD_ARCH=aarch64 #  https://pkg.freebsd.org/FreeBSD:13:aarch64/
+        ;;
+esac
+
 main() {
     apt-get update && apt-get install --assume-yes --no-install-recommends \
         curl \

--- a/src/docker/image.rs
+++ b/src/docker/image.rs
@@ -407,6 +407,7 @@ pub mod tests {
         assert_eq!(arch!("arm-unknown-linux-gnueabihf")?, Architecture::Arm);
         assert_eq!(arch!("armv7-unknown-linux-gnueabihf")?, Architecture::Arm);
         assert_eq!(arch!("aarch64-unknown-linux-gnu")?, Architecture::Arm64);
+        assert_eq!(arch!("aarch64-unknown-freebsd")?, Architecture::Arm64);
         assert_eq!(arch!("mips-unknown-linux-gnu")?, Architecture::Mips);
         assert_eq!(
             arch!("mips64-unknown-linux-gnuabi64")?,
@@ -424,6 +425,7 @@ pub mod tests {
     fn os_from_target() -> Result<()> {
         assert_eq!(Os::from_target(&t!("x86_64-apple-darwin"))?, Os::Darwin);
         assert_eq!(Os::from_target(&t!("x86_64-unknown-freebsd"))?, Os::Freebsd);
+        assert_eq!(Os::from_target(&t!("aarch64-unknown-freebsd"))?, Os::Freebsd);
         assert_eq!(Os::from_target(&t!("x86_64-unknown-netbsd"))?, Os::Netbsd);
         assert_eq!(Os::from_target(&t!("sparcv9-sun-solaris"))?, Os::Solaris);
         assert_eq!(Os::from_target(&t!("sparcv9-sun-illumos"))?, Os::Illumos);

--- a/src/docker/image.rs
+++ b/src/docker/image.rs
@@ -425,7 +425,10 @@ pub mod tests {
     fn os_from_target() -> Result<()> {
         assert_eq!(Os::from_target(&t!("x86_64-apple-darwin"))?, Os::Darwin);
         assert_eq!(Os::from_target(&t!("x86_64-unknown-freebsd"))?, Os::Freebsd);
-        assert_eq!(Os::from_target(&t!("aarch64-unknown-freebsd"))?, Os::Freebsd);
+        assert_eq!(
+            Os::from_target(&t!("aarch64-unknown-freebsd"))?,
+            Os::Freebsd
+        );
         assert_eq!(Os::from_target(&t!("x86_64-unknown-netbsd"))?, Os::Netbsd);
         assert_eq!(Os::from_target(&t!("sparcv9-sun-solaris"))?, Os::Solaris);
         assert_eq!(Os::from_target(&t!("sparcv9-sun-illumos"))?, Os::Illumos);

--- a/src/docker/provided_images.rs
+++ b/src/docker/provided_images.rs
@@ -234,6 +234,11 @@ pub static PROVIDED_IMAGES: &[ProvidedImage] = &[
             sub: None
         },
         ProvidedImage {
+            name: "aarch64-unknown-freebsd",
+            platforms: &[ImagePlatform::X86_64_UNKNOWN_LINUX_GNU],
+            sub: None
+        },
+        ProvidedImage {
             name: "x86_64-unknown-netbsd",
             platforms: &[ImagePlatform::X86_64_UNKNOWN_LINUX_GNU],
             sub: None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,7 @@ impl TargetTriple {
             "x86_64-unknown-dragonfly" => Some("dragonflybsd-amd64"),
             "i686-unknown-freebsd" => Some("freebsd-i386"),
             "x86_64-unknown-freebsd" => Some("freebsd-amd64"),
+            "aarch64-unknown-freebsd" => Some("freebsd-arm64"),
             "x86_64-unknown-netbsd" => Some("netbsd-amd64"),
             "sparcv9-sun-solaris" => Some("solaris-sparc"),
             "x86_64-sun-solaris" => Some("solaris-amd64"),

--- a/targets.toml
+++ b/targets.toml
@@ -410,6 +410,13 @@ dylib = true
 std = true
 
 [[target]]
+target = "aarch64-unknown-freebsd"
+os = "ubuntu-latest"
+cpp = true
+dylib = true
+std = true
+
+[[target]]
 target = "x86_64-unknown-netbsd"
 os = "ubuntu-latest"
 cpp = true

--- a/targets.toml
+++ b/targets.toml
@@ -415,6 +415,7 @@ os = "ubuntu-latest"
 cpp = true
 dylib = true
 std = true
+build-std = true
 
 [[target]]
 target = "x86_64-unknown-netbsd"


### PR DESCRIPTION
👋🏾 

Thanks for Cross, we've been using it at the pact-foundation to build cross platform targets, and I've gone through the target list and attempted to build for everything I can. See [PR here](https://github.com/pact-foundation/pact-reference/pull/276)

I've managed to build for freebsd in a parallels vm on a mac m1 pro, but makes sense to try and apply that to a Docker image.

Relates to https://github.com/cross-rs/cross/issues/975

Still requires testing but thought I would drop it here for others to have a look at / test / try out 

