### PR TITLE
feat(rootless): help detection with execv check "is current builder rootless?"

### DIFF
--- a/src/docker/engine.rs
+++ b/src/docker/engine.rs
@@ -95,7 +95,7 @@ impl Engine {
             None => Self::in_docker(msg_info)?,
         };
         let (kind, arch, os) = get_engine_info(&path, msg_info)?;
-        let is_rootless = is_rootless(&path, msg_info, kind);
+        let is_rootless = is_rootless(kind).unwrap_or_else(|| is_docker_rootless(&path, msg_info));
         let is_remote = is_remote.unwrap_or_else(Self::is_remote);
         Ok(Engine {
             path,
@@ -146,8 +146,7 @@ impl Engine {
     }
 }
 
-#[must_use]
-fn is_rootless(ce: &Path, msg_info: &mut MessageInfo, kind: EngineType) -> bool {
+fn is_rootless(kind: EngineType) -> Option<bool> {
     env::var("CROSS_ROOTLESS_CONTAINER_ENGINE")
         .ok()
         .and_then(|s| match s.as_ref() {
@@ -155,9 +154,9 @@ fn is_rootless(ce: &Path, msg_info: &mut MessageInfo, kind: EngineType) -> bool 
             b => Some(bool_from_envvar(b)),
         })
         .or_else(|| (!kind.is_docker()).then_some(true))
-        .unwrap_or_else(|| is_docker_rootless(ce, msg_info))
 }
 
+#[must_use]
 fn is_docker_rootless(ce: &Path, msg_info: &mut MessageInfo) -> bool {
     let mut cmd = Command::new(ce);
     cmd.args(["info", "-f", "{{.SecurityOptions}}"])
@@ -174,34 +173,35 @@ fn is_docker_rootless(ce: &Path, msg_info: &mut MessageInfo) -> bool {
 
 #[test]
 fn various_is_rootless_configs() {
-    let ce = Path::new("docker");
-    let msg_info = &mut MessageInfo::default();
     let var = "CROSS_ROOTLESS_CONTAINER_ENGINE";
     let old = env::var(var);
     env::remove_var(var);
 
-    assert!(is_rootless(ce, msg_info, EngineType::Docker));
-    assert!(is_rootless(ce, msg_info, EngineType::Podman));
-    assert!(is_rootless(ce, msg_info, EngineType::PodmanRemote));
-    assert!(is_rootless(ce, msg_info, EngineType::Other));
+    assert!(!is_rootless(EngineType::Docker).unwrap_or(false));
+    assert!(is_rootless(EngineType::Docker).unwrap_or(true));
+
+    assert_eq!(is_rootless(EngineType::Docker), None);
+    assert_eq!(is_rootless(EngineType::Podman), Some(true));
+    assert_eq!(is_rootless(EngineType::PodmanRemote), Some(true));
+    assert_eq!(is_rootless(EngineType::Other), Some(true));
 
     env::set_var(var, "0");
-    assert!(!is_rootless(ce, msg_info, EngineType::Docker));
-    assert!(!is_rootless(ce, msg_info, EngineType::Podman));
-    assert!(!is_rootless(ce, msg_info, EngineType::PodmanRemote));
-    assert!(!is_rootless(ce, msg_info, EngineType::Other));
+    assert_eq!(is_rootless(EngineType::Docker), Some(false));
+    assert_eq!(is_rootless(EngineType::Podman), Some(false));
+    assert_eq!(is_rootless(EngineType::PodmanRemote), Some(false));
+    assert_eq!(is_rootless(EngineType::Other), Some(false));
 
     env::set_var(var, "1");
-    assert!(is_rootless(ce, msg_info, EngineType::Docker));
-    assert!(is_rootless(ce, msg_info, EngineType::Podman));
-    assert!(is_rootless(ce, msg_info, EngineType::PodmanRemote));
-    assert!(is_rootless(ce, msg_info, EngineType::Other));
+    assert_eq!(is_rootless(EngineType::Docker), Some(true));
+    assert_eq!(is_rootless(EngineType::Podman), Some(true));
+    assert_eq!(is_rootless(EngineType::PodmanRemote), Some(true));
+    assert_eq!(is_rootless(EngineType::Other), Some(true));
 
     env::set_var(var, "auto");
-    assert!(is_rootless(ce, msg_info, EngineType::Docker));
-    assert!(is_rootless(ce, msg_info, EngineType::Podman));
-    assert!(is_rootless(ce, msg_info, EngineType::PodmanRemote));
-    assert!(is_rootless(ce, msg_info, EngineType::Other));
+    assert_eq!(is_rootless(EngineType::Docker), None);
+    assert_eq!(is_rootless(EngineType::Podman), Some(true));
+    assert_eq!(is_rootless(EngineType::PodmanRemote), Some(true));
+    assert_eq!(is_rootless(EngineType::Other), Some(true));
 
     match old {
         Ok(v) => env::set_var(var, v),

--- a/src/docker/local.rs
+++ b/src/docker/local.rs
@@ -73,7 +73,7 @@ pub(crate) fn run(
     docker
         .add_seccomp(engine.kind, &options.target, &paths.metadata)
         .wrap_err("when copying seccomp profile")?;
-    docker.add_user_id(engine.kind);
+    docker.add_user_id(engine.is_rootless);
 
     docker
         .args([

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -972,7 +972,7 @@ symlink_recurse \"${{prefix}}\"
 
     // 6. execute our cargo command inside the container
     let mut docker = engine.subcommand("exec");
-    docker.add_user_id(engine.kind);
+    docker.add_user_id(engine.is_rootless);
     docker.add_envvars(&options, toolchain_dirs, msg_info)?;
     docker.add_cwd(&paths)?;
     docker.arg(&container_id);

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -1505,53 +1505,25 @@ pub fn path_hash(path: &Path, count: usize) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    // use crate::id;
+    use crate::id;
 
     #[cfg(not(target_os = "windows"))]
     use crate::file::PathExt;
 
-    // #[test]
-    // fn test_is_rootless() {
-    //     let var = "CROSS_ROOTLESS_CONTAINER_ENGINE";
-    //     let old = env::var(var);
-    //     env::remove_var(var);
+    #[test]
+    fn test_docker_user_id() {
+        let rootful = format!("\"engine\" \"--user\" \"{}:{}\"", id::user(), id::group());
+        let rootless = "\"engine\"".to_owned();
 
-    //     let rootful = format!("\"engine\" \"--user\" \"{}:{}\"", id::user(), id::group());
-    //     let rootless = "\"engine\"".to_owned();
+        let test = |noroot, expected| {
+            let mut cmd = Command::new("engine");
+            cmd.add_user_id(noroot);
+            assert_eq!(expected, &format!("{cmd:?}"));
+        };
 
-    //     let test = |engine, expected| {
-    //         let mut cmd = Command::new("engine");
-    //         cmd.add_user_id(engine, );
-    //         assert_eq!(expected, &format!("{cmd:?}"));
-    //     };
-    //     test(EngineType::Docker, &rootful);
-    //     test(EngineType::Podman, &rootless);
-    //     test(EngineType::PodmanRemote, &rootless);
-    //     test(EngineType::Other, &rootless);
-
-    //     env::set_var(var, "0");
-    //     test(EngineType::Docker, &rootful);
-    //     test(EngineType::Podman, &rootful);
-    //     test(EngineType::PodmanRemote, &rootful);
-    //     test(EngineType::Other, &rootful);
-
-    //     env::set_var(var, "1");
-    //     test(EngineType::Docker, &rootless);
-    //     test(EngineType::Podman, &rootless);
-    //     test(EngineType::PodmanRemote, &rootless);
-    //     test(EngineType::Other, &rootless);
-
-    //     env::set_var(var, "auto");
-    //     test(EngineType::Docker, &rootful);
-    //     test(EngineType::Podman, &rootless);
-    //     test(EngineType::PodmanRemote, &rootless);
-    //     test(EngineType::Other, &rootless);
-
-    //     match old {
-    //         Ok(v) => env::set_var(var, v),
-    //         Err(_) => env::remove_var(var),
-    //     }
-    // }
+        test(false, &rootful);
+        test(true, &rootless);
+    }
 
     #[test]
     fn test_docker_userns() {


### PR DESCRIPTION
I recently encountered #1098 and propose an iteration on the fix in #890

This patch adds a last minute check that looks up the current builder endpoint. This may be seen as a costly operation however, as mentioned in #889

Here's the output of `docker builder inspect` on my rootless install:
```
Name:          rootless
Driver:        docker
Last Activity: 2023-12-03 02:04:14 +0000 UTC

Nodes:
Name:      rootless
Endpoint:  rootless  # <= THIS HERE
Status:    running
Buildkit:  v0.11.7+d3e6c1360f6e
Platforms: linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/amd64/v4, linux/386
Labels:
 org.mobyproject.buildkit.worker.moby.host-gateway-ip: 172.17.0.1
```