### PR TITLE
fix(docker): bump Debian Bullseye kernel version to 5.10.0-39

### DIFF
--- a/docker/linux-image.sh
+++ b/docker/linux-image.sh
@@ -57,7 +57,7 @@ max_kernel_version() {
 main() {
     # arch in the rust target
     local arch="${1}" \
-        kversion=5.10.0-34
+        kversion=5.10.0-39
 
     local debsource="deb http://http.debian.net/debian/ bullseye main"
     debsource="${debsource}\ndeb http://security.debian.org/ bullseye-security main"


### PR DESCRIPTION
linux-image-5.10.0-34-amd64 (and arm64/686) are no longer available in the Debian Bullseye repositories. The current latest is 5.10.0-39.