### PR TITLE
ci: use node20 in post action

### DIFF
--- a/.github/actions/post/action.yml
+++ b/.github/actions/post/action.yml
@@ -9,6 +9,6 @@ inputs:
     description: 'Post command/script.'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'
   post: 'main.js'


### PR DESCRIPTION
Blog post: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/