### PR TITLE
Bump ct-ng to 1.27.0

### DIFF
--- a/.changes/1625.json
+++ b/.changes/1625.json
@@ -1,0 +1,4 @@
+{
+    "description": "bump ct-ng to 1.27.0",
+    "type": "changed"
+}

--- a/docker/Dockerfile.loongarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.loongarch64-unknown-linux-gnu
@@ -15,7 +15,7 @@ FROM cross-base as build
 ARG VERBOSE
 COPY crosstool-ng.sh /
 COPY crosstool-config/loongarch64-unknown-linux-gnu.config /
-RUN /crosstool-ng.sh loongarch64-unknown-linux-gnu.config 5 ed12fa68402f58e171a6f79500f73f4781fdc9e5
+RUN /crosstool-ng.sh loongarch64-unknown-linux-gnu.config 5
 
 ENV PATH /x-tools/loongarch64-unknown-linux-gnu/bin/:$PATH
 

--- a/docker/Dockerfile.loongarch64-unknown-linux-musl
+++ b/docker/Dockerfile.loongarch64-unknown-linux-musl
@@ -15,7 +15,7 @@ FROM cross-base as build
 ARG VERBOSE
 COPY crosstool-ng.sh /
 COPY crosstool-config/loongarch64-unknown-linux-musl.config /
-RUN /crosstool-ng.sh loongarch64-unknown-linux-musl.config 5 ed12fa68402f58e171a6f79500f73f4781fdc9e5
+RUN /crosstool-ng.sh loongarch64-unknown-linux-musl.config 5
 
 ENV PATH /x-tools/loongarch64-unknown-linux-musl/bin/:$PATH
 

--- a/docker/crosstool-ng.sh
+++ b/docker/crosstool-ng.sh
@@ -17,7 +17,7 @@ silence_stdout() {
 main() {
     local config="${1}"
     local nproc="${2}"
-    local ctng_version=${3:-crosstool-ng-1.26.0}
+    local ctng_version=${3:-crosstool-ng-1.27.0}
     local ctng_url="https://github.com/crosstool-ng/crosstool-ng"
     local username=crosstool
     local crosstooldir=/opt/crosstool


### PR DESCRIPTION
Bump ct-ng to [1.27.0](https://github.com/crosstool-ng/crosstool-ng/releases/tag/crosstool-ng-1.27.0).