### PR TITLE
fix Dockerfile warn LegacyKeyValueFormat ENV key value => ENV key=value

### DIFF
--- a/docker/Dockerfile.arm-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabihf
@@ -17,7 +17,7 @@ COPY crosstool-ng.sh /
 COPY crosstool-config/arm-unknown-linux-gnueabihf.config /
 RUN /crosstool-ng.sh arm-unknown-linux-gnueabihf.config 5
 
-ENV PATH /x-tools/arm-unknown-linux-gnueabihf/bin/:$PATH
+ENV PATH=/x-tools/arm-unknown-linux-gnueabihf/bin/:$PATH
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=armhf /deny-debian-packages.sh

--- a/docker/Dockerfile.loongarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.loongarch64-unknown-linux-gnu
@@ -17,7 +17,7 @@ COPY crosstool-ng.sh /
 COPY crosstool-config/loongarch64-unknown-linux-gnu.config /
 RUN /crosstool-ng.sh loongarch64-unknown-linux-gnu.config 5
 
-ENV PATH /x-tools/loongarch64-unknown-linux-gnu/bin/:$PATH
+ENV PATH=/x-tools/loongarch64-unknown-linux-gnu/bin/:$PATH
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=loong64 /deny-debian-packages.sh

--- a/docker/Dockerfile.loongarch64-unknown-linux-musl
+++ b/docker/Dockerfile.loongarch64-unknown-linux-musl
@@ -17,7 +17,7 @@ COPY crosstool-ng.sh /
 COPY crosstool-config/loongarch64-unknown-linux-musl.config /
 RUN /crosstool-ng.sh loongarch64-unknown-linux-musl.config 5
 
-ENV PATH /x-tools/loongarch64-unknown-linux-musl/bin/:$PATH
+ENV PATH=/x-tools/loongarch64-unknown-linux-musl/bin/:$PATH
 
 COPY deny-debian-packages.sh /
 RUN TARGET_ARCH=loong64 /deny-debian-packages.sh


### PR DESCRIPTION
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 20) https://docs.docker.com/reference/build-checks/legacy-key-value-format/