### PR TITLE
Define cargo aliases as a strings instead of lists

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
+# If this project is cloned into another Rust project's subdirectory, and that
+# project defines its own aliases, string literals provide the best
+# compatibility because of Cargo's config merging rules:
+# https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
 [alias]
-xtask = ["run", "-p", "xtask", "--"]
-build-docker-image = ["xtask", "build-docker-image"]
+xtask = "run -p xtask --"
+build-docker-image = "xtask build-docker-image"


### PR DESCRIPTION
Having the xtask alias be defined as a string allows cross-rs to be cloned into a subdirectory of another project that defines its own xtask alias. This compatibility is only possible if both the parent project's xtask alias and the cross-rs' xtask alias are strings.

Cargo implements hierarchical config structure[^1] where the parent and the child configs are merged.

- If the parent and the child have a different type, then cargo outright fails to load the configuration due to the type mismatch[^2].
- If both the parent and the child have the array type, the arrays are appended to each other instead of being replaced[^3]. This results in a broken command if the parent's array is non-empty.
- If both the parent and the child have the type string, the child's value takes precedence. This is the only way to configure both the parent's and the child's `cargo.toml` to make the merging work as expected.

Having the alias defined as a literal string matches the example provided in matklad/cargo-xtask[^4], it is commonly used, and provides the best compatibility. And unfortunately Cargo doesn't support ignoring parent's configs yet[^5].

[^1]: https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure

[^2]: failed to merge config value from `parent/.cargo/config.toml` into
     `parent/cross/.cargo/config.toml`: expected array, but found string

[^3]: For example, if the parent alias.xtask is `["foo", "bar"]` the
      resulting command is `["foo", "bar", "run", "-p", "xtask", "--"]`.

[^4]: https://github.com/matklad/cargo-xtask#defining-xtasks

[^5]: https://redirect.github.com/rust-lang/cargo/issues/7621