### PR TITLE
Support `linux/arm64/v8` for most Ubuntu-based images

### DIFF
--- a/.changes/1597.json
+++ b/.changes/1597.json
@@ -1,0 +1,4 @@
+{
+  "type": "added",
+  "description": "Add docker platform support for `linux/arm64/v8` target for many Ubuntu-based targets"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,9 +545,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libredox"

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,7 @@ version = 2
 # patched, or we migrated to an MSRV of 1.66.0.
 ignore = [
     "RUSTSEC-2021-0145",
+    "RUSTSEC-2024-0375"
 ]
 
 [bans]

--- a/docker/Dockerfile.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu
@@ -12,10 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-aarch64-linux-gnu \
-    gfortran-aarch64-linux-gnu \
-    libc6-dev-arm64-cross
+ENV CROSS_TOOLCHAIN_PREFIX=aarch64-linux-gnu-
+ENV CROSS_SYSROOT=/usr/aarch64-linux-gnu
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=arm64 TARGET_TRIPLE=aarch64-linux-gnu /apt-cross-essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=arm64 /deny-debian-packages.sh \
@@ -34,8 +35,6 @@ RUN /linux-image.sh aarch64
 COPY linux-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=aarch64-linux-gnu-
-ENV CROSS_SYSROOT=/usr/aarch64-linux-gnu
 ENV CROSS_TARGET_RUNNER="/linux-runner aarch64"
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.arm-unknown-linux-gnueabi
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabi
@@ -15,7 +15,7 @@ FROM cross-base AS build
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabi-
 ENV CROSS_SYSROOT=/usr/arm-linux-gnueabi
 
-COPY essential.sh /
+COPY apt-cross-essential.sh /
 RUN TARGET_ARCH=armel TARGET_TRIPLE=arm-linux-gnueabi /essential.sh
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.arm-unknown-linux-gnueabi
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabi
@@ -10,12 +10,13 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-FROM cross-base as build
+FROM cross-base AS build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-arm-linux-gnueabi \
-    gfortran-arm-linux-gnueabi \
-    libc6-dev-armel-cross
+ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabi-
+ENV CROSS_SYSROOT=/usr/arm-linux-gnueabi
+
+COPY essential.sh /
+RUN TARGET_ARCH=armel TARGET_TRIPLE=arm-linux-gnueabi /essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=armel /deny-debian-packages.sh \
@@ -28,8 +29,6 @@ RUN /qemu.sh arm
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabi-
-ENV CROSS_SYSROOT=/usr/arm-linux-gnueabi
 ENV CROSS_TARGET_RUNNER="/qemu-runner arm"
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.armv5te-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-gnueabi
@@ -12,11 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-arm-linux-gnueabi \
-    gfortran-arm-linux-gnueabi \
-    crossbuild-essential-armel \
-    libc6-dev-armel-cross
+ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabi-
+ENV CROSS_SYSROOT=/usr/arm-linux-gnueabi
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=armel TARGET_TRIPLE=arm-linux-gnueabi /apt-cross-essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=armel /deny-debian-packages.sh \
@@ -29,8 +29,6 @@ RUN /qemu.sh arm
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabi-
-ENV CROSS_SYSROOT=/usr/arm-linux-gnueabi
 ENV CROSS_TARGET_RUNNER="/qemu-runner arm"
 ENV CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_GNUEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_GNUEABI_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabi
@@ -12,10 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get install --assume-yes --no-install-recommends \
-    g++-arm-linux-gnueabi \
-    gfortran-arm-linux-gnueabi \
-    libc6-dev-armel-cross
+ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabi-
+ENV CROSS_SYSROOT=/usr/arm-linux-gnueabi
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=armel TARGET_TRIPLE=arm-linux-gnueabi /apt-cross-essential.sh
 
 COPY qemu.sh /
 RUN /qemu.sh arm
@@ -23,8 +24,6 @@ RUN /qemu.sh arm
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabi-
-ENV CROSS_SYSROOT=/usr/arm-linux-gnueabi
 ENV CROSS_TARGET_RUNNER="/qemu-runner armv7"
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABI_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -10,12 +10,13 @@ RUN /cmake.sh
 COPY xargo.sh /
 RUN /xargo.sh
 
-FROM cross-base as build
+FROM cross-base AS build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-arm-linux-gnueabihf \
-    gfortran-arm-linux-gnueabihf \
-    libc6-dev-armhf-cross
+ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabihf-
+ENV CROSS_SYSROOT=/usr/arm-linux-gnueabihf
+
+COPY essential.sh /
+RUN TARGET_ARCH=armhf TARGET_TRIPLE=arm-linux-gnueabihf /essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=armhf /deny-debian-packages.sh \
@@ -34,8 +35,6 @@ RUN /linux-image.sh armv7
 COPY linux-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabihf-
-ENV CROSS_SYSROOT=/usr/arm-linux-gnueabihf
 ENV CROSS_TARGET_RUNNER="/linux-runner armv7hf"
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -15,7 +15,7 @@ FROM cross-base AS build
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabihf-
 ENV CROSS_SYSROOT=/usr/arm-linux-gnueabihf
 
-COPY essential.sh /
+COPY apt-cross-essential.sh /
 RUN TARGET_ARCH=armhf TARGET_TRIPLE=arm-linux-gnueabihf /essential.sh
 
 COPY deny-debian-packages.sh /

--- a/docker/Dockerfile.i586-unknown-linux-gnu
+++ b/docker/Dockerfile.i586-unknown-linux-gnu
@@ -12,10 +12,8 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-i686-linux-gnu \
-    gfortran-i686-linux-gnu \
-    libc6-dev-i386-cross
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=i386 TARGET_TRIPLE=i686-linux-gnu /apt-cross-essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=i386 /deny-debian-packages.sh \

--- a/docker/Dockerfile.i686-unknown-linux-gnu
+++ b/docker/Dockerfile.i686-unknown-linux-gnu
@@ -12,10 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-i686-linux-gnu \
-    gfortran-i686-linux-gnu \
-    libc6-dev-i386-cross
+ENV CROSS_TOOLCHAIN_PREFIX=i686-linux-gnu-
+ENV CROSS_SYSROOT=/usr/i686-linux-gnu
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=i386 TARGET_TRIPLE=i686-linux-gnu /apt-cross-essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=i386 /deny-debian-packages.sh \
@@ -34,8 +35,6 @@ RUN /linux-image.sh i686
 COPY linux-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=i686-linux-gnu-
-ENV CROSS_SYSROOT=/usr/i686-linux-gnu
 ENV CROSS_TARGET_RUNNER="/linux-runner i686"
 ENV CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.mips-unknown-linux-gnu
+++ b/docker/Dockerfile.mips-unknown-linux-gnu
@@ -12,10 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get install --assume-yes --no-install-recommends \
-    g++-mips-linux-gnu \
-    gfortran-mips-linux-gnu \
-    libc6-dev-mips-cross
+ENV CROSS_TOOLCHAIN_PREFIX=mips-linux-gnu-
+ENV CROSS_SYSROOT=/usr/mips-linux-gnu
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=mips TARGET_TRIPLE=mips-linux-gnu /apt-cross-essential.sh
 
 COPY qemu.sh /
 RUN /qemu.sh mips
@@ -23,8 +24,6 @@ RUN /qemu.sh mips
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=mips-linux-gnu-
-ENV CROSS_SYSROOT=/usr/mips-linux-gnu
 ENV CROSS_TARGET_RUNNER="/qemu-runner mips"
 ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.mips64-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-gnuabi64
@@ -12,10 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-mips64-linux-gnuabi64 \
-    gfortran-mips64-linux-gnuabi64 \
-    libc6-dev-mips64-cross
+ENV CROSS_TOOLCHAIN_PREFIX=mips64-linux-gnuabi64-
+ENV CROSS_SYSROOT=/usr/mips64-linux-gnuabi64
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=mips64 TARGET_TRIPLE=mips64-linux-gnuabi64 /apt-cross-essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=mips64 /deny-debian-packages.sh \
@@ -28,8 +29,6 @@ RUN /qemu.sh mips64
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=mips64-linux-gnuabi64-
-ENV CROSS_SYSROOT=/usr/mips64-linux-gnuabi64
 ENV CROSS_TARGET_RUNNER="/qemu-runner mips64"
 ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
@@ -12,10 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-mips64el-linux-gnuabi64 \
-    gfortran-mips64el-linux-gnuabi64 \
-    libc6-dev-mips64el-cross
+ENV CROSS_TOOLCHAIN_PREFIX=mips64el-linux-gnuabi64-
+ENV CROSS_SYSROOT=/usr/mips64el-linux-gnuabi64
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=mips64el TARGET_TRIPLE=mips64el-linux-gnuabi64 /apt-cross-essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=mips64el /deny-debian-packages.sh \
@@ -34,8 +35,6 @@ RUN /linux-image.sh mips64el
 COPY linux-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=mips64el-linux-gnuabi64-
-ENV CROSS_SYSROOT=/usr/mips64el-linux-gnuabi64
 ENV CROSS_TARGET_RUNNER="/linux-runner mips64el"
 ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_GNUABI64_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.mipsel-unknown-linux-gnu
+++ b/docker/Dockerfile.mipsel-unknown-linux-gnu
@@ -12,10 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-mipsel-linux-gnu \
-    gfortran-mipsel-linux-gnu \
-    libc6-dev-mipsel-cross
+ENV CROSS_TOOLCHAIN_PREFIX=mipsel-linux-gnu-
+ENV CROSS_SYSROOT=/usr/mipsel-linux-gnu
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=mipsel TARGET_TRIPLE=mipsel-linux-gnu /apt-cross-essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=mipsel /deny-debian-packages.sh \
@@ -34,8 +35,6 @@ RUN /linux-image.sh mipsel
 COPY linux-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=mipsel-linux-gnu-
-ENV CROSS_SYSROOT=/usr/mipsel-linux-gnu
 ENV CROSS_TARGET_RUNNER="/linux-runner mipsel"
 ENV CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.powerpc-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc-unknown-linux-gnu
@@ -12,10 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-powerpc-linux-gnu \
-    gfortran-powerpc-linux-gnu \
-    libc6-dev-powerpc-cross
+ENV CROSS_TOOLCHAIN_PREFIX=powerpc-linux-gnu-
+ENV CROSS_SYSROOT=/usr/powerpc-linux-gnu
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=powerpc TARGET_TRIPLE=powerpc-linux-gnu /apt-cross-essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=powerpc /deny-debian-packages.sh \
@@ -34,8 +35,6 @@ RUN /linux-image.sh powerpc
 COPY linux-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=powerpc-linux-gnu-
-ENV CROSS_SYSROOT=/usr/powerpc-linux-gnu
 ENV CROSS_TARGET_RUNNER="/linux-runner powerpc"
 ENV CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.powerpc64-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64-unknown-linux-gnu
@@ -12,10 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-powerpc64-linux-gnu \
-    gfortran-powerpc64-linux-gnu \
-    libc6-dev-ppc64-cross
+ENV CROSS_TOOLCHAIN_PREFIX=powerpc64-linux-gnu-
+ENV CROSS_SYSROOT=/usr/powerpc64-linux-gnu
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=ppc64 TARGET_TRIPLE=powerpc64-linux-gnu /apt-cross-essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=ppc64 /deny-debian-packages.sh \
@@ -34,8 +35,6 @@ RUN /linux-image.sh powerpc64
 COPY linux-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=powerpc64-linux-gnu-
-ENV CROSS_SYSROOT=/usr/powerpc64-linux-gnu
 ENV CROSS_TARGET_RUNNER="/linux-runner powerpc64"
 ENV CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.powerpc64le-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64le-unknown-linux-gnu
@@ -12,10 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-powerpc64le-linux-gnu \
-    gfortran-powerpc64le-linux-gnu \
-    libc6-dev-ppc64el-cross
+ENV CROSS_TOOLCHAIN_PREFIX=powerpc64le-linux-gnu-
+ENV CROSS_SYSROOT=/usr/powerpc64le-linux-gnu
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=ppc64el TARGET_TRIPLE=powerpc64le-linux-gnu /apt-cross-essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=ppc64el /deny-debian-packages.sh \
@@ -34,8 +35,6 @@ RUN /linux-image.sh powerpc64le
 COPY linux-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=powerpc64le-linux-gnu-
-ENV CROSS_SYSROOT=/usr/powerpc64le-linux-gnu
 ENV CROSS_TARGET_RUNNER="/linux-runner powerpc64le"
 ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.riscv64gc-unknown-linux-gnu
+++ b/docker/Dockerfile.riscv64gc-unknown-linux-gnu
@@ -12,10 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    g++-riscv64-linux-gnu \
-    gfortran-riscv64-linux-gnu \
-    libc6-dev-riscv64-cross
+ENV CROSS_TOOLCHAIN_PREFIX=riscv64-linux-gnu-
+ENV CROSS_SYSROOT=/usr/riscv64-linux-gnu
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=riscv64 TARGET_TRIPLE=riscv64-linux-gnu /apt-cross-essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=riscv64 /deny-debian-packages.sh \
@@ -34,8 +35,6 @@ RUN /linux-image.sh riscv64
 COPY linux-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=riscv64-linux-gnu-
-ENV CROSS_SYSROOT=/usr/riscv64-linux-gnu
 ENV CROSS_TARGET_RUNNER="/linux-runner riscv64"
 ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.s390x-unknown-linux-gnu
+++ b/docker/Dockerfile.s390x-unknown-linux-gnu
@@ -12,10 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-s390x-linux-gnu \
-    gfortran-s390x-linux-gnu \
-    libc6-dev-s390x-cross
+ENV CROSS_TOOLCHAIN_PREFIX=s390x-linux-gnu-
+ENV CROSS_SYSROOT=/usr/s390x-linux-gnu
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=s390x TARGET_TRIPLE=s390x-linux-gnu /apt-cross-essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=s390x /deny-debian-packages.sh \
@@ -34,8 +35,6 @@ RUN /linux-image.sh s390x
 COPY linux-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=s390x-linux-gnu-
-ENV CROSS_SYSROOT=/usr/s390x-linux-gnu
 ENV CROSS_TARGET_RUNNER="/linux-runner s390x"
 ENV CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.sparc64-unknown-linux-gnu
+++ b/docker/Dockerfile.sparc64-unknown-linux-gnu
@@ -12,8 +12,14 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
+ENV CROSS_TOOLCHAIN_PREFIX=sparc64-linux-gnu-
+ENV CROSS_SYSROOT=/usr/sparc64-linux-gnu
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=sparc64 TARGET_TRIPLE=sparc64-linux-gnu /apt-cross-essential.sh
+
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-sparc64-linux-gnu \
+    g++- \
     gfortran-sparc64-linux-gnu \
     libc6-dev-sparc64-cross
 
@@ -34,8 +40,6 @@ RUN /linux-image.sh sparc64
 COPY linux-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=sparc64-linux-gnu-
-ENV CROSS_SYSROOT=/usr/sparc64-linux-gnu
 ENV CROSS_TARGET_RUNNER="/linux-runner sparc64"
 ENV CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_SPARC64_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.thumbv7neon-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.thumbv7neon-unknown-linux-gnueabihf
@@ -12,10 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-arm-linux-gnueabihf \
-    gfortran-arm-linux-gnueabihf \
-    libc6-dev-armhf-cross
+ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabihf-
+ENV CROSS_SYSROOT=/usr/arm-linux-gnueabihf
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=armhf TARGET_TRIPLE=arm-linux-gnueabihf /apt-cross-essential.sh
 
 COPY qemu.sh /
 RUN /qemu.sh arm softmmu
@@ -30,8 +31,6 @@ COPY linux-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
 # Export all target binutils just in case required.
-ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-gnueabihf-
-ENV CROSS_SYSROOT=/usr/arm-linux-gnueabihf
 ENV CROSS_TARGET_RUNNER="/linux-runner armv7hf"
 ENV CARGO_TARGET_THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_THUMBV7NEON_UNKNOWN_LINUX_GNUEABIHF_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/Dockerfile.x86_64-unknown-linux-gnu
+++ b/docker/Dockerfile.x86_64-unknown-linux-gnu
@@ -12,10 +12,11 @@ RUN /xargo.sh
 
 FROM cross-base as build
 
-RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-    g++-x86-64-linux-gnu \
-    gfortran-x86-64-linux-gnu \
-    libc6-dev-amd64-cross
+ENV CROSS_TOOLCHAIN_PREFIX=x86_64-linux-gnu-
+ENV CROSS_SYSROOT=/usr/x86_64-linux-gnu
+
+COPY apt-cross-essential.sh /
+RUN TARGET_ARCH=amd64 TARGET_TRIPLE=x86-64-linux-gnu /apt-cross-essential.sh
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=amd64 /deny-debian-packages.sh \
@@ -34,8 +35,6 @@ RUN /linux-image.sh x86_64
 COPY linux-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
-ENV CROSS_TOOLCHAIN_PREFIX=x86_64-linux-gnu-
-ENV CROSS_SYSROOT=/usr/x86_64-linux-gnu
 ENV CROSS_TARGET_RUNNER="/linux-runner x86_64"
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \

--- a/docker/apt-cross-essential.sh
+++ b/docker/apt-cross-essential.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -x
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. lib.sh
+
+main() {
+    local narch
+    local -a packages
+
+    narch="$(dpkg --print-architecture)"
+    packages+=("libc6-dev-${TARGET_ARCH}-cross:${narch}" "crossbuild-essential-${TARGET_ARCH}:${narch}")
+
+    if ! command -v "${CROSS_TOOLCHAIN_PREFIX}g++" &>/dev/null; then
+      packages+=("g++-${TARGET_TRIPLE}:${narch}")
+    fi
+
+    if ! command -v "${CROSS_TOOLCHAIN_PREFIX}gfortran" &>/dev/null; then
+      packages+=("gfortran-${TARGET_TRIPLE}:${narch}")
+    fi
+
+    install_packages "${packages[@]}"
+
+    rm "${0}"
+}
+
+main "${@}"

--- a/docker/cmake.sh
+++ b/docker/cmake.sh
@@ -13,11 +13,33 @@ main() {
 
     local td
     td="$(mktemp -d)"
-
     pushd "${td}"
 
-    curl --retry 3 -sSfL "https://github.com/Kitware/CMake/releases/download/v${version}/cmake-${version}-linux-x86_64.sh" -o cmake.sh
+    local cmake_arch
+    local cmake_sha256
+
+    local narch
+    narch="$(dpkg --print-architecture)"
+
+    case "${narch}" in
+        amd64)
+            cmake_arch="linux-x86_64"
+            cmake_sha256="da2a9b18c3bfb136917fa1a579aa5316b01c1d6c111043d03f18877ff05bda30"
+            ;;
+        arm64)
+            cmake_arch="linux-aarch64"
+            cmake_sha256="86122bdfd030208aa36705ef421a218ccec52a14368020b2d67043af5e45490b"
+            ;;
+        *)
+            echo "Unsupported architecture: ${narch}" 1>&2
+            exit 1
+            ;;
+     esac
+
+    curl --retry 3 -sSfL "https://github.com/Kitware/CMake/releases/download/v${version}/cmake-${version}-${cmake_arch}.sh" -o cmake.sh
+    sha256sum --check <<<"${cmake_sha256}  cmake.sh"
     sh cmake.sh --skip-license --prefix=/usr/local
+    cmake --version
 
     popd
 

--- a/docker/common.sh
+++ b/docker/common.sh
@@ -6,12 +6,19 @@ set -euo pipefail
 # shellcheck disable=SC1091
 . lib.sh
 
-# For architectures except amd64 and i386, look for packages on ports.ubuntu.com instead.
+# For non-native architectures, look for packages on ports.ubuntu.com instead.
 # This is important if you enable additional architectures so you can install libraries to cross-compile against.
 # Look for 'dpkg --add-architecture' in the README for more details.
 if grep -i ubuntu /etc/os-release >/dev/null; then
-    sed 's/http:\/\/\(.*\).ubuntu.com\/ubuntu\//[arch-=amd64,i386] http:\/\/ports.ubuntu.com\/ubuntu-ports\//g' /etc/apt/sources.list > /etc/apt/sources.list.d/ports.list
-    sed -i 's/http:\/\/\(.*\).ubuntu.com\/ubuntu\//[arch=amd64,i386] http:\/\/\1.archive.ubuntu.com\/ubuntu\//g' /etc/apt/sources.list
+    NATIVE_ARCH=$(dpkg --print-architecture)
+
+    if [ "$NATIVE_ARCH" = "amd64" ]; then
+        sed 's/http:\/\/\(.*\).ubuntu.com\/ubuntu\//[arch-=amd64,i386] http:\/\/ports.ubuntu.com\/ubuntu-ports\//g' /etc/apt/sources.list > /etc/apt/sources.list.d/ports.list
+        sed -i 's/http:\/\/\(.*\).ubuntu.com\/ubuntu\//[arch=amd64,i386] http:\/\/\1.archive.ubuntu.com\/ubuntu\//g' /etc/apt/sources.list
+    else
+        sed -i "s/http:\/\/\(.*\).ubuntu.com\/ubuntu\//[arch-=${NATIVE_ARCH}] http:\/\/ports.ubuntu.com\/ubuntu-ports\//g" /etc/apt/sources.list
+        sed -i "s/http:\/\/\(.*\).ubuntu.com\/ubuntu\//[arch=${NATIVE_ARCH}] http:\/\/\1.archive.ubuntu.com\/ubuntu\//g" /etc/apt/sources.list
+    fi
 fi
 
 install_packages \

--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -57,7 +57,7 @@ max_kernel_version() {
 main() {
     # arch in the rust target
     local arch="${1}" \
-        kversion=5.10.0-26
+        kversion=5.10.0-27
 
     local debsource="deb http://http.debian.net/debian/ bullseye main"
     debsource="${debsource}\ndeb http://security.debian.org/ bullseye-security main"
@@ -424,7 +424,7 @@ EOF
 
     # need to reinstall the removed libgcc packages, which are required for apt
     if [[ "${arch}" == "${dpkg_arch}" ]]; then
-        apt-get install --no-install-recommends --assume-yes "${packages[@]}"
+        apt-get install --no-install-recommends --assume-yes "${libgcc_packages[@]}"
     fi
 
     purge_packages

--- a/docker/qemu.sh
+++ b/docker/qemu.sh
@@ -19,7 +19,7 @@ build_static_libffi () {
     tar --strip-components=1 -xzf "v${version}.tar.gz"
     ./configure --prefix="$td"/lib --disable-builddir --disable-shared --enable-static
     make "-j$(nproc)"
-    install -m 644 ./.libs/libffi.a /usr/lib64/
+    install -m 644 ./.libs/libffi.a /usr/local/lib/
 
     popd
 
@@ -42,7 +42,7 @@ build_static_libmount () {
     tar --strip-components=1 -xJf "util-linux-${version_spec}.tar.xz"
     ./configure --disable-shared --enable-static --without-ncurses
     make "-j$(nproc)" mount blkid
-    install -m 644 ./.libs/*.a /usr/lib64/
+    install -m 644 ./.libs/*.a /usr/local/lib/
 
     popd
 
@@ -67,7 +67,7 @@ build_static_libattr() {
 
     ./configure
     make "-j$(nproc)"
-    install -m 644 ./libattr/.libs/libattr.a /usr/lib64/
+    install -m 644 ./libattr/.libs/libattr.a /usr/local/lib/
 
     yum remove -y gettext
 
@@ -87,7 +87,7 @@ build_static_libcap() {
     curl --retry 3 -sSfL "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-${version}.tar.xz" -O
     tar --strip-components=1 -xJf "libcap-${version}.tar.xz"
     make "-j$(nproc)"
-    install -m 644 libcap/libcap.a /usr/lib64/
+    install -m 644 libcap/libcap.a /usr/local/lib/
 
     popd
 
@@ -106,7 +106,7 @@ build_static_pixman() {
     tar --strip-components=1 -xzf "pixman-${version}.tar.gz"
     ./configure
     make "-j$(nproc)"
-    install -m 644 ./pixman/.libs/libpixman-1.a /usr/lib64/
+    install -m 644 ./pixman/.libs/libpixman-1.a /usr/local/lib/
 
     popd
 
@@ -125,7 +125,7 @@ build_static_slirp() {
     tar -xzf "libslirp-v${version}.tar.gz"
     meson setup -Ddefault_library=static libslirp-v${version} build
     ninja -C build
-    install -m 644 ./build/libslirp.a /usr/lib64/
+    install -m 644 ./build/libslirp.a /usr/local/lib/
 
     popd
 

--- a/xtask/src/codegen.rs
+++ b/xtask/src/codegen.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use cross::docker::ImagePlatform;
 use eyre::Context;
 use std::fmt::Write;
 
@@ -39,10 +40,12 @@ pub static PROVIDED_IMAGES: &[ProvidedImage] = &["#,
                 .platforms()
                 .iter()
                 .map(|p| {
-                    format!(
-                        "ImagePlatform::{}",
-                        p.replace('-', "_").to_ascii_uppercase()
-                    )
+                    let image_platform: ImagePlatform =
+                        p.parse().expect("should be a valid platform");
+
+                    image_platform
+                        .to_codegen_string()
+                        .expect("should be a valid platform")
                 })
                 .collect::<Vec<_>>()
                 .join(", "),


### PR DESCRIPTION
Previously, many images only provided `linux/amd64` builds, which meant that Apple silicon folks were left to Rosetta or qemu emulation when cross-compiling. Although Rosetta's `x86_64` emulation is a remarkable feat of engineering, nothing beats the performance of using the `linux/arm64/v8` on Apple silicon.

This PR adds support to a bunch of Ubuntu-based images for `linux/arm64/v8` builds. I haven't been able to build all of them yet... mostly just tested the `x86_64-unknown-linux-gnu` container. But I plan to squash any issues that arise from CI. Theoretically, it shouldn't be too hard since the core logic is the same across all images.

### New Platforms Supported

- `aarch64-unknown-linux-gnu`
- `armv5te-unknown-linux-gnueabi`
- `armv7-unknown-linux-gnueabi`
- `i586-unknown-linux-gnu`
- `i686-unknown-linux-gnu`
- `mips-unknown-linux-gnu`
- `mips64-unknown-linux-gnuabi64`
- `mips64el-unknown-linux-gnuabi64`
- `mipsel-unknown-linux-gnu`
- `powerpc-unknown-linux-gnu`
- `powerpc64-unknown-linux-gnu`
- `powerpc64le-unknown-linux-gnu`
- `riscv64gc-unknown-linux-gnu`
- `s390x-unknown-linux-gnu`
- `sparc64-unknown-linux-gnu`
- `thumbv7neon-unknown-linux-gnueabihf`
- `x86_64-unknown-linux-gnu`