### PR TITLE
fix(docker): use eval path for multi-line pre-build strings

### DIFF
--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -133,8 +133,8 @@ impl DockerOptions {
                     line: pre_build_script,
                     env,
                 } if !env
-                    || !pre_build_script.contains('\n')
-                        && paths.host_root().join(&pre_build_script).is_file() =>
+                    && !pre_build_script.contains('\n')
+                    && paths.host_root().join(&pre_build_script).is_file() =>
                 {
                     let custom = Dockerfile::Custom {
                         content: format!(


### PR DESCRIPTION
Triple-quoted TOML strings with newlines were incorrectly routed to file-based COPY path. Fixed boolean logic in shared.rs:135-137 to ensure multi-line strings use eval path for proper variable expansion.

Closes #1554