### PR TITLE
fix: ubuntu does not provide mips packages

### DIFF
--- a/docker/Dockerfile.mipsel-unknown-linux-musl
+++ b/docker/Dockerfile.mipsel-unknown-linux-musl
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM debian:bookworm
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/docker/lib.sh
+++ b/docker/lib.sh
@@ -10,7 +10,7 @@ set_centos_ulimit() {
 }
 
 install_packages() {
-    if grep -i ubuntu /etc/os-release; then
+    if grep -i debian /etc/os-release || grep -i ubuntu /etc/os-release; then
         apt-get update
 
         for pkg in "${@}"; do
@@ -34,7 +34,7 @@ install_packages() {
 
 purge_packages() {
     if (( ${#purge_list[@]} )); then
-        if grep -i ubuntu /etc/os-release; then
+        if grep -i ubuntu /etc/os-release || grep -i debian /etc/os-release ; then
             apt-get purge --assume-yes --auto-remove "${purge_list[@]}"
         else
             yum remove -y "${purge_list[@]}"
@@ -49,7 +49,7 @@ if_centos() {
 }
 
 if_ubuntu() {
-    if grep -q -i ubuntu /etc/os-release; then
+    if grep -q -i debian /etc/os-release || grep -q -i ubuntu /etc/os-release; then
         eval "${@}"
     fi
 }


### PR DESCRIPTION
Ubuntu does not support mips, so we cannot add libraries with pre-build hooks like [suggested in the documentation](https://github.com/cross-rs/cross#pre-build-hook).

This changes the mipsel-unknown-linux-musl image to build from Debian stable.

You can now do:

```
pre-build = ["dpkg --add-architecture mipsel && apt-get update && apt-get install -y zlib1g-dev:mipsel && ln -s /usr/include/zlib.h /usr/local/mipsel-linux-muslsf/include"]
```

I realize this is not a benign change but it ended up being pretty small. I am curious if this is something you would consider merging - or if you would suggest a better approach.