### PR TITLE
fix check rustup on default toolchain

### DIFF
--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -35,7 +35,7 @@ pub fn setup_rustup(
     if !toolchain.is_custom
         && !installed_toolchains(msg_info)?
             .into_iter()
-            .any(|t| t == toolchain.to_string())
+            .any(|t| t.split_whitespace().next().unwrap_or("") == toolchain.to_string())
     {
         install_toolchain(toolchain, msg_info)?;
     }


### PR DESCRIPTION
Seems that any cross command is trying to add a rustup toolchain even if is already installed.

I checked that was just checking the `rustup --quiet toolchain list` command and comparing each one, but this check will not work for the active one with `(active, default)`.


Example:

```
▷ rustup --quiet toolchain list
stable-aarch64-apple-darwin (active, default)
stable-x86_64-unknown-linux-gnu
nightly-aarch64-apple-darwin
nightly-2024-10-31-aarch64-apple-darwin
1.72.0-aarch64-apple-darwin
1.74.0-aarch64-apple-darwin
1.75.0-aarch64-apple-darwin
1.78.0-aarch64-apple-darwin
1.79.0-aarch64-apple-darwin
1.80.0-aarch64-apple-darwin
1.81.0-aarch64-apple-darwin
1.82.0-aarch64-apple-darwin
1.83.0-aarch64-apple-darwin
1.84.0-aarch64-apple-darwin
1.85.0-aarch64-apple-darwin
1.86.0-aarch64-apple-darwin
```

I needed this fix because setuptools-rust calls cargo/cross metadata and convert it to json, but I was always getting it before the json expected: 

```
stable-x86_64-unknown-linux-gnu unchanged - rustc 1.87.0 (17067e9ac 2025-05-09)
```