### PR TITLE
Allow environment variables to contain numbers

### DIFF
--- a/.changes/1481.json
+++ b/.changes/1481.json
@@ -1,0 +1,4 @@
+{
+    "description": "allow pass-through environment variables to contain numbers",
+    "type": "fixed"
+}

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -914,7 +914,7 @@ fn validate_env_var<'a>(
         && !*warned
         && !var
             .chars()
-            .all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '_' ))
+            .all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '_' | '0'..='9'))
     {
         msg_info.warn(format_args!(
             "got {var_type} of \"{var}\" which is not a valid environment variable name. the proper syntax is {var_syntax}"


### PR DESCRIPTION
When environment variable pass-through is used, a warning is displayed if the name of the variable contains a number and the value is taken from the host. For example:
```
[cross] warning: got environment variable of "MY_VAR_AES256" which is not a valid environment variable name. the proper syntax is `passthrough = ["ENVVAR=value"]`
```

The variable is still passed onto the cross container with the value from the host, but the warning is misleading.