### PR TITLE
Remove set -x from gcc wrappers and fix behavior with 0 arguments

### DIFF
--- a/docker/freebsd-gcc.sh
+++ b/docker/freebsd-gcc.sh
@@ -7,10 +7,10 @@ set -euo pipefail
 
 main() {
     if [[ $# -eq 0 ]]; then
-        exec "${CROSS_TOOLCHAIN_PREFIX}gcc" "${@}"
+        exec "${CROSS_TOOLCHAIN_PREFIX}gcc"
     else
         exec "${CROSS_TOOLCHAIN_PREFIX}gcc" "${@}" -lc++ -lstdc++
     fi
 }
 
-main "${@}"
+main "$@"

--- a/docker/musl-gcc.sh
+++ b/docker/musl-gcc.sh
@@ -27,9 +27,9 @@ main() {
     minor=$(rustc_minor_version)
 
     if [[ $# -eq 0 ]] || [[ "${minor}" -ge "${patched_minor}" ]]; then
-        exec "${CROSS_TOOLCHAIN_PREFIX}"gcc "${@}"
+        exec "${CROSS_TOOLCHAIN_PREFIX}"gcc "$@"
     else
-        exec "${CROSS_TOOLCHAIN_PREFIX}"gcc "${@}" -lgcc -static-libgcc
+        exec "${CROSS_TOOLCHAIN_PREFIX}"gcc "$@" -lgcc -static-libgcc
     fi
 }
 
@@ -70,4 +70,4 @@ rustc_patch_version() {
     echo "${CROSS_RUSTC_PATCH_VERSION}"
 }
 
-main "${@}"
+main "$@"


### PR DESCRIPTION
Fixes https://github.com/cross-rs/cross/issues/1618.

Additionally fixes the behavior when invoked with 0 arguments:
`${@}` is a single word, regardless of how many arguments were passed to
the program. To expand it as an array, it must be `$@`.
See https://www.gnu.org/software/bash/manual/html_node/Shell-Expansions.html.

```
docker/musl-gcc.sh: line 73: @: unbound variable
docker/freebsd-gcc.sh: line 16: @: unbound variable
```