### PR TITLE
don't look at `package.metadata.cross` when the package isn't part of the current workspace

### DIFF
--- a/.changes/1623.json
+++ b/.changes/1623.json
@@ -1,0 +1,4 @@
+{
+    "type": "fixed",
+    "description": "fixed an issue where cross would look for metadata.cross outside the workspace"
+  }

--- a/deny.toml
+++ b/deny.toml
@@ -9,10 +9,11 @@ targets = [
 
 [advisories]
 version = 2
-# FIXME: remove this if/when clap changes to is-terminal, atty is
-# patched, or we migrated to an MSRV of 1.66.0.
 ignore = [
+    # FIXME: remove this if/when clap changes to is-terminal, atty is
+    # patched, or we migrated to an MSRV of 1.66.0.
     "RUSTSEC-2021-0145",
+    "RUSTSEC-2024-0375"
 ]
 
 [bans]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -959,6 +959,7 @@ pub fn toml(metadata: &CargoMetadata, msg_info: &mut MessageInfo) -> Result<Cros
     for (package, package_metadata) in metadata
         .packages
         .iter()
+        .filter(|p| metadata.workspace_members.contains(&p.id))
         .filter_map(|p| Some((p.manifest_path.as_path(), p.metadata.as_deref()?)))
     {
         let package_metadata =


### PR DESCRIPTION
resolves #1619 