### PR TITLE
shared: point users at cargo and cross-toolchains in no-image error

### DIFF
--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -1202,8 +1202,12 @@ pub(crate) fn group_id() -> String {
 #[derive(Debug, thiserror::Error)]
 pub enum GetImageError {
     #[error(
-        "`cross` does not provide a Docker image for target {0}, \
-    specify a custom image in `Cross.toml`."
+        "`cross` does not provide a Docker image for target {0}. \
+    If your target is the host (or close to it, e.g. macOS or Windows on \
+    macOS/Windows), you can typically just use `cargo` directly. \
+    Otherwise, specify a custom image in `Cross.toml`, or see \
+    https://github.com/cross-rs/cross-toolchains for community-built \
+    images covering targets like `*-apple-darwin` and `*-pc-windows-msvc`."
     )]
     NoCompatibleImages(String),
     #[error("platforms for provided image `{0}` are not specified, this is a bug in cross")]


### PR DESCRIPTION
Closes #1447.

The current error when `cross` doesn't have a Docker image for a target (e.g. `x86_64-apple-darwin` or `x86_64-pc-windows-msvc`) just tells you to specify a custom image in Cross.toml:

```
[cross] warning: `cross` does not provide a Docker image for target x86_64-apple-darwin, specify a custom image in `Cross.toml`.
```

That's not very actionable. Two cases I keep running into:

- target == host (or basically host, like macOS on macOS). Just `cargo build` works.
- target needs the Apple/MSVC SDKs. cross-toolchains has community Dockerfiles for that.

Mention both in the message so people can find their next step without having to dig through the issue tracker or matrix room.