### PR TITLE
Use `/proc/self/mountinfo` as a fallback for `docker inspect` if using `HOSTNAME` fails

### DIFF
--- a/.changes/1485.json
+++ b/.changes/1485.json
@@ -1,0 +1,5 @@
+{
+    "description": "Use `/proc/self/mountinfo` as a fallback for `docker inspect` if using `HOSTNAME` fails",
+    "issues": [1321],
+    "type": "changed"
+}


### PR DESCRIPTION
Fixes #1321.