### PR TITLE
[RFC] Shrink musl docker image size by ~50%

### DIFF
--- a/docker/Dockerfile.aarch64-unknown-linux-musl
+++ b/docker/Dockerfile.aarch64-unknown-linux-musl
@@ -18,6 +18,13 @@ RUN /qemu.sh aarch64
 COPY musl.sh /
 RUN /musl.sh TARGET=aarch64-linux-musl
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+
 ENV CROSS_TOOLCHAIN_PREFIX=aarch64-linux-musl-
 ENV CROSS_SYSROOT=/usr/local/aarch64-linux-musl
 COPY musl-symlink.sh /

--- a/docker/Dockerfile.arm-unknown-linux-musleabi
+++ b/docker/Dockerfile.arm-unknown-linux-musleabi
@@ -22,6 +22,13 @@ RUN /musl.sh \
                       --with-float=soft \
                       --with-mode=arm"
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-musleabi-
 ENV CROSS_SYSROOT=/usr/local/arm-linux-musleabi
 COPY musl-symlink.sh /

--- a/docker/Dockerfile.arm-unknown-linux-musleabihf
+++ b/docker/Dockerfile.arm-unknown-linux-musleabihf
@@ -23,6 +23,13 @@ RUN /musl.sh \
                       --with-float=hard \
                       --with-mode=arm"
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-musleabihf-
 ENV CROSS_SYSROOT=/usr/local/arm-linux-musleabihf
 COPY musl-symlink.sh /

--- a/docker/Dockerfile.armv5te-unknown-linux-musleabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-musleabi
@@ -22,6 +22,13 @@ RUN /musl.sh \
                       --with-float=soft \
                       --with-mode=arm"
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-musleabi-
 ENV CROSS_SYSROOT=/usr/local/arm-linux-musleabi
 COPY musl-symlink.sh /

--- a/docker/Dockerfile.armv7-unknown-linux-musleabi
+++ b/docker/Dockerfile.armv7-unknown-linux-musleabi
@@ -23,6 +23,13 @@ RUN /musl.sh \
                       --with-mode=thumb \
                       --with-mode=arm"
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-musleabi-
 ENV CROSS_SYSROOT=/usr/local/arm-linux-musleabi
 COPY musl-symlink.sh /

--- a/docker/Dockerfile.armv7-unknown-linux-musleabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-musleabihf
@@ -23,6 +23,13 @@ RUN /musl.sh \
                       --with-mode=thumb \
                       --with-fpu=vfp"
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+
 ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-musleabihf-
 ENV CROSS_SYSROOT=/usr/local/arm-linux-musleabihf
 COPY musl-symlink.sh /

--- a/docker/Dockerfile.i586-unknown-linux-musl
+++ b/docker/Dockerfile.i586-unknown-linux-musl
@@ -18,6 +18,13 @@ RUN /musl.sh TARGET=i586-linux-musl
 COPY qemu.sh /
 RUN /qemu.sh i386
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+
 ENV CROSS_TOOLCHAIN_PREFIX=i586-linux-musl-
 ENV CROSS_SYSROOT=/usr/local/i586-linux-musl
 COPY musl-symlink.sh /

--- a/docker/Dockerfile.i686-unknown-linux-musl
+++ b/docker/Dockerfile.i686-unknown-linux-musl
@@ -18,6 +18,13 @@ RUN /musl.sh TARGET=i686-linux-musl
 COPY qemu.sh /
 RUN /qemu.sh i386
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+
 ENV CROSS_TOOLCHAIN_PREFIX=i686-linux-musl-
 ENV CROSS_SYSROOT=/usr/local/i686-linux-musl
 COPY musl-symlink.sh /

--- a/docker/Dockerfile.loongarch64-unknown-linux-musl
+++ b/docker/Dockerfile.loongarch64-unknown-linux-musl
@@ -28,6 +28,14 @@ RUN /qemu.sh loongarch64
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+ENV PATH=/x-tools/loongarch64-unknown-linux-musl/bin/:$PATH
+
 ENV CROSS_TOOLCHAIN_PREFIX=loongarch64-unknown-linux-musl-
 ENV CROSS_SYSROOT=/x-tools/loongarch64-unknown-linux-musl/loongarch64-unknown-linux-musl/sysroot/
 ENV CROSS_TARGET_RUNNER="/qemu-runner loongarch64"

--- a/docker/Dockerfile.mips-unknown-linux-musl
+++ b/docker/Dockerfile.mips-unknown-linux-musl
@@ -22,6 +22,13 @@ RUN /musl.sh \
     TARGET=mips-linux-muslsf \
     "COMMON_CONFIG += -with-arch=mips32r2"
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+
 ENV CROSS_TOOLCHAIN_PREFIX=mips-linux-muslsf-
 ENV CROSS_SYSROOT=/usr/local/mips-linux-muslsf
 COPY musl-symlink.sh /

--- a/docker/Dockerfile.mips64-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-muslabi64
@@ -22,6 +22,13 @@ RUN /musl.sh \
     TARGET=mips64-linux-musl \
     "COMMON_CONFIG += -with-arch=mips64r2"
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+
 ENV CROSS_TOOLCHAIN_PREFIX=mips64-linux-musl-
 ENV CROSS_SYSROOT=/usr/local/mips64-linux-musl
 COPY musl-symlink.sh /

--- a/docker/Dockerfile.mips64el-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-muslabi64
@@ -22,6 +22,13 @@ RUN /musl.sh \
     TARGET=mips64el-linux-musl \
     "COMMON_CONFIG += -with-arch=mips64r2"
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+
 ENV CROSS_TOOLCHAIN_PREFIX=mips64el-linux-musl-
 ENV CROSS_SYSROOT=/usr/local/mips64el-linux-musl
 COPY musl-symlink.sh /

--- a/docker/Dockerfile.mipsel-unknown-linux-musl
+++ b/docker/Dockerfile.mipsel-unknown-linux-musl
@@ -22,6 +22,13 @@ RUN /musl.sh \
     TARGET=mipsel-linux-muslsf \
     "COMMON_CONFIG += -with-arch=mips32r2"
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+
 ENV CROSS_TOOLCHAIN_PREFIX=mipsel-linux-muslsf-
 ENV CROSS_SYSROOT=/usr/local/mipsel-linux-muslsf
 COPY musl-symlink.sh /

--- a/docker/Dockerfile.riscv64gc-unknown-linux-musl
+++ b/docker/Dockerfile.riscv64gc-unknown-linux-musl
@@ -26,6 +26,14 @@ ENV PATH=/x-tools/riscv64-unknown-linux-musl/bin/:$PATH
 COPY qemu.sh /
 RUN /qemu.sh riscv64
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+ENV PATH=/x-tools/riscv64-unknown-linux-musl/bin/:$PATH
+
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 

--- a/docker/Dockerfile.x86_64-unknown-linux-musl
+++ b/docker/Dockerfile.x86_64-unknown-linux-musl
@@ -18,6 +18,13 @@ RUN /musl.sh TARGET=x86_64-linux-musl
 COPY qemu.sh /
 RUN /qemu.sh x86_64
 
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+
 ENV CROSS_TOOLCHAIN_PREFIX=x86_64-linux-musl-
 ENV CROSS_SYSROOT=/usr/local/x86_64-linux-musl
 COPY musl-symlink.sh /

--- a/docker/musl.sh
+++ b/docker/musl.sh
@@ -36,6 +36,9 @@ main() {
     # Don't depend on the mirrors of sabotage linux that musl-cross-make uses.
     local linux_headers_site=https://ci-mirrors.rust-lang.org/rustc/sabotage-linux-tarballs
     local linux_ver=headers-4.19.88
+    local gcc_ver=9.2.0
+    local target
+    find_argument TARGET target "${@}"
 
     # alpine GCC is built with `--enable-default-pie`, so we want to
     # ensure we use that. we want support for shared runtimes except for
@@ -44,7 +47,7 @@ main() {
     # linked, so our behavior has maximum portability, and is consistent
     # with popular musl distros.
     hide_output make install "-j$(nproc)" \
-        GCC_VER=9.2.0 \
+        GCC_VER=${gcc_ver} \
         MUSL_VER=1.2.3 \
         BINUTILS_VER=2.33.1 \
         DL_CMD='curl --retry 3 -sSfL -C - -o' \
@@ -57,6 +60,14 @@ main() {
     purge_packages
 
     popd
+
+    symlinkify_and_strip_toolchain "${target}" "${gcc_ver}"
+
+    for dir in /usr/local/libexec/gcc/"${target}"/*; do
+        pushd "${dir}" || exit 1
+        strip cc1 cc1plus collect2 f951 lto1 lto-wrapper liblto_plugin.so.0.0.0
+        popd || exit 1
+    done
 
     rm -rf "${td}"
     rm "${0}"

--- a/docker/tidyup.sh
+++ b/docker/tidyup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+rm -rf /var/lib/apt/lists
+rm -rf /usr/local/doc


### PR DESCRIPTION
Here is a proof of concept patchset which reduces the size of the musl images from ~2.4G to ~1.2G, on the two architectures I tried (x86_64 and aarch64).

Using aarch64 as a primary testbed, I got these results:
* Baseline (edge): image size 2.39G (794M gzipped)
* Patch 1 (strip the binaries in musl.sh): 1.55G
* Add patch 2 (flatten the output image): 1.31G
* Add patch 3 (additional tidyup script): 1.22G (348M gzipped).

A space/bandwidth saving of 47% uncompressed, 56% compressed.

I've tested the result with my use cases (x86_64 and aarch64). The crate I am cross-compiling depends on `ring` which has a C component.

There is almost certainly more squeezing that could be done, but the Law of Diminishing Returns kicks in somewhere. For example, I spotted copies of identical binaries in /usr/local/bin which could be symlinked together to save a few more MB, but coming up with a safe and robust solution there might take a little thought.

The majority of these savings are specific to the musl builds. I haven't analysed any of the non-musl images but there could be scope for improvement there as well.

If you like this approach, I'll happily copy & paste the tidyup & flatten part into the other dockerfiles. OTOH, there may be other ways to achieve this; happy to discuss.