### PR TITLE
Add ability to set rust version explicitly, rather than `rustup` latest

### DIFF
--- a/docker/Dockerfile.aarch64-linux-android
+++ b/docker/Dockerfile.aarch64-linux-android
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.aarch64-unknown-freebsd
+++ b/docker/Dockerfile.aarch64-unknown-freebsd
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.aarch64-unknown-linux-gnu.centos
+++ b/docker/Dockerfile.aarch64-unknown-linux-gnu.centos
@@ -6,6 +6,8 @@ RUN /linux-image.sh aarch64
 
 FROM centos:7
 
+ARG RUST_VERSION=latest
+
 # From https://github.com/rust-lang/rust/blob/672e3aaf28ab1e5cbe80b3ff012cd3a8e4ef98af/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile#L9-L12
 # CentOS 7 EOL is June 30, 2024, but the repos remain in the vault.
 RUN sed -i /etc/yum.repos.d/*.repo -e 's!^mirrorlist!#mirrorlist!' \
@@ -19,7 +21,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 COPY qemu.sh /
 RUN /qemu.sh aarch64 softmmu

--- a/docker/Dockerfile.aarch64-unknown-linux-musl
+++ b/docker/Dockerfile.aarch64-unknown-linux-musl
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.arm-linux-androideabi
+++ b/docker/Dockerfile.arm-linux-androideabi
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.arm-unknown-linux-gnueabi
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabi
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.arm-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.arm-unknown-linux-gnueabihf
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.arm-unknown-linux-musleabi
+++ b/docker/Dockerfile.arm-unknown-linux-musleabi
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.arm-unknown-linux-musleabihf
+++ b/docker/Dockerfile.arm-unknown-linux-musleabihf
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.armv5te-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-gnueabi
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.armv5te-unknown-linux-musleabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-musleabi
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.armv7-linux-androideabi
+++ b/docker/Dockerfile.armv7-linux-androideabi
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabi
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabi
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-gnueabihf
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.armv7-unknown-linux-musleabi
+++ b/docker/Dockerfile.armv7-unknown-linux-musleabi
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.armv7-unknown-linux-musleabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-musleabihf
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.asmjs-unknown-emscripten
+++ b/docker/Dockerfile.asmjs-unknown-emscripten
@@ -1,6 +1,7 @@
 FROM emscripten/emsdk:3.1.14
 WORKDIR /
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -9,7 +10,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
     libxml2 \

--- a/docker/Dockerfile.i586-unknown-linux-gnu
+++ b/docker/Dockerfile.i586-unknown-linux-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.i586-unknown-linux-musl
+++ b/docker/Dockerfile.i586-unknown-linux-musl
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.i686-linux-android
+++ b/docker/Dockerfile.i686-linux-android
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.i686-pc-windows-gnu
+++ b/docker/Dockerfile.i686-pc-windows-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.i686-unknown-freebsd
+++ b/docker/Dockerfile.i686-unknown-freebsd
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.i686-unknown-linux-gnu
+++ b/docker/Dockerfile.i686-unknown-linux-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.i686-unknown-linux-musl
+++ b/docker/Dockerfile.i686-unknown-linux-musl
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.loongarch64-unknown-linux-gnu
+++ b/docker/Dockerfile.loongarch64-unknown-linux-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.loongarch64-unknown-linux-musl
+++ b/docker/Dockerfile.loongarch64-unknown-linux-musl
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.mips-unknown-linux-gnu
+++ b/docker/Dockerfile.mips-unknown-linux-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.mips-unknown-linux-musl
+++ b/docker/Dockerfile.mips-unknown-linux-musl
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.mips64-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-gnuabi64
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.mips64-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-muslabi64
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-gnuabi64
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.mips64el-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-muslabi64
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.mipsel-unknown-linux-gnu
+++ b/docker/Dockerfile.mipsel-unknown-linux-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.mipsel-unknown-linux-musl
+++ b/docker/Dockerfile.mipsel-unknown-linux-musl
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -1,6 +1,7 @@
 # This dockerfile is used when the target matches the images platform in `build-docker-image`
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -9,7 +10,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.native.centos
+++ b/docker/Dockerfile.native.centos
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 ARG TARGETARCH
 ARG TARGETVARIANT
@@ -24,7 +25,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 # these need to be present in **both** FROM sections
 ARG TARGETARCH

--- a/docker/Dockerfile.powerpc-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc-unknown-linux-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.powerpc64-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64-unknown-linux-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.powerpc64le-unknown-linux-gnu
+++ b/docker/Dockerfile.powerpc64le-unknown-linux-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.riscv64gc-unknown-linux-gnu
+++ b/docker/Dockerfile.riscv64gc-unknown-linux-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:22.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.riscv64gc-unknown-linux-musl
+++ b/docker/Dockerfile.riscv64gc-unknown-linux-musl
@@ -1,5 +1,6 @@
 FROM ubuntu:24.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.s390x-unknown-linux-gnu
+++ b/docker/Dockerfile.s390x-unknown-linux-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.sparc64-unknown-linux-gnu
+++ b/docker/Dockerfile.sparc64-unknown-linux-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.sparcv9-sun-solaris
+++ b/docker/Dockerfile.sparcv9-sun-solaris
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.thumbv6m-none-eabi
+++ b/docker/Dockerfile.thumbv6m-none-eabi
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.thumbv7em-none-eabi
+++ b/docker/Dockerfile.thumbv7em-none-eabi
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.thumbv7em-none-eabihf
+++ b/docker/Dockerfile.thumbv7em-none-eabihf
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.thumbv7m-none-eabi
+++ b/docker/Dockerfile.thumbv7m-none-eabi
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.thumbv7neon-linux-androideabi
+++ b/docker/Dockerfile.thumbv7neon-linux-androideabi
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.thumbv7neon-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.thumbv7neon-unknown-linux-gnueabihf
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.thumbv8m.base-none-eabi
+++ b/docker/Dockerfile.thumbv8m.base-none-eabi
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.thumbv8m.main-none-eabi
+++ b/docker/Dockerfile.thumbv8m.main-none-eabi
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.thumbv8m.main-none-eabihf
+++ b/docker/Dockerfile.thumbv8m.main-none-eabihf
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.wasm32-unknown-emscripten
+++ b/docker/Dockerfile.wasm32-unknown-emscripten
@@ -1,6 +1,7 @@
 FROM emscripten/emsdk:3.1.14
 WORKDIR /
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -9,7 +10,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
   libxml2 \

--- a/docker/Dockerfile.x86_64-linux-android
+++ b/docker/Dockerfile.x86_64-linux-android
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.x86_64-pc-solaris
+++ b/docker/Dockerfile.x86_64-pc-solaris
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.x86_64-pc-windows-gnu
+++ b/docker/Dockerfile.x86_64-pc-windows-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.x86_64-unknown-dragonfly
+++ b/docker/Dockerfile.x86_64-unknown-dragonfly
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.x86_64-unknown-freebsd
+++ b/docker/Dockerfile.x86_64-unknown-freebsd
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.x86_64-unknown-illumos
+++ b/docker/Dockerfile.x86_64-unknown-illumos
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.x86_64-unknown-linux-gnu
+++ b/docker/Dockerfile.x86_64-unknown-linux-gnu
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.x86_64-unknown-linux-musl
+++ b/docker/Dockerfile.x86_64-unknown-linux-musl
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.x86_64-unknown-netbsd
+++ b/docker/Dockerfile.x86_64-unknown-netbsd
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/Dockerfile.zig
+++ b/docker/Dockerfile.zig
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04 AS cross-base
 ENV DEBIAN_FRONTEND=noninteractive
+ARG RUST_VERSION=latest
 
 COPY common.sh lib.sh /
 RUN /common.sh
@@ -8,7 +9,7 @@ COPY cmake.sh /
 RUN /cmake.sh
 
 COPY xargo.sh /
-RUN /xargo.sh
+RUN /xargo.sh $RUST_VERSION
 
 FROM cross-base AS build
 

--- a/docker/xargo.sh
+++ b/docker/xargo.sh
@@ -13,7 +13,15 @@ main() {
     export CARGO_HOME=/tmp/cargo
 
     curl --retry 3 -sSfL https://sh.rustup.rs -o rustup-init.sh
-    sh rustup-init.sh -y --no-modify-path --profile minimal
+    # xargo does not always build with the most recent default version of rust,
+    # and it may be desirable to explicitly select a `rust` version anyway,
+    # so allow specifying that. If unspecified or set to `latest`, just use
+    # the rustup default.
+    if [[ $# -gt 0 ]] && [[ -n "${1}" ]] && [[ "${1}" != "latest" ]]; then
+        sh rustup-init.sh -y --no-modify-path --profile minimal --default-toolchain="${1}"
+    else
+        sh rustup-init.sh -y --no-modify-path --profile minimal
+    fi
     rm rustup-init.sh
 
     PATH="${CARGO_HOME}/bin:${PATH}" cargo install xargo --root /usr/local


### PR DESCRIPTION
The image build scripts always let the `rustup` binary choose the latest `rust` target version to install. 

This can break things when `rustup` is updated and pulls a newer version of rust that the components in this repo haven't yet been updated to build against, see https://github.com/japaric/xargo/pull/349 for example.

That can be fixed, but in general it would be good to allow a specific/fixed/pinned version to be specified, if desired, for whatever reason.

This PR adds the ability to request a specific rust target version by setting the `RUST_VERSION` container arg, such as

- `RUST_VERSION=1.88`

if unset, or `RUST_VERSION=latest`, fall back to current behavior of letting `rustup` decide what version to install (current behavior).

I updated the `ARG` default for `RUST_VERSION` to be `latest` in all the images, for the sake of explicitness. 