### PR TITLE
Fix broken links to config_file in custom images docs

### DIFF
--- a/docs/custom_images.md
+++ b/docs/custom_images.md
@@ -85,7 +85,7 @@ default one. Normal Docker behavior applies, so:
 
 
 
-[config-target-pre-build]: ./config.md#targettargetpre-build
-[config_target_dockerfile]: ./config.md#targettargetdockerfile
-[config_target_image]: ./config.md#targettargetimage
-[config_build_dockerfile]: ./config.md#builddockerfile
+[config-target-pre-build]: ./config_file.md#targettargetpre-build
+[config_target_dockerfile]: ./config_file.md#targettargetdockerfile
+[config_target_image]: ./config_file.md#targettargetimage
+[config_build_dockerfile]: ./config_file.md#builddockerfile


### PR DESCRIPTION
Points the broken links in [docs/custom_images]( https://github.com/cross-rs/cross/blob/main/docs/custom_images.md#custom-dockerfile) to the renamed file.