### PR TITLE
fix: suggest running cargo directly for native targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -771,6 +771,28 @@ pub fn setup(
         Err(err) => {
             msg_info.warn(err)?;
 
+            let target_triple = target.triple();
+            let host_triple = host.triple();
+            let native_targets = [
+                "x86_64-pc-windows-msvc",
+                "x86_64-apple-darwin",
+                "aarch64-apple-darwin",
+            ];
+            if native_targets.contains(&target_triple) {
+                if target_triple == host_triple {
+                    msg_info.note(format_args!(
+                        "target `{target_triple}` is the same as the host; \
+                         try running `cargo` directly instead of `cross`."
+                    ))?;
+                } else {
+                    msg_info.note(format_args!(
+                        "`cross` does not natively support target `{target_triple}`. \
+                         See <https://github.com/cross-rs/cross-toolchains> for pre-built \
+                         Docker images for additional targets."
+                    ))?;
+                }
+            }
+
             return Ok(None);
         }
     };


### PR DESCRIPTION
## Summary

Adds helpful guidance when `cross` reports `NoCompatibleImages` for native targets (Windows MSVC, macOS Darwin).

## Problem

When users run `cross` for a target that doesn't need Docker (e.g. `x86_64-apple-darwin` on a macOS host), they get:

```
[cross] warning: `cross` does not provide a Docker image for target x86_64-apple-darwin, ...
[cross] error: Errors encountered before cross compilation, aborting.
```

In CI (where warnings are errors), this is confusing — the user may not realize that `cargo` can compile natively for that target without `cross`.

## Solution

After the existing warning, emit an additional note:

- **If target == host**: suggest running `cargo` directly instead of `cross`
- **If target is native but != host**: point to [cross-toolchains](https://github.com/cross-rs/cross-toolchains) for pre-built Docker images

## Changes

`src/lib.rs`: Added platform detection in the `NoCompatibleImages` error path to provide actionable guidance for native targets.

## Testing

- `cargo check` passes
- `cargo test` passes (1 test)

## Related

Fixes #1447