### PR TITLE
Fix `zig.image` precedence

### DIFF
--- a/.changes/1494.json
+++ b/.changes/1494.json
@@ -1,0 +1,5 @@
+{
+    "description": "Fix `zig.image` precedence",
+    "type": "fixed",
+    "breaking": true
+}


### PR DESCRIPTION
Currently, `image` always takes precedence over `zig.image`.
This change makes it so `image` doesn't get used when zig is enabled, even if `zig.image` is unset (and vice versa).

This is a breaking change.