### PR TITLE
Add powerpc64le-unknown-linux-musl target

### DIFF
--- a/.changes/1777.json
+++ b/.changes/1777.json
@@ -1,0 +1,5 @@
+{
+    "type": "added",
+    "description": "added the powerpc64le-unknown-linux-musl target.",
+    "issues": [1776]
+}

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ terminate.
 | `powerpc-unknown-linux-gnu`            | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
 | `powerpc64-unknown-linux-gnu`          | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
 | `powerpc64le-unknown-linux-gnu`        | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
+| `powerpc64le-unknown-linux-musl`       | 1.2.5  | 14.2.0 | ✓   | 8.2.2 |   ✓    |
 | `riscv64gc-unknown-linux-gnu`          | 2.35   | 11.4.0 | ✓   | 8.2.2 |   ✓    |
 | `riscv64gc-unknown-linux-musl`         | 1.2.5  | 14.2.0 | ✓   | 8.2.2 |   ✓    |
 | `s390x-unknown-linux-gnu`              | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |

--- a/docker/Dockerfile.powerpc64le-unknown-linux-musl
+++ b/docker/Dockerfile.powerpc64le-unknown-linux-musl
@@ -1,0 +1,55 @@
+FROM ubuntu:24.04 AS cross-base
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY common.sh lib.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+FROM cross-base AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bzip2 \
+    adduser
+
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/powerpc64le-unknown-linux-musl.config /
+RUN /crosstool-ng.sh powerpc64le-unknown-linux-musl.config 5
+
+ENV PATH=/x-tools/powerpc64le-unknown-linux-musl/bin/:$PATH
+
+COPY qemu.sh /
+RUN /qemu.sh ppc64le
+
+COPY tidyup.sh /
+RUN /tidyup.sh
+
+FROM scratch AS final
+COPY --from=build / /
+CMD ["/bin/bash"]
+ENV PATH=/x-tools/powerpc64le-unknown-linux-musl/bin/:$PATH
+
+COPY qemu-runner base-runner.sh /
+COPY toolchain.cmake /opt/toolchain.cmake
+
+ENV CROSS_TOOLCHAIN_PREFIX=powerpc64le-unknown-linux-musl-
+ENV CROSS_SYSROOT=/x-tools/powerpc64le-unknown-linux-musl/powerpc64le-unknown-linux-musl/sysroot/
+
+ENV CROSS_TARGET_RUNNER="/qemu-runner ppc64le"
+ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_MUSL_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
+    CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_MUSL_RUNNER="$CROSS_TARGET_RUNNER" \
+    AR_powerpc64le_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"ar \
+    CC_powerpc64le_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"gcc \
+    CXX_powerpc64le_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_powerpc64le_unknown_linux_musl=/opt/toolchain.cmake \
+    BINDGEN_EXTRA_CLANG_ARGS_powerpc64le_unknown_linux_musl="--sysroot=$CROSS_SYSROOT" \
+    QEMU_LD_PREFIX="$CROSS_SYSROOT" \
+    RUST_TEST_THREADS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=Linux \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=ppc64le \
+    CROSS_CMAKE_CRT=musl \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC -m64"
+
+RUN sed -e "s#@DEFAULT_QEMU_LD_PREFIX@#$QEMU_LD_PREFIX#g" -i /qemu-runner

--- a/docker/crosstool-config/powerpc64le-unknown-linux-musl.config
+++ b/docker/crosstool-config/powerpc64le-unknown-linux-musl.config
@@ -1,0 +1,37 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_POWERPC=y
+CT_ARCH_LE=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_64=y
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.2.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y

--- a/src/docker/provided_images.rs
+++ b/src/docker/provided_images.rs
@@ -109,6 +109,11 @@ pub static PROVIDED_IMAGES: &[ProvidedImage] = &[
             sub: None
         },
         ProvidedImage {
+            name: "powerpc64le-unknown-linux-musl",
+            platforms: &[ImagePlatform::X86_64_UNKNOWN_LINUX_GNU],
+            sub: None
+        },
+        ProvidedImage {
             name: "riscv64gc-unknown-linux-gnu",
             platforms: &[ImagePlatform::X86_64_UNKNOWN_LINUX_GNU],
             sub: None

--- a/targets.toml
+++ b/targets.toml
@@ -229,6 +229,16 @@ run = true
 runners = "qemu-user qemu-system"
 
 [[target]]
+target = "powerpc64le-unknown-linux-musl"
+os = "ubuntu-latest"
+cpp = true
+dylib = true
+std = true
+run = true
+runners = "qemu-user"
+build-std = true
+
+[[target]]
 target = "riscv64gc-unknown-linux-gnu"
 os = "ubuntu-latest"
 cpp = true


### PR DESCRIPTION
## Summary

Adds a `powerpc64le-unknown-linux-musl` cross image, building the toolchain with crosstool-NG (GCC 14.2.0, musl 1.2.5), with a qemu-user runner. Closes #1776.

`powerpc64le-unknown-linux-musl` is a tier-2 Rust target, and the `gnu` counterpart already ships here; this fills the musl gap. Modeled on the existing `riscv64gc-unknown-linux-musl` image and #1706.

## Changes

- `docker/Dockerfile.powerpc64le-unknown-linux-musl` — crosstool-NG build + qemu-user runner
- `docker/crosstool-config/powerpc64le-unknown-linux-musl.config` — crosstool-NG defconfig (powerpc64le LE, musl 1.2.5, GCC 14.2.0)
- `src/docker/provided_images.rs` — register the provided image
- `targets.toml` — declare the target (`runners = "qemu-user"`, `build-std`)
- `README.md` — add to the supported-targets table

## Validation

Built the image with `docker build` and exercised the toolchain:

```
$ powerpc64le-unknown-linux-musl-gcc --version
powerpc64le-unknown-linux-musl-gcc (crosstool-NG UNKNOWN) 14.2.0

$ powerpc64le-unknown-linux-musl-gcc -static t.c -o t && file t
t: ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, OpenPOWER ELF V2 ABI,
   version 1 (SYSV), statically linked
```
