### PR TITLE
freebsd: fix image build

### DIFF
--- a/.changes/1674.json
+++ b/.changes/1674.json
@@ -1,0 +1,4 @@
+{
+    "type": "fixed",
+    "description": "use zstd to extract the compressed file as FreeBSD do so. also, bump the gcc version"
+}

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ terminate.
 | `armv7-unknown-linux-musleabihf`       | 1.2.3  | 9.2.0  | ✓   | 6.1.0 |   ✓    |
 | `i586-unknown-linux-gnu`               | 2.31   | 9.4.0  | ✓   | N/A   |   ✓    |
 | `i586-unknown-linux-musl`              | 1.2.3  | 9.2.0  | ✓   | N/A   |   ✓    |
-| `i686-unknown-freebsd`                 | 1.5    | 6.4.0  | ✓   | N/A   |        |
+| `i686-unknown-freebsd`                 | 1.6    | 13.3.0 | ✓   | N/A   |        |
 | `i686-linux-android` [1]               | 9.0.8  | 9.0.8  | ✓   | 6.1.0 |   ✓    |
 | `i686-pc-windows-gnu`                  | N/A    | 9.4    | ✓   | N/A   |   ✓    |
 | `i686-unknown-linux-gnu`               | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
@@ -255,7 +255,7 @@ terminate.
 | `x86_64-linux-android` [1]             | 9.0.8  | 9.0.8  | ✓   | 6.1.0 |   ✓    |
 | `x86_64-pc-windows-gnu`                | N/A    | 9.3    | ✓   | N/A   |   ✓    |
 | `x86_64-pc-solaris`                    | 1.22.7 | 8.4.0  | ✓   | N/A   |        |
-| `x86_64-unknown-freebsd`               | 1.5    | 6.4.0  | ✓   | N/A   |        |
+| `x86_64-unknown-freebsd`               | 1.6    | 13.3.0 | ✓   | N/A   |        |
 | `x86_64-unknown-dragonfly` [2] [3]     | 6.0.1  | 10.3.0 | ✓   | N/A   |        |
 | `x86_64-unknown-illumos`               | 1.20.4 | 8.4.0  | ✓   | N/A   |        |
 | `x86_64-unknown-linux-gnu`             | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |

--- a/docker/freebsd-extras.sh
+++ b/docker/freebsd-extras.sh
@@ -21,7 +21,8 @@ main() {
         curl \
         dnsutils \
         jq \
-        xz-utils
+        xz-utils \
+        zstd
 
     local url=
     url=$(fetch_best_freebsd_mirror)

--- a/docker/freebsd-install.sh
+++ b/docker/freebsd-install.sh
@@ -121,10 +121,8 @@ setup_freebsd_packagesite() {
     pkg_source=$(freebsd_package_source "${url}")
 
     mkdir -p "${FREEBSD_PACKAGEDIR}"
-    curl --retry 3 -sSfL "${pkg_source}/packagesite.txz" -O
-    tar -C "${FREEBSD_PACKAGEDIR}" -xJf packagesite.txz
-
-    rm packagesite.txz
+    curl --retry 3 -sSfL "${pkg_source}/packagesite.tzst" -O
+    tar -C "${FREEBSD_PACKAGEDIR}" --zstd -xf packagesite.tzst
 }
 
 # don't provide the mirror as a positional argument, so it can be optional

--- a/docker/freebsd.sh
+++ b/docker/freebsd.sh
@@ -144,7 +144,7 @@ bsd_url="${mirror}/${FREEBSD_ARCH}/${base_release}-RELEASE"
 
 main() {
     local binutils=2.40 \
-        gcc=6.4.0 \
+        gcc=13.3.0 \
         target="${ARCH}-unknown-freebsd${FREEBSD_MAJOR}"
 
     install_packages ca-certificates \
@@ -153,7 +153,8 @@ main() {
         make \
         wget \
         texinfo \
-        xz-utils
+        xz-utils \
+        bzip2
 
     local td
     td="$(mktemp -d)"
@@ -188,9 +189,10 @@ main() {
     cp "${td}/freebsd/usr/lib/libc++.so.1" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib/libc++.a" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib/libcxxrt.a" "${destdir}/lib"
+    cp "${td}/freebsd/usr/lib/libcxxrt.so" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib/libcompiler_rt.a" "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/lib{c,util,m,ssp_nonshared,memstat}.a "${destdir}/lib"
-    cp "${td}/freebsd/usr/lib"/lib{rt,execinfo,procstat}.so.1 "${destdir}/lib"
+    cp "${td}/freebsd/usr/lib"/lib{rt,execinfo,procstat}.so "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/libmemstat.so.3 "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/{crt1,Scrt1,crti,crtn}.o "${destdir}/lib"
     cp "${td}/freebsd/usr/lib"/libkvm.a "${destdir}/lib"
@@ -228,6 +230,7 @@ main() {
         --disable-libvtv \
         --disable-lto \
         --disable-nls \
+        --disable-multilib \
         --enable-languages=c,c++,fortran \
         --target="${target}"
     make "-j$(nproc)"

--- a/xtask/src/target_info.sh
+++ b/xtask/src/target_info.sh
@@ -304,7 +304,7 @@ case "${target}" in
         # the symbol versioning can be found here:
         #   https://wiki.freebsd.org/SymbolVersioning
         version=$(cat /opt/freebsd-version)
-        if [[ "${version}" =~ ([0-9]+)\.([0-9]+)" ("[A-Za-z]+")" ]]; then
+        if [[ "${version}" =~ ([0-9]+)\.([0-9]+)" ("[A-Za-z0-9]+")" ]]; then
             major_version="${BASH_REMATCH[1]}"
             minor_version="${BASH_REMATCH[2]}"
             case "${major_version}" in
@@ -328,6 +328,9 @@ case "${target}" in
                     ;;
                 13)
                     libc="1.6"
+                    ;;
+                14)
+                    libc="1.7"
                     ;;
                 *)
                     echo "Invalid FreeBSD version, got ${major_version}.${minor_version}." 1>&2


### PR DESCRIPTION
Currently, this patch is tested by built the docker image but haven't test the build of any application upon the docker image.

When I use cross to build application, it will create the following Dockerfile in the target directory:

```
FROM ghcr.io/cross-rs/x86_64-unknown-freebsd:main
                ARG CROSS_DEB_ARCH=
                ARG CROSS_CMD
                RUN eval "${CROSS_CMD}"
```

I try to replace the "FROM" sentence to my local build image but when `cross build` is executed, it will recover to ghcr.io again.


FreeBSD change the compress algorithm of the packagesite to zstd. Also it change the download filename.

Besides fixing the download issue, I update the gcc version to 13
