### PR TITLE
feat: add riscv64gc-unknown-linux-musl image

### DIFF
--- a/.changes/1664.json
+++ b/.changes/1664.json
@@ -1,0 +1,5 @@
+{
+    "type": "added",
+    "description": "add riscv64gc-unknown-linux-musl support",
+    "issues": [1197]
+}

--- a/.github/ISSUE_TEMPLATE/b_issue_report.yml
+++ b/.github/ISSUE_TEMPLATE/b_issue_report.yml
@@ -66,6 +66,7 @@ body:
         - powerpc64-unknown-linux-gnu
         - powerpc-unknown-linux-gnu
         - riscv64gc-unknown-linux-gnu
+        - riscv64gc-unknown-linux-musl
         - s390x-unknown-linux-gnu
         - sparc64-unknown-linux-gnu
         - sparcv9-sun-solaris

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ terminate.
 | `powerpc64-unknown-linux-gnu`          | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
 | `powerpc64le-unknown-linux-gnu`        | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
 | `riscv64gc-unknown-linux-gnu`          | 2.35   | 11.4.0 | ✓   | 8.2.2 |   ✓    |
+| `riscv64gc-unknown-linux-musl`         | 1.2.5  | 14.2.0 | ✓   | 8.2.2 |   ✓    |
 | `s390x-unknown-linux-gnu`              | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
 | `sparc64-unknown-linux-gnu`            | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
 | `sparcv9-sun-solaris`                  | 1.22.7 | 8.4.0  | ✓   | N/A   |        |

--- a/docker/Dockerfile.riscv64gc-unknown-linux-musl
+++ b/docker/Dockerfile.riscv64gc-unknown-linux-musl
@@ -1,0 +1,50 @@
+FROM ubuntu:24.04 AS cross-base
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY common.sh lib.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+FROM cross-base AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bzip2 \
+    adduser
+
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/riscv64gc-unknown-linux-musl.config /
+RUN /crosstool-ng.sh riscv64gc-unknown-linux-musl.config 5
+
+ENV PATH=/x-tools/riscv64-unknown-linux-musl/bin/:$PATH
+
+COPY qemu.sh /
+RUN /qemu.sh riscv64
+
+COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
+
+ENV CROSS_TOOLCHAIN_PREFIX=riscv64-unknown-linux-musl-
+ENV CROSS_SYSROOT=/x-tools/riscv64-unknown-linux-musl/riscv64-unknown-linux-musl/sysroot/
+
+ENV CROSS_TARGET_RUNNER="/qemu-runner riscv64"
+ENV CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
+    CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_RUNNER="$CROSS_TARGET_RUNNER" \
+    AR_riscv64gc_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"ar \
+    CC_riscv64gc_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"gcc \
+    CXX_riscv64gc_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_riscv64gc_unknown_linux_musl=/opt/toolchain.cmake \
+    BINDGEN_EXTRA_CLANG_ARGS_riscv64gc_unknown_linux_musl="--sysroot=$CROSS_SYSROOT" \
+    QEMU_LD_PREFIX="$CROSS_SYSROOT" \
+    RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=riscv64gc \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -march=rv64gc -mabi=lp64d -mcmodel=medany"
+
+RUN sed -e "s#@DEFAULT_QEMU_LD_PREFIX@#$QEMU_LD_PREFIX#g" -i /qemu-runner

--- a/docker/crosstool-config/riscv64gc-unknown-linux-musl.config
+++ b/docker/crosstool-config/riscv64gc-unknown-linux-musl.config
@@ -1,0 +1,38 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_RISCV=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_ARCH="rv64g"
+CT_ARCH_64=y
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.2.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y
+

--- a/src/docker/provided_images.rs
+++ b/src/docker/provided_images.rs
@@ -109,6 +109,11 @@ pub static PROVIDED_IMAGES: &[ProvidedImage] = &[
             sub: None
         },
         ProvidedImage {
+            name: "riscv64gc-unknown-linux-musl",
+            platforms: &[ImagePlatform::X86_64_UNKNOWN_LINUX_GNU],
+            sub: None
+        },
+        ProvidedImage {
             name: "s390x-unknown-linux-gnu",
             platforms: &[ImagePlatform::X86_64_UNKNOWN_LINUX_GNU],
             sub: None

--- a/targets.toml
+++ b/targets.toml
@@ -228,6 +228,15 @@ run = true
 runners = "qemu-user qemu-system"
 
 [[target]]
+target = "riscv64gc-unknown-linux-musl"
+os = "ubuntu-latest"
+cpp = true
+dylib = true
+std = true
+run = true
+runners = "qemu-user"
+
+[[target]]
 target = "s390x-unknown-linux-gnu"
 os = "ubuntu-latest"
 cpp = true


### PR DESCRIPTION
Close #1197

* * *

Only use crosstools-ng

If use [musl-cross-make](https://github.com/richfelker/musl-cross-make), `binutils` version is to low too `ld` cannot link in riscv

I test [musl.cc](http://musl.cc/) [riscv64-linux-musl-cross.tgz](http://musl.cc/riscv64-linux-musl-cross.tgz), It's ok `binutils: 2.37`, `ld` can link, It's working

But, `musl-cross-make` is only support `binutils: 2.33.1`, `binutils: 2.33.2` is big changed, The patch is unavailable, migration this patch is very complex (a lot of conflict). BTW: These patches have nothing to do with riscv