### PR TITLE
freebsd: let helper scripts work not just from /

### DIFF
--- a/docker/freebsd-common.sh
+++ b/docker/freebsd-common.sh
@@ -4,7 +4,7 @@ set -x
 set -euo pipefail
 
 # shellcheck disable=SC1091
-. freebsd-arch.sh
+. /freebsd-arch.sh
 
 export FREEBSD_ARCH=
 case "${ARCH}" in

--- a/docker/freebsd-extras.sh
+++ b/docker/freebsd-extras.sh
@@ -4,11 +4,11 @@ set -x
 set -euo pipefail
 
 # shellcheck disable=SC1091
-. lib.sh
+. /lib.sh
 # shellcheck disable=SC1091
-. freebsd-common.sh
+. /freebsd-common.sh
 # shellcheck disable=SC1091
-. freebsd-install.sh
+. /freebsd-install.sh
 
 case "${FREEBSD_ARCH}" in
     arm64) # extras mirrors are under https://pkg.freebsd.org/

--- a/docker/freebsd-install.sh
+++ b/docker/freebsd-install.sh
@@ -4,7 +4,7 @@ set -x
 set -euo pipefail
 
 # shellcheck disable=SC1091
-. freebsd-common.sh
+. /freebsd-common.sh
 
 # list of SRV records to query if the default mirror fails
 FREEBSD_HTTP_TCP_SOURCES=(

--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -4,9 +4,9 @@ set -x
 set -euo pipefail
 
 # shellcheck disable=SC1091
-. freebsd-common.sh
+. /freebsd-common.sh
 # shellcheck disable=SC1091
-. lib.sh
+. /lib.sh
 
 # we prefer those closer in geography to the US. they're triaged in
 # order of ease of use, reliability, and then geography. the mirror


### PR DESCRIPTION
Scripts should not source their libs as if they were going to be run with `PWD=/`