### PR TITLE
Allow `build-std` to take an array of crate names

### DIFF
--- a/.changes/1488.json
+++ b/.changes/1488.json
@@ -1,0 +1,6 @@
+{
+    "description": "Allow `build-std` to take an array of crate names",
+    "issues": [896],
+    "type": "changed",
+	"breaking": true
+}

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -161,10 +161,10 @@ targets:
 
 ```toml
 [target.aarch64-unknown-linux-gnu]
-build-std = false          # always build the std library. has precedence over xargo
-xargo = false              # disable the use of xargo
-image = "test-image"       # use a different image for the target
-runner = "qemu-user"       # wrapper to run the binary (must be `qemu-system`, `qemu-user`, or `native`).
+build-std = ["core", "alloc"]   # always build the `core` and `alloc` crates from the std library. has precedence over xargo
+xargo = false                   # disable the use of xargo
+image = "test-image"            # use a different image for the target
+runner = "qemu-user"            # wrapper to run the binary (must be `qemu-system`, `qemu-user`, or `native`).
 ```
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ use cli::Args;
 use color_eyre::owo_colors::OwoColorize;
 use color_eyre::{Help, SectionExt};
 use config::Config;
+use cross_toml::BuildStd;
 use rustc::{QualifiedToolchain, Toolchain};
 use rustc_version::Channel;
 use serde::{Deserialize, Serialize, Serializer};
@@ -541,7 +542,7 @@ pub fn run(
             target,
             uses_xargo,
             uses_zig,
-            uses_build_std,
+            build_std,
             zig_version,
             toolchain,
             is_remote,
@@ -586,7 +587,7 @@ pub fn run(
             rustup::setup_components(
                 &target,
                 uses_xargo,
-                uses_build_std,
+                build_std.enabled(),
                 &toolchain,
                 is_nightly,
                 available_targets,
@@ -594,14 +595,8 @@ pub fn run(
                 msg_info,
             )?;
 
-            let filtered_args = get_filtered_args(
-                zig_version,
-                &args,
-                &target,
-                &config,
-                is_nightly,
-                uses_build_std,
-            );
+            let filtered_args =
+                get_filtered_args(zig_version, &args, &target, &config, is_nightly, &build_std);
 
             let needs_docker = args
                 .subcommand
@@ -693,7 +688,7 @@ pub fn get_filtered_args(
     target: &Target,
     config: &Config,
     is_nightly: bool,
-    uses_build_std: bool,
+    build_std: &BuildStd,
 ) -> Vec<String> {
     let add_libc = |triple: &str| add_libc_version(triple, zig_version.as_deref());
     let mut filtered_args = if args
@@ -746,9 +741,16 @@ pub fn get_filtered_args(
     if is_test && config.doctests().unwrap_or_default() && is_nightly {
         filtered_args.push("-Zdoctest-xcompile".to_owned());
     }
-    if uses_build_std {
-        filtered_args.push("-Zbuild-std".to_owned());
+
+    if build_std.enabled() {
+        let mut arg = "-Zbuild-std".to_owned();
+        if let BuildStd::Crates(crates) = build_std {
+            arg.push('=');
+            arg.push_str(&crates.join(","));
+        }
+        filtered_args.push(arg);
     }
+
     filtered_args.extend(args.rest_args.iter().cloned());
     filtered_args
 }
@@ -769,8 +771,8 @@ pub fn setup(
         .clone()
         .or_else(|| config.target(&target_list))
         .unwrap_or_else(|| Target::from(host.triple(), &target_list));
-    let uses_build_std = config.build_std(&target).unwrap_or(false);
-    let uses_xargo = !uses_build_std && config.xargo(&target).unwrap_or(!target.is_builtin());
+    let build_std = config.build_std(&target)?.unwrap_or_default();
+    let uses_xargo = !build_std.enabled() && config.xargo(&target).unwrap_or(!target.is_builtin());
     let uses_zig = config.zig(&target).unwrap_or(false);
     let zig_version = config.zig_version(&target)?;
     let image = match docker::get_image(&config, &target, uses_zig) {
@@ -815,7 +817,7 @@ To override the toolchain mounted in the image, set `target.{target}.image.toolc
         target,
         uses_xargo,
         uses_zig,
-        uses_build_std,
+        build_std,
         zig_version,
         toolchain,
         is_remote,
@@ -830,7 +832,7 @@ pub struct CrossSetup {
     pub target: Target,
     pub uses_xargo: bool,
     pub uses_zig: bool,
-    pub uses_build_std: bool,
+    pub build_std: BuildStd,
     pub zig_version: Option<String>,
     pub toolchain: QualifiedToolchain,
     pub is_remote: bool,


### PR DESCRIPTION
Closes #896.

This is technically a breaking change because arbitrary strings passed to the `CROSS_BUILD_STD` environment variable (e.g. `yes`) are now no longer parsed as truthy values, but rather as a single crate name (or multiple, if containing commas) to pass to `-Zbuild-std` (resulting in e.g. `-Zbuild-std=yes`, which is invalid).
Behaviour remains the same when `CROSS_BUILD_STD` is set to `true`, `false`, or a number that fits in an `i32`.