### PR TITLE
Update owo-colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,17 +90,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,7 +215,7 @@ dependencies = [
  "eyre",
  "indenter",
  "once_cell",
- "owo-colors",
+ "owo-colors 3.5.0",
  "tracing-error",
 ]
 
@@ -237,7 +226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
 dependencies = [
  "once_cell",
- "owo-colors",
+ "owo-colors 3.5.0",
  "tracing-core",
  "tracing-error",
 ]
@@ -277,7 +266,7 @@ dependencies = [
  "libc",
  "nix",
  "once_cell",
- "owo-colors",
+ "owo-colors 4.1.0",
  "regex",
  "rustc_version",
  "semver",
@@ -428,15 +417,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -511,7 +491,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys",
 ]
@@ -626,8 +606,15 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "owo-colors"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 dependencies = [
- "supports-color",
+ "supports-color 2.1.0",
+ "supports-color 3.0.2",
 ]
 
 [[package]]
@@ -840,11 +827,20 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "supports-color"
-version = "1.3.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
 dependencies = [
- "atty",
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
  "is_ci",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ signal-hook = { version = "0.3.15" }
 directories = "4.0.1"
 walkdir = { version = "2.3.2", optional = true }
 tempfile = "3.3.0"
-owo-colors = { version = "3.5.0", features = ["supports-colors"] }
+owo-colors = { version = "4.0", features = ["supports-colors"] }
 semver = "1.0.16"
 is_ci = "1.1.1"
 

--- a/deny.toml
+++ b/deny.toml
@@ -9,11 +9,6 @@ targets = [
 
 [advisories]
 version = 2
-# FIXME: remove this if/when clap changes to is-terminal, atty is
-# patched, or we migrated to an MSRV of 1.66.0.
-ignore = [
-    "RUSTSEC-2021-0145",
-]
 
 [bans]
 multiple-versions = "deny"

--- a/src/bin/commands/containers.rs
+++ b/src/bin/commands/containers.rs
@@ -3,8 +3,9 @@ use std::io;
 use clap::{Args, Subcommand};
 use cross::docker::ImagePlatform;
 use cross::rustc::{QualifiedToolchain, Toolchain};
-use cross::shell::{MessageInfo, Stream};
+use cross::shell::MessageInfo;
 use cross::{docker, CommandExt, TargetTriple};
+use is_terminal::IsTerminal;
 
 #[derive(Args, Debug)]
 pub struct ListVolumes {
@@ -327,7 +328,8 @@ pub fn create_persistent_volume(
     docker.arg("--rm");
     docker.args(["-v", &format!("{}:{}", volume_id, mount_prefix)]);
     docker.arg("-d");
-    let is_tty = io::Stdin::is_atty() && io::Stdout::is_atty() && io::Stderr::is_atty();
+    let is_tty =
+        io::stdin().is_terminal() && io::stdout().is_terminal() && io::stderr().is_terminal();
     if is_tty {
         docker.arg("-t");
     }

--- a/src/docker/local.rs
+++ b/src/docker/local.rs
@@ -7,8 +7,9 @@ use super::shared::*;
 use crate::errors::Result;
 use crate::extensions::CommandExt;
 use crate::file::{PathExt, ToUtf8};
-use crate::shell::{MessageInfo, Stream};
+use crate::shell::MessageInfo;
 use eyre::Context;
+use is_terminal::IsTerminal;
 
 // NOTE: host path must be absolute
 fn mount(
@@ -136,7 +137,7 @@ pub(crate) fn run(
         ]);
     }
 
-    if io::Stdin::is_atty() && io::Stdout::is_atty() && io::Stderr::is_atty() {
+    if io::stdin().is_terminal() && io::stdout().is_terminal() && io::stderr().is_terminal() {
         docker.arg("-t");
     }
 

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -5,6 +5,7 @@ use std::process::{Command, ExitStatus};
 use std::{env, fs, time};
 
 use eyre::Context;
+use is_terminal::IsTerminal;
 
 use super::engine::Engine;
 use super::shared::*;
@@ -13,7 +14,7 @@ use crate::errors::Result;
 use crate::extensions::CommandExt;
 use crate::file::{self, PathExt, ToUtf8};
 use crate::rustc::{self, QualifiedToolchain, VersionMetaExt};
-use crate::shell::{MessageInfo, Stream};
+use crate::shell::MessageInfo;
 use crate::temp;
 use crate::TargetTriple;
 
@@ -774,7 +775,8 @@ pub(crate) fn run(
     }
 
     docker.arg("-d");
-    let is_tty = io::Stdin::is_atty() && io::Stdout::is_atty() && io::Stderr::is_atty();
+    let is_tty =
+        io::stdin().is_terminal() && io::stdout().is_terminal() && io::stderr().is_terminal();
     if is_tty {
         docker.arg("-t");
     }


### PR DESCRIPTION
The goal here is to remove a transitive dependency on the deprecated `atty` crate, which trips `cargo deny` because it's unmaintained.

This currently does not eliminate the dependency completely, as we're still waiting on `color-eyre` to release [1], and merging this PR as-is would result in `cargo deny` being even more angry at using different versions of the same crate, so this PR is a draft for now.

The update is non-trivial because `owo-colors` no longer supports checking whether stdin supports colors, which is, well, reasonable.

Semantically, this cements the `Stream` trait as something that can be printed onto, rather than a generic-purpose stream. Uses of `as_tty` are replaced with a direct call to the `std` `is_terminal` function, and `Stream` (now called `OwoStream`) now exclusively handles mapping `std` I/O streams to `owo-colors` streams.

[1]: https://github.com/eyre-rs/eyre/issues/215