### PR TITLE
Allow specifying only a tag or subtarget for images in config

### DIFF
--- a/.changes/1491.json
+++ b/.changes/1491.json
@@ -1,0 +1,5 @@
+{
+    "description": "Allow specifying only a tag for images in config",
+    "issues": [1169],
+    "type": "changed"
+}

--- a/.changes/1491.json
+++ b/.changes/1491.json
@@ -1,5 +1,5 @@
 {
-    "description": "Allow specifying only a tag for images in config",
+    "description": "Allow specifying only a tag or subtarget for images in config",
     "issues": [1169],
     "type": "changed"
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,12 @@ search = "<!-- next-url -->"
 replace = "<!-- next-url -->\n\n[Unreleased]: https://github.com/cross-rs/{{crate_name}}/compare/v{{version}}...HEAD"
 exactly = 1
 
+[[package.metadata.release.pre-release-replacements]]
+file = "docs/config_file.md"
+search = "(# Translates to `.*?:).*?(-centos`)"
+replace = "${1}{{version}}$2"
+exactly = 1
+
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"
 bin-dir = "{ bin }{ binary-ext }"

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -234,6 +234,14 @@ image = ":edge"
 image = "@sha256:77db671d8356a64ae72a3e1415e63f547f26d374fbe3c4762c1cd36c7eac7b99"
 ```
 
+You can also specify a subtarget with no tag nor image name:
+
+```toml
+[target.x86_64-unknown-linux-gnu]
+# Translates to `ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.3.0-centos`
+image = "-centos"
+```
+
 The `image` key can also take the toolchains/platforms supported by the image:
 
 ```toml

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -221,6 +221,19 @@ the default one. Normal Docker behavior applies, so:
 - If only `image:latest` is specified, then Docker won't look in Docker Hub.
 - If the tag is omitted, then Docker will use the `latest` tag.
 
+If you specify a tag but no image name, `cross` will use the default image with
+the tag you provided:
+
+```toml
+[target.aarch64-unknown-linux-gnu]
+# Translates to `ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge`
+image = ":edge"
+
+[target.x86_64-unknown-linux-musl]
+# Translates to `ghcr.io/cross-rs/x86_64-unknown-linux-musl@sha256:77db671d8356a64ae72a3e1415e63f547f26d374fbe3c4762c1cd36c7eac7b99`
+image = "@sha256:77db671d8356a64ae72a3e1415e63f547f26d374fbe3c4762c1cd36c7eac7b99"
+```
+
 The `image` key can also take the toolchains/platforms supported by the image:
 
 ```toml

--- a/src/bin/commands/run.rs
+++ b/src/bin/commands/run.rs
@@ -76,7 +76,7 @@ impl Run {
                 }
             };
 
-            let image = image.to_definite_with(&engine, msg_info);
+            let image = image.to_definite_with(&engine, msg_info)?;
 
             let paths = docker::DockerPaths::create(&engine, metadata, cwd, toolchain, msg_info)?;
             let options = docker::DockerOptions::new(

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,10 +41,10 @@ impl<T: PartialEq> PartialEq<(Option<T>, Option<T>)> for ConfVal<T> {
 }
 
 #[derive(Debug)]
-struct Environment(&'static str, Option<HashMap<&'static str, &'static str>>);
+pub(crate) struct Environment(&'static str, Option<HashMap<&'static str, &'static str>>);
 
 impl Environment {
-    fn new(map: Option<HashMap<&'static str, &'static str>>) -> Self {
+    pub(crate) fn new(map: Option<HashMap<&'static str, &'static str>>) -> Self {
         Environment("CROSS", map)
     }
 
@@ -352,7 +352,7 @@ impl Config {
     }
 
     #[cfg(test)]
-    fn new_with(toml: Option<CrossToml>, env: Environment) -> Self {
+    pub(crate) fn new_with(toml: Option<CrossToml>, env: Environment) -> Self {
         Config { toml, env }
     }
 

--- a/src/cross_toml.rs
+++ b/src/cross_toml.rs
@@ -591,7 +591,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::docker::ImagePlatform;
+    use crate::docker::{ImagePlatform, ImageReference};
 
     use super::*;
     use crate::shell;
@@ -741,7 +741,7 @@ mod tests {
                 build_std: None,
                 zig: None,
                 image: Some(PossibleImage {
-                    name: "test-image".to_owned(),
+                    reference: ImageReference::Name("test-image".to_owned()),
                     toolchain: vec![ImagePlatform::from_target(
                         "aarch64-unknown-linux-musl".into(),
                     )?],
@@ -773,7 +773,7 @@ mod tests {
                     enable: None,
                     version: None,
                     image: Some(PossibleImage {
-                        name: "zig:local".to_owned(),
+                        reference: ImageReference::Name("zig:local".to_owned()),
                         toolchain: vec![ImagePlatform::from_target(
                             "aarch64-unknown-linux-gnu".into(),
                         )?],
@@ -939,7 +939,7 @@ mod tests {
             [target.target3]
             xargo = false
             build-std = true
-            image = "test-image3"
+            image = "@sha256:test-image3"
 
             [target.target3.env]
             volumes = ["VOL3_ARG"]
@@ -978,7 +978,7 @@ mod tests {
             [target.target3]
             xargo = false
             build-std = true
-            image = "test-image3"
+            image = "@sha256:test-image3"
 
             [target.target3.env]
             volumes = ["VOL3_ARG"]
@@ -1042,7 +1042,7 @@ mod tests {
         let target3 = &targets[&Target::new_custom("target3")];
         assert_eq!(target3.build_std, Some(BuildStd::Bool(true)));
         assert_eq!(target3.xargo, Some(false));
-        assert_eq!(target3.image, Some(p!("test-image3")));
+        assert_eq!(target3.image, Some(p!("@sha256:test-image3")));
         assert_eq!(target3.pre_build, None);
         assert_eq!(target3.dockerfile, None);
         assert_eq!(target3.env.passthrough, Some(vec![p!("VAR3")]));

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -12,7 +12,9 @@ pub use self::engine::*;
 pub use self::provided_images::PROVIDED_IMAGES;
 pub use self::shared::*;
 
-pub use image::{Architecture, Image, ImagePlatform, Os as ContainerOs, PossibleImage};
+pub use image::{
+    Architecture, Image, ImagePlatform, ImageReference, Os as ContainerOs, PossibleImage,
+};
 
 use std::process::ExitStatus;
 

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -31,6 +31,10 @@ impl ProvidedImage {
     pub fn image_name(&self, repository: &str, tag: &str) -> String {
         image_name(self.name, self.sub, repository, tag)
     }
+
+    pub fn default_image_name(&self) -> String {
+        self.image_name(CROSS_IMAGE, DEFAULT_IMAGE_VERSION)
+    }
 }
 
 pub fn image_name(target: &str, sub: Option<&str>, repository: &str, tag: &str) -> String {

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -5,10 +5,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::{env, fs, time};
 
 use super::custom::{Dockerfile, PreBuild};
-use super::engine::*;
 use super::image::PossibleImage;
 use super::Image;
 use super::PROVIDED_IMAGES;
+use super::{engine::*, ProvidedImage};
 use crate::cargo::CargoMetadata;
 use crate::config::Config;
 use crate::errors::*;
@@ -26,6 +26,11 @@ pub use super::custom::CROSS_CUSTOM_DOCKERFILE_IMAGE_PREFIX;
 pub const CROSS_IMAGE: &str = "ghcr.io/cross-rs";
 // note: this is the most common base image for our images
 pub const UBUNTU_BASE: &str = "ubuntu:20.04";
+pub const DEFAULT_IMAGE_VERSION: &str = if crate::commit_info().is_empty() {
+    env!("CARGO_PKG_VERSION")
+} else {
+    "main"
+};
 
 #[derive(Debug)]
 pub struct DockerOptions {
@@ -1228,23 +1233,30 @@ pub enum GetImageError {
     Other(eyre::Report),
 }
 
-/// Simpler version of [get_image]
-pub fn get_image_name(
+fn get_target_name(target: &Target, uses_zig: bool) -> &str {
+    if uses_zig {
+        "zig"
+    } else {
+        target.triple()
+    }
+}
+
+fn get_user_image(
     config: &Config,
     target: &Target,
     uses_zig: bool,
-) -> Result<String, GetImageError> {
-    if let Some(image) = config.image(target).map_err(GetImageError::Other)? {
-        return Ok(image.name);
+) -> Result<Option<PossibleImage>, GetImageError> {
+    let mut image = config.image(target).map_err(GetImageError::Other)?;
+    if image.is_none() && uses_zig {
+        image = config.zig_image(target).map_err(GetImageError::Other)?;
     }
 
-    let target_name = match uses_zig {
-        true => match config.zig_image(target).map_err(GetImageError::Other)? {
-            Some(image) => return Ok(image.name),
-            None => "zig",
-        },
-        false => target.triple(),
-    };
+    Ok(image)
+}
+
+fn get_provided_images_for_target(
+    target_name: &str,
+) -> Result<Vec<&'static ProvidedImage>, GetImageError> {
     let compatible = PROVIDED_IMAGES
         .iter()
         .filter(|p| p.name == target_name)
@@ -1254,16 +1266,25 @@ pub fn get_image_name(
         return Err(GetImageError::NoCompatibleImages(target_name.to_owned()));
     }
 
-    let version = if crate::commit_info().is_empty() {
-        env!("CARGO_PKG_VERSION")
-    } else {
-        "main"
-    };
+    Ok(compatible)
+}
 
+/// Simpler version of [get_image]
+pub fn get_image_name(
+    config: &Config,
+    target: &Target,
+    uses_zig: bool,
+) -> Result<String, GetImageError> {
+    if let Some(image) = get_user_image(config, target, uses_zig)? {
+        return Ok(image.name);
+    }
+
+    let target_name = get_target_name(target, uses_zig);
+    let compatible = get_provided_images_for_target(target_name)?;
     Ok(compatible
         .first()
         .expect("should not be empty")
-        .image_name(CROSS_IMAGE, version))
+        .default_image_name())
 }
 
 pub fn get_image(
@@ -1271,35 +1292,15 @@ pub fn get_image(
     target: &Target,
     uses_zig: bool,
 ) -> Result<PossibleImage, GetImageError> {
-    if let Some(image) = config.image(target).map_err(GetImageError::Other)? {
+    if let Some(image) = get_user_image(config, target, uses_zig)? {
         return Ok(image);
     }
 
-    let target_name = match uses_zig {
-        true => match config.zig_image(target).map_err(GetImageError::Other)? {
-            Some(image) => return Ok(image),
-            None => "zig",
-        },
-        false => target.triple(),
-    };
-    let compatible = PROVIDED_IMAGES
-        .iter()
-        .filter(|p| p.name == target_name)
-        .collect::<Vec<_>>();
-
-    if compatible.is_empty() {
-        return Err(GetImageError::NoCompatibleImages(target_name.to_owned()));
-    }
-
-    let version = if crate::commit_info().is_empty() {
-        env!("CARGO_PKG_VERSION")
-    } else {
-        "main"
-    };
-
-    let pick = if compatible.len() == 1 {
+    let target_name = get_target_name(target, uses_zig);
+    let compatible = get_provided_images_for_target(target_name)?;
+    let pick = if let [first] = compatible[..] {
         // If only one match, use that
-        compatible.first().expect("should not be empty")
+        first
     } else if compatible
         .iter()
         .filter(|provided| provided.sub.is_none())
@@ -1323,10 +1324,7 @@ pub fn get_image(
                     "candidates: {}",
                     compatible
                         .iter()
-                        .map(|provided| format!(
-                            "\"{}\"",
-                            provided.image_name(CROSS_IMAGE, version)
-                        ))
+                        .map(|provided| format!("\"{}\"", provided.default_image_name()))
                         .collect::<Vec<_>>()
                         .join(", ")
                 )
@@ -1334,12 +1332,12 @@ pub fn get_image(
         ));
     };
 
-    let mut image: PossibleImage = pick.image_name(CROSS_IMAGE, version).into();
-
+    let image_name = pick.default_image_name();
     if pick.platforms.is_empty() {
-        return Err(GetImageError::SpecifiedImageNoPlatform(image.to_string()));
-    };
+        return Err(GetImageError::SpecifiedImageNoPlatform(image_name));
+    }
 
+    let mut image: PossibleImage = image_name.into();
     image.toolchain = pick.platforms.to_vec();
     Ok(image)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -810,7 +810,7 @@ To override the toolchain mounted in the image, set `target.{target}.image.toolc
     };
     let is_remote = docker::Engine::is_remote();
     let engine = docker::Engine::new(None, Some(is_remote), msg_info)?;
-    let image = image.to_definite_with(&engine, msg_info);
+    let image = image.to_definite_with(&engine, msg_info)?;
     toolchain.replace_host(&image.platform);
     Ok(Some(CrossSetup {
         config,


### PR DESCRIPTION
Closes #1169.

Also supports specifying only a hash (`@sha256:...`) or subtarget (`-centos`).