### PR TITLE
Forward unstable feature flags (-Z) to cargo metadata invocations

### DIFF
--- a/src/bin/commands/run.rs
+++ b/src/bin/commands/run.rs
@@ -39,6 +39,7 @@ impl Run {
         let args = Args {
             cargo_args: vec![],
             rest_args: vec![],
+            unstable_features: vec![],
             subcommand: None,
             channel: None,
             target: Some(target.clone()),

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -153,6 +153,13 @@ pub fn cargo_metadata_with_args(
     if let Some(features) = args.map(|a| &a.features).filter(|v| !v.is_empty()) {
         command.args([String::from("--features"), features.join(",")]);
     }
+    if let Some(unstable_features) = args.map(|a| &a.unstable_features).filter(|v| !v.is_empty()) {
+        command.args(
+            unstable_features
+                .iter()
+                .flat_map(|f| [String::from("-Z"), f.to_owned()]),
+        );
+    }
     let output = command.run_and_get_output(msg_info)?;
     if !output.status.success() {
         msg_info.warn("unable to get metadata for package")?;


### PR DESCRIPTION
# The problem

I ran across some issues when using nightly Cargo features such as [`artifacts-dependencies`](https://doc.rust-lang.org/cargo/reference/unstable.html#artifact-dependencies).

Cargo forces users to pass a `-Z bindeps` flag to activate the feature in every cargo command.

Cross already forwards the `+nightly` flag to internal cargo invocations, but it does not forward `-Z` flags.

Consequently, `cargo metadata` always fail for projects using such feature.

This problem would also occur when using other Cargo nightly features.

# Solution

Parse the `-Z` flags and forward them to `cargo metadata`.