### PR TITLE
fix env var for custom toolchain compatibility

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -189,7 +189,7 @@ impl Environment {
     }
 
     fn custom_toolchain_compat(&self) -> Option<String> {
-        self.get_var("CUSTOM_TOOLCHAIN_COMPAT")
+        self.get_var("CROSS_CUSTOM_TOOLCHAIN_COMPAT")
     }
 
     fn build_opts(&self) -> Option<String> {


### PR DESCRIPTION
I was having some trouble setting toolchain compatibility with nix flakes environment and noticed the env var the configuration reads is actually different from the one the [documention](https://github.com/cross-rs/cross/blob/51f46f296253d8122c927c5bb933e3c4f27cc317/docs/environment_variables.md?plain=1#L48) and other parts of [code](https://github.com/cross-rs/cross/blob/51f46f296253d8122c927c5bb933e3c4f27cc317/src/rustc.rs#L187) suggests. This fixes the environment variable loaded on configuration
