### PR TITLE
Upgrade qemu and integrate qemu-user runners for loongarch64

### DIFF
--- a/.changes/1466.json
+++ b/.changes/1466.json
@@ -1,0 +1,5 @@
+{
+    "type": "added",
+    "description": "Upgrade qemu and integrate qemu-user runners for loongarch64-linux-gnu",
+    "issues": [1467]
+}

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ terminate.
 | `i686-linux-android` [1]               | 9.0.8  | 9.0.8  | ✓   | 6.1.0 |   ✓    |
 | `i686-pc-windows-gnu`                  | N/A    | 9.4    | ✓   | N/A   |   ✓    |
 | `i686-unknown-linux-gnu`               | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `loongarch64-unknown-linux-gnu`        | 2.36   | 13.2.0 | ✓   | N/A   |        |
+| `loongarch64-unknown-linux-gnu`        | 2.36   | 13.2.0 | ✓   | 8.2.2 |   ✓    |
 | `mips-unknown-linux-gnu`               | 2.30   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
 | `mips-unknown-linux-musl`              | 1.2.3  | 9.2.0  | ✓   | 6.1.0 |   ✓    |
 | `mips64-unknown-linux-gnuabi64`        | 2.30   | 9.4.0  | ✓   | 6.1.0 |   ✓    |

--- a/docker/Dockerfile.loongarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.loongarch64-unknown-linux-gnu
@@ -19,15 +19,31 @@ RUN /crosstool-ng.sh loongarch64-unknown-linux-gnu.config 5
 
 ENV PATH /x-tools/loongarch64-unknown-linux-gnu/bin/:$PATH
 
+COPY deny-debian-packages.sh /
+RUN TARGET_ARCH=loong64 /deny-debian-packages.sh
+
+COPY qemu.sh /
+RUN /qemu.sh loongarch64
+
+COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TOOLCHAIN_PREFIX=loongarch64-unknown-linux-gnu-
+ENV CROSS_SYSROOT=/x-tools/loongarch64-unknown-linux-gnu/loongarch64-unknown-linux-gnu/sysroot/
+ENV CROSS_TARGET_RUNNER="/qemu-runner loongarch64"
 ENV CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
+    CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_loongarch64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_loongarch64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_loongarch64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
     CMAKE_TOOLCHAIN_FILE_loongarch64_unknown_linux_gnu=/opt/toolchain.cmake \
+    BINDGEN_EXTRA_CLANG_ARGS_loongarch64_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT -idirafter/usr/include" \
+    QEMU_LD_PREFIX="$CROSS_SYSROOT" \
+    RUST_TEST_THREADS=1 \
     CROSS_CMAKE_SYSTEM_NAME=Linux \
     CROSS_CMAKE_SYSTEM_PROCESSOR=loongarch64 \
     CROSS_CMAKE_CRT=gnu \
     CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC"
+
+RUN mv $CROSS_SYSROOT/lib/* $CROSS_SYSROOT/lib64/
+RUN sed -e "s#@DEFAULT_QEMU_LD_PREFIX@#$QEMU_LD_PREFIX#g" -i /qemu-runner

--- a/targets.toml
+++ b/targets.toml
@@ -120,6 +120,8 @@ os = "ubuntu-latest"
 cpp = true
 dylib = true
 std = true
+run = true
+runners = "qemu-user"
 
 [[target]]
 target = "mips-unknown-linux-gnu"


### PR DESCRIPTION
Even though the Debian/LoongArch port is still in progress, qemu-user is now available. This PR upgrades qemu to version `8.2.2` and incorporates qemu-user runners for the `loongarch64-unknown-linux-gnu` target.

Close #1467