### PR TITLE
Fix in docker_inspect_self_mountinfo() fo Gitlab runner

### DIFF
--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -1364,7 +1364,7 @@ fn docker_inspect_self_mountinfo(engine: &Engine, msg_info: &mut MessageInfo) ->
     let container_id = mountinfo
         .lines()
         .filter_map(|s| s.split(' ').nth(3))
-        .filter(|s| s.contains("/docker/"))
+        .filter(|s| s.contains("/docker/") || s.contains("/docker-data/")) // Check for both "/docker/" and "/docker-data/"
         .flat_map(|s| s.split('/'))
         .find(|s| s.len() == 64 && s.as_bytes().iter().all(u8::is_ascii_hexdigit))
         .ok_or_else(|| eyre::eyre!("couldn't find container id in mountinfo"))?;


### PR DESCRIPTION
Crossbuilding in our buildimage on a Gitlab runner failed:
![image](https://github.com/user-attachments/assets/1562fe3f-18ba-4faa-8d2d-e6928cf106dc)

Container ID could not be resolved from /proc/self/mountinfo, because "/docker/" string was expected, but "/docker-data/" provided:
![image](https://github.com/user-attachments/assets/8f0c3355-9352-4fbe-8889-1f9f53f32e8e)

I extended string matching with "/docker-data/" and our pipeline is working again. 