### PR TITLE
fix(rustup): toolchain list --quiet

### DIFF
--- a/.changes/1681.json
+++ b/.changes/1681.json
@@ -1,0 +1,5 @@
+{
+    "description": "also recognize active and default as installed toolchains",
+    "issues": [1645, 1678],
+    "type": "fixed"
+}

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -85,7 +85,7 @@ pub fn active_toolchain(msg_info: &mut MessageInfo) -> Result<String> {
 
 pub fn installed_toolchains(msg_info: &mut MessageInfo) -> Result<Vec<String>> {
     let out = rustup_command(msg_info, true)
-        .args(["--quiet", "toolchain", "list"])
+        .args(["toolchain", "list", "--quiet"]) // suppress " (active, default)" suffix
         .run_and_get_stdout(msg_info)?;
 
     Ok(out.lines().map(|l| l.trim().to_owned()).collect())


### PR DESCRIPTION
Fixes #1678

### Old
```shell
$ rustup --quiet toolchain list
stable-aarch64-apple-darwin (active, default)
```

### New
```shell
$ rustup toolchain list --quiet
stable-aarch64-apple-darwin
```
