### PR TITLE
Add GCC_CONFIG option to enable default PIE

### DIFF
--- a/docker/musl.sh
+++ b/docker/musl.sh
@@ -51,6 +51,7 @@ main() {
         LINUX_HEADERS_SITE="${linux_headers_site}" \
         LINUX_VER="${linux_ver}" \
         OUTPUT=/usr/local/ \
+        "GCC_CONFIG += --enable-default-pie" \
         "${@}"
 
     purge_packages


### PR DESCRIPTION
This was removed in #1346 for unknown reasons. I'm adding it back in.