### PR TITLE
feat: add mips64-unknown-linux-muslsfabi64

### DIFF
--- a/docker/Dockerfile.mips64-unknown-linux-muslsfabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-muslsfabi64
@@ -1,0 +1,56 @@
+FROM ubuntu:20.04 AS cross-base
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY common.sh lib.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+FROM cross-base AS build
+
+COPY qemu.sh /
+RUN /qemu.sh mips64
+
+COPY musl.sh /
+RUN /musl.sh \
+    TARGET=mips64-linux-muslsf \
+    "COMMON_CONFIG += -with-arch=mips64r2"
+
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+
+ENV CROSS_TOOLCHAIN_PREFIX=mips64-linux-muslsf-
+ENV CROSS_SYSROOT=/usr/local/mips64-linux-muslsf
+COPY musl-symlink.sh /
+RUN /musl-symlink.sh $CROSS_SYSROOT mips64
+RUN mkdir -p $CROSS_SYSROOT/usr/lib64
+# needed for the C/C++ runners
+RUN ln -s $CROSS_SYSROOT/usr/lib/libc.so $CROSS_SYSROOT/usr/lib64/libc.so
+RUN ln -s $CROSS_SYSROOT/usr/lib/libc.so.1 $CROSS_SYSROOT/usr/lib64/libc.so.1
+
+COPY musl-gcc.sh /usr/bin/"$CROSS_TOOLCHAIN_PREFIX"gcc.sh
+COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
+
+ENV CROSS_TARGET_RUNNER="/qemu-runner mips64"
+ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc.sh \
+    CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_RUNNER="$CROSS_TARGET_RUNNER" \
+    AR_mips64_unknown_linux_muslabi64="$CROSS_TOOLCHAIN_PREFIX"ar \
+    CC_mips64_unknown_linux_muslabi64="$CROSS_TOOLCHAIN_PREFIX"gcc \
+    CXX_mips64_unknown_linux_muslabi64="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_mips64_unknown_linux_muslabi64=/opt/toolchain.cmake \
+    BINDGEN_EXTRA_CLANG_ARGS_mips64_unknown_linux_muslabi64="--sysroot=$CROSS_SYSROOT" \
+    QEMU_LD_PREFIX="$CROSS_SYSROOT" \
+    RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=mips64 \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC" \
+    CROSS_BUILTINS_PATCHED_MINOR_VERSION=65
+
+RUN sed -e "s#@DEFAULT_QEMU_LD_PREFIX@#$QEMU_LD_PREFIX#g" -i /qemu-runner


### PR DESCRIPTION
by using cargo 1.96.0-nightly (888f67534 2026-03-30). it's possible build a mips64 soft float binary by just run

```
$ cross +nightly build --target mips64-unknown-linux-muslabi64 --bin xxx --release
```

without set any flag.

So I add a new soft docker image.

<img width="2520" height="386" alt="image" src="https://github.com/user-attachments/assets/5ca8500d-11f1-4b16-b4a9-2dbc65706cf4" />
