### PR TITLE
Remove a dbg!

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -941,7 +941,7 @@ pub fn toml(metadata: &CargoMetadata, msg_info: &mut MessageInfo) -> Result<Cros
     if let Some(workspace_metadata) = &metadata.metadata {
         let workspace_metadata =
             serde_json::de::from_str::<serde_json::Value>(workspace_metadata.get())?;
-        if let Some(cross) = dbg!(workspace_metadata.get("cross")) {
+        if let Some(cross) = workspace_metadata.get("cross") {
             found = Some(
                 metadata
                     .workspace_root


### PR DESCRIPTION
After following the installation step at https://github.com/cross-rs/cross?tab=readme-ov-file#installation 
I see the following output when running the commands:
```
❯ ccrossbuild --target aarch64-unknown-linux-gnu

[src/lib.rs:944:30] workspace_metadata.get("cross") = None
``` 

which looks like a leftover.