### PR TITLE
Fix paths when using `CROSS_CONTAINER_IN_CONTAINER`

### DIFF
--- a/.changes/1483.json
+++ b/.changes/1483.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fix paths when using `CROSS_CONTAINER_IN_CONTAINER`",
+    "type": "fixed"
+}

--- a/src/docker/local.rs
+++ b/src/docker/local.rs
@@ -95,20 +95,25 @@ pub(crate) fn run(
         // Prevent `bin` from being mounted inside the Docker container.
         .args(["-v", &format!("{}/bin", toolchain_dirs.cargo_mount_path())]);
 
+    let host_root = paths.mount_finder.find_mount_path(package_dirs.host_root());
     docker.args([
         "-v",
         &format!(
             "{}:{}{selinux}",
-            package_dirs.host_root().to_utf8()?,
+            host_root.to_utf8()?,
             package_dirs.mount_root()
         ),
     ]);
+
+    let sysroot = paths
+        .mount_finder
+        .find_mount_path(toolchain_dirs.get_sysroot());
     docker
         .args([
             "-v",
             &format!(
                 "{}:{}{selinux_ro}",
-                toolchain_dirs.get_sysroot().to_utf8()?,
+                sysroot.to_utf8()?,
                 toolchain_dirs.sysroot_mount_path()
             ),
         ])


### PR DESCRIPTION
Currently, `MountFinder` is used for almost all paths, rather than only for the host path in bind/volume mounts.

Because of this, `docker build` invocations use the wrong working directory (`/var/lib/docker/.../workdir-path` instead of `/workdir-path`), causing failures for builds that use `pre-build` with a relative file path, and `docker run` invocations use incorrect `-v` arguments (e.g. `/var/lib/docker/.../toolchain-dir:/var/lib/docker/.../toolchain-dir` instead of `/var/lib/docker/.../toolchain-dir:/toolchain-dir`).

This PR fixes those issues by only using `find_path` and `find_mount_path` when necessary.