### PR TITLE
Fix illumos BINDGEN_EXTRA_CLANG_ARGS

### DIFF
--- a/.changes/1651.json
+++ b/.changes/1651.json
@@ -1,0 +1,6 @@
+{
+    "description": "Fix BINDGEN_EXTRA_CLANG_ARGS for x86_64-unknown-illumos",
+    "issues": [1644],
+    "type": "fixed",
+    "breaking": false
+}

--- a/docker/Dockerfile.x86_64-unknown-illumos
+++ b/docker/Dockerfile.x86_64-unknown-illumos
@@ -22,7 +22,7 @@ ENV PATH=$PATH:/usr/local/x86_64-unknown-illumos/bin/ \
     CC_x86_64_unknown_illumos="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CXX_x86_64_unknown_illumos="$CROSS_TOOLCHAIN_PREFIX"g++ \
     CMAKE_TOOLCHAIN_FILE_x86_64_unknown_illumos=/opt/toolchain.cmake \
-    BINDGEN_EXTRA_CLANG_ARGS_sparcv9_sun_solaris="--sysroot=$CROSS_SYSROOT" \
+    BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_illumos="--sysroot=$CROSS_SYSROOT" \
     CROSS_CMAKE_SYSTEM_NAME=illumos \
     CROSS_CMAKE_SYSTEM_PROCESSOR=x86_64 \
     CROSS_CMAKE_CRT=solaris \


### PR DESCRIPTION
Hello! The Docker image for `x86_64-unknown-illumos` specifies a `BINDGEN_EXTRA_CLANG_ARGS` variable for `sparcv9_sun_solaris`. I noticed while working on this PR: https://github.com/aws/aws-lc-rs/pull/709

This commit updates the name of the variable to match the intended target.