### PR TITLE
Update `taiki-e/install-action` to `v2`

### DIFF
--- a/.github/actions/cargo-llvm-cov/action.yml
+++ b/.github/actions/cargo-llvm-cov/action.yml
@@ -12,9 +12,9 @@ runs:
   using: composite
   steps:
     - name: Install cargo-llvm-cov
-      uses: taiki-e/install-action@v1
+      uses: taiki-e/install-action@v2
       with:
-        tool: cargo-llvm-cov
+        tool: cargo-llvm-cov@0.5.3
     - run: rustup component add llvm-tools-preview
       shell: bash
     - name: LLVM instrument coverage


### PR DESCRIPTION
Fixes the `cargo-llvm-cov` action breaking on Windows runners since `dtolnay/rust-toolchain` started setting `CARGO_HOME`.

I pinned the `cargo-llvm-cov` version to `0.5.3`, the one currently used, to change as few things as possible.

No changelog entry included, since this only affects CI.