### PR TITLE
Update emsdk to 3.1.74

### DIFF
--- a/.changes/1610.json
+++ b/.changes/1610.json
@@ -1,0 +1,5 @@
+{
+    "description": "update emsdk to 3.1.74.",
+    "type": "changed",
+    "breaking": false
+}

--- a/docker/Dockerfile.wasm32-unknown-emscripten
+++ b/docker/Dockerfile.wasm32-unknown-emscripten
@@ -1,4 +1,4 @@
-FROM emscripten/emsdk:3.1.14
+FROM emscripten/emsdk:3.1.74
 WORKDIR /
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -12,8 +12,7 @@ COPY xargo.sh /
 RUN /xargo.sh
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
-  libxml2 \
-  python
+    libxml2
 
 ENV CROSS_TOOLCHAIN_PREFIX=em
 ENV CROSS_SYSROOT=/emsdk/upstream/emscripten/cache/sysroot


### PR DESCRIPTION
Some of the latest rustc updates (not sure which) have at the very least broken panics when running on Node 14, which the old emsdk version uses. As such, update the base container.

This also removes an unused (AFAIK) Python dependency.