### PR TITLE
docker: Add gfortran support

### DIFF
--- a/.changes/1458.json
+++ b/.changes/1458.json
@@ -1,0 +1,6 @@
+{
+  "description": "add gfortran for target *-gnu*, *-musl*, *-freebsd*, *-solaris*, *-dragonfly*, *-illumos*, *-netbsd*",
+  "issues": [1457],
+  "type": "added"
+
+}

--- a/docker/Dockerfile.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-aarch64-linux-gnu \
+    gfortran-aarch64-linux-gnu \
     libc6-dev-arm64-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.arm-unknown-linux-gnueabi
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabi
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-arm-linux-gnueabi \
+    gfortran-arm-linux-gnueabi \
     libc6-dev-armel-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.armv5te-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-gnueabi
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-arm-linux-gnueabi \
+    gfortran-arm-linux-gnueabi \
     crossbuild-essential-armel \
     libc6-dev-armel-cross
 

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabi
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get install --assume-yes --no-install-recommends \
     g++-arm-linux-gnueabi \
+    gfortran-arm-linux-gnueabi \
     libc6-dev-armel-cross
 
 COPY qemu.sh /

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-arm-linux-gnueabihf \
+    gfortran-arm-linux-gnueabihf \
     libc6-dev-armhf-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.i586-unknown-linux-gnu
+++ b/docker/Dockerfile.i586-unknown-linux-gnu
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-i686-linux-gnu \
+    gfortran-i686-linux-gnu \
     libc6-dev-i386-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.i686-unknown-linux-gnu
+++ b/docker/Dockerfile.i686-unknown-linux-gnu
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-i686-linux-gnu \
+    gfortran-i686-linux-gnu \
     libc6-dev-i386-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.mips-unknown-linux-gnu
+++ b/docker/Dockerfile.mips-unknown-linux-gnu
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get install --assume-yes --no-install-recommends \
     g++-mips-linux-gnu \
+    gfrotran-mips-linux-gnu \
     libc6-dev-mips-cross
 
 COPY qemu.sh /

--- a/docker/Dockerfile.mips-unknown-linux-gnu
+++ b/docker/Dockerfile.mips-unknown-linux-gnu
@@ -14,7 +14,7 @@ FROM cross-base as build
 
 RUN apt-get install --assume-yes --no-install-recommends \
     g++-mips-linux-gnu \
-    gfrotran-mips-linux-gnu \
+    gfortran-mips-linux-gnu \
     libc6-dev-mips-cross
 
 COPY qemu.sh /

--- a/docker/Dockerfile.mips64-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-gnuabi64
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-mips64-linux-gnuabi64 \
+    gfortran-mips64-linux-gnuabi64 \
     libc6-dev-mips64-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-mips64el-linux-gnuabi64 \
+    gfortran-mips64el-linux-gnuabi64 \
     libc6-dev-mips64el-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.mipsel-unknown-linux-gnu
+++ b/docker/Dockerfile.mipsel-unknown-linux-gnu
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-mipsel-linux-gnu \
+    gfortran-mipsel-linux-gnu \
     libc6-dev-mipsel-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.powerpc-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc-unknown-linux-gnu
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-powerpc-linux-gnu \
+    gfortran-powerpc-linux-gnu \
     libc6-dev-powerpc-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.powerpc64-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64-unknown-linux-gnu
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-powerpc64-linux-gnu \
+    gfrotran-powerpc64-linux-gnu \
     libc6-dev-ppc64-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.powerpc64-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64-unknown-linux-gnu
@@ -14,7 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-powerpc64-linux-gnu \
-    gfrotran-powerpc64-linux-gnu \
+    gfortran-powerpc64-linux-gnu \
     libc6-dev-ppc64-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.powerpc64le-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64le-unknown-linux-gnu
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-powerpc64le-linux-gnu \
+    gfortran-powerpc64le-linux-gnu \
     libc6-dev-ppc64el-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.riscv64gc-unknown-linux-gnu
+++ b/docker/Dockerfile.riscv64gc-unknown-linux-gnu
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     g++-riscv64-linux-gnu \
+    gfortran-riscv64-linux-gnu \
     libc6-dev-riscv64-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.s390x-unknown-linux-gnu
+++ b/docker/Dockerfile.s390x-unknown-linux-gnu
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-s390x-linux-gnu \
+    gfortran-s390x-linux-gnu \
     libc6-dev-s390x-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.sparc64-unknown-linux-gnu
+++ b/docker/Dockerfile.sparc64-unknown-linux-gnu
@@ -14,7 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-sparc64-linux-gnu \
-    g++-sparc64-linux-gfortran \
+    gfortran-sparc64-linux-gnu \
     libc6-dev-sparc64-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.sparc64-unknown-linux-gnu
+++ b/docker/Dockerfile.sparc64-unknown-linux-gnu
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-sparc64-linux-gnu \
+    g++-sparc64-linux-gfortran \
     libc6-dev-sparc64-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.thumbv7neon-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.thumbv7neon-unknown-linux-gnueabihf
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-arm-linux-gnueabihf \
+    gfortran-arm-linux-gnueabihf \
     libc6-dev-armhf-cross
 
 COPY qemu.sh /

--- a/docker/Dockerfile.x86_64-pc-windows-gnu
+++ b/docker/Dockerfile.x86_64-pc-windows-gnu
@@ -18,7 +18,7 @@ RUN dpkg --add-architecture i386 && apt-get update && \
 COPY wine.sh /
 RUN /wine.sh
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends g++-mingw-w64-x86-64
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends g++-mingw-w64-x86-64 gfortran-mingw-w64-x86-64
 
 # run-detectors are responsible for calling the correct interpreter for exe
 # files. For some reason it does not work inside a docker container (it works

--- a/docker/Dockerfile.x86_64-unknown-linux-gnu
+++ b/docker/Dockerfile.x86_64-unknown-linux-gnu
@@ -14,6 +14,7 @@ FROM cross-base as build
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     g++-x86-64-linux-gnu \
+    gfortran-x86-64-linux-gnu \
     libc6-dev-amd64-cross
 
 COPY deny-debian-packages.sh /

--- a/docker/aarch64-linux-gnu-glibc.sh
+++ b/docker/aarch64-linux-gnu-glibc.sh
@@ -40,7 +40,7 @@ cp_gcc_archive() {
 main() {
     set_centos_ulimit
     yum install -y epel-release
-    yum install -y gcc-aarch64-linux-gnu gcc-c++-aarch64-linux-gnu binutils-aarch64-linux-gnu binutils gcc-c++ glibc-devel
+    yum install -y gcc-aarch64-linux-gnu gcc-c++-aarch64-linux-gnu gfortran-c++-aarch64-linux-gnu binutils-aarch64-linux-gnu binutils gcc-c++ glibc-devel
     yum clean all
 
     local td

--- a/docker/common.sh
+++ b/docker/common.sh
@@ -30,11 +30,13 @@ install_packages \
 if_centos install_packages \
     clang-devel \
     gcc-c++ \
+    gcc-gfortran \
     glibc-devel \
     pkgconfig
 
 if_ubuntu install_packages \
     g++ \
+    gfortran \
     libc6-dev \
     libclang-dev \
     pkg-config

--- a/docker/dragonfly.sh
+++ b/docker/dragonfly.sh
@@ -95,7 +95,7 @@ EOF
         --disable-lto \
         --disable-multilib \
         --disable-nls \
-        --enable-languages=c,c++,,fortran \
+        --enable-languages=c,c++,fortran \
         --target="${target}"
     make "-j${nproc}"
     make install

--- a/docker/dragonfly.sh
+++ b/docker/dragonfly.sh
@@ -95,7 +95,7 @@ EOF
         --disable-lto \
         --disable-multilib \
         --disable-nls \
-        --enable-languages=c,c++ \
+        --enable-languages=c,c++,,fortran \
         --target="${target}"
     make "-j${nproc}"
     make install

--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -228,7 +228,7 @@ main() {
         --disable-libvtv \
         --disable-lto \
         --disable-nls \
-        --enable-languages=c,c++ \
+        --enable-languages=c,c++,fortran \
         --target="${target}"
     make "-j$(nproc)"
     make install

--- a/docker/illumos.sh
+++ b/docker/illumos.sh
@@ -104,7 +104,7 @@ main() {
         --target="${build_target}" \
         --program-prefix="${target}-" \
         --with-sysroot="${sysroot_dir}" \
-        --enable-languages=c,c++ \
+        --enable-languages=c,c++,fortran \
         --disable-libada \
         --disable-libcilkrts \
         --disable-libgomp \

--- a/docker/musl.sh
+++ b/docker/musl.sh
@@ -51,7 +51,7 @@ main() {
         LINUX_HEADERS_SITE="${linux_headers_site}" \
         LINUX_VER="${linux_ver}" \
         OUTPUT=/usr/local/ \
-        "GCC_CONFIG += --enable-default-pie" \
+        "GCC_CONFIG += --enable-default-pie --enable-languages=c,c++,fortran" \
         "${@}"
 
     purge_packages

--- a/docker/netbsd.sh
+++ b/docker/netbsd.sh
@@ -38,8 +38,9 @@ main() {
     sed -i -e 's/ftp:/https:/g' ./contrib/download_prerequisites
     ./contrib/download_prerequisites
     local patches=(
-        https://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/lang/gcc9/patches/patch-libstdc++-v3_config_os_bsd_netbsd_ctype__base.h
         https://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/lang/gcc9/patches/patch-libstdc++-v3_config_os_bsd_netbsd_ctype__configure__char.cc
+        https://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/lang/gcc9/patches/patch-libstdc++-v3_config_os_bsd_netbsd_ctype__base.h
+        https://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/lang/gcc8/patches/patch-libgfortran_io_io.h
     )
 
     local patch
@@ -92,7 +93,8 @@ main() {
     ln -s libutil.so.7.24 "${destdir}/lib/libutil.so.7"
 
     pushd gcc-build
-    ../gcc/configure \
+    # remove the environment variables after bumping the gcc version to 11.
+    target_configargs="ac_cv_func_newlocale=no ac_cv_func_freelocale=no ac_cv_func_uselocale=no" ../gcc/configure \
         --disable-libada \
         --disable-libcilkrt \
         --disable-libcilkrts \

--- a/docker/netbsd.sh
+++ b/docker/netbsd.sh
@@ -105,7 +105,7 @@ main() {
         --disable-lto \
         --disable-multilib \
         --disable-nls \
-        --enable-languages=c,c++ \
+        --enable-languages=c,c++,fortran \
         --target="${target}"
     make "-j$(nproc)"
     make install

--- a/docker/solaris.sh
+++ b/docker/solaris.sh
@@ -121,7 +121,7 @@ EOF
         --disable-lto \
         --disable-multilib \
         --disable-nls \
-        --enable-languages=c,c++ \
+        --enable-languages=c,c++,fortran \
         --with-gnu-as \
         --with-gnu-ld \
         --target="${target}"


### PR DESCRIPTION
Add gfortran support for all docker except target of `*-none*` and `*-andriod*`.

Close #1457 