### PR TITLE
make `mips-unknown-linux-musl` and `mipsel-unknown-linux-musl` use build-std in ci

### DIFF
--- a/targets.toml
+++ b/targets.toml
@@ -308,6 +308,7 @@ cpp = true
 dylib = true
 std = true
 run = true
+build-std = true
 
 [[target]]
 target = "mipsel-unknown-linux-musl"
@@ -316,6 +317,7 @@ cpp = true
 dylib = true
 std = true
 run = true
+build-std = true
 
 [[target]]
 target = "aarch64-linux-android"


### PR DESCRIPTION
This was missed in https://github.com/cross-rs/cross/pull/1394 somehow