### PR TITLE
Add powerpc64le-unknown-freebsd image

### DIFF
--- a/.changes/1781.json
+++ b/.changes/1781.json
@@ -1,0 +1,5 @@
+{
+    "description": "add powerpc64le-unknown-freebsd image.",
+    "type": "added",
+    "breaking": false
+}

--- a/.github/ISSUE_TEMPLATE/b_issue_report.yml
+++ b/.github/ISSUE_TEMPLATE/b_issue_report.yml
@@ -63,6 +63,7 @@ body:
         - mips-unknown-linux-gnu
         - mips-unknown-linux-musl
         - powerpc64le-unknown-linux-gnu
+        - powerpc64le-unknown-freebsd
         - powerpc64-unknown-linux-gnu
         - powerpc-unknown-linux-gnu
         - riscv64gc-unknown-linux-gnu

--- a/docker/Dockerfile.powerpc64le-unknown-freebsd
+++ b/docker/Dockerfile.powerpc64le-unknown-freebsd
@@ -1,0 +1,46 @@
+FROM ubuntu:20.04 AS cross-base
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY common.sh lib.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+FROM cross-base AS build
+
+RUN echo "export ARCH=powerpc64le" > /freebsd-arch.sh
+COPY freebsd-common.sh /
+COPY freebsd.sh /
+RUN /freebsd.sh
+
+COPY freebsd-install.sh /
+COPY freebsd-extras.sh /
+RUN /freebsd-extras.sh
+
+ENV CROSS_TOOLCHAIN_PREFIX=powerpc64le-unknown-freebsd13-
+ENV CROSS_SYSROOT=/usr/local/powerpc64le-unknown-freebsd13
+
+COPY freebsd-gcc.sh /usr/bin/"$CROSS_TOOLCHAIN_PREFIX"gcc.sh
+COPY toolchain.cmake /opt/toolchain.cmake
+
+COPY freebsd-fetch-best-mirror.sh /
+COPY freebsd-setup-packagesite.sh /
+COPY freebsd-install-package.sh /
+
+ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_FREEBSD_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc.sh \
+    AR_powerpc64le_unknown_freebsd="$CROSS_TOOLCHAIN_PREFIX"ar \
+    CC_powerpc64le_unknown_freebsd="$CROSS_TOOLCHAIN_PREFIX"gcc \
+    CXX_powerpc64le_unknown_freebsd="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    CMAKE_TOOLCHAIN_FILE_powerpc64le_unknown_freebsd=/opt/toolchain.cmake \
+    BINDGEN_EXTRA_CLANG_ARGS_powerpc64le_unknown_freebsd="--sysroot=$CROSS_SYSROOT" \
+    POWERPC64LE_UNKNOWN_FREEBSD_OPENSSL_DIR="$CROSS_SYSROOT" \
+    PKG_CONFIG_PATH="${CROSS_SYSROOT}/libdata/pkgconfig/:${PKG_CONFIG_PATH}" \
+    PKG_CONFIG_ALLOW_CROSS=1 \
+    CROSS_CMAKE_SYSTEM_NAME=FreeBSD \
+    CROSS_CMAKE_SYSTEM_PROCESSOR=powerpc64le \
+    CROSS_CMAKE_CRT=freebsd \
+    CROSS_CMAKE_OBJECT_FLAGS="-ffunction-sections -fdata-sections -fPIC"

--- a/docker/freebsd-common.sh
+++ b/docker/freebsd-common.sh
@@ -17,6 +17,9 @@ case "${ARCH}" in
     i686)
         FREEBSD_ARCH=i386
         ;;
+    powerpc64le) # releases are under http://ftp.freebsd.org/pub/FreeBSD/releases/powerpc/powerpc64le/
+        FREEBSD_ARCH=powerpc/powerpc64le
+        ;;
 esac
 
 export FREEBSD_MAJOR=13

--- a/src/docker/image.rs
+++ b/src/docker/image.rs
@@ -284,6 +284,7 @@ pub enum Architecture {
     MipsLe,
     #[serde(alias = "powerpc64")]
     Ppc64,
+    #[serde(alias = "powerpc64le")]
     Ppc64Le,
     #[serde(alias = "riscv64gc")]
     Riscv64,
@@ -487,6 +488,7 @@ pub mod tests {
         assert_eq!(arch!("armv7-unknown-linux-gnueabihf")?, Architecture::Arm);
         assert_eq!(arch!("aarch64-unknown-linux-gnu")?, Architecture::Arm64);
         assert_eq!(arch!("aarch64-unknown-freebsd")?, Architecture::Arm64);
+        assert_eq!(arch!("powerpc64le-unknown-freebsd")?, Architecture::Ppc64Le);
         assert_eq!(
             arch!("loongarch64-unknown-linux-gnu")?,
             Architecture::LoongArch64
@@ -510,6 +512,10 @@ pub mod tests {
         assert_eq!(Os::from_target(&t!("x86_64-unknown-freebsd"))?, Os::Freebsd);
         assert_eq!(
             Os::from_target(&t!("aarch64-unknown-freebsd"))?,
+            Os::Freebsd
+        );
+        assert_eq!(
+            Os::from_target(&t!("powerpc64le-unknown-freebsd"))?,
             Os::Freebsd
         );
         assert_eq!(

--- a/src/docker/provided_images.rs
+++ b/src/docker/provided_images.rs
@@ -239,6 +239,11 @@ pub static PROVIDED_IMAGES: &[ProvidedImage] = &[
             sub: None
         },
         ProvidedImage {
+            name: "powerpc64le-unknown-freebsd",
+            platforms: &[ImagePlatform::X86_64_UNKNOWN_LINUX_GNU],
+            sub: None
+        },
+        ProvidedImage {
             name: "x86_64-unknown-netbsd",
             platforms: &[ImagePlatform::X86_64_UNKNOWN_LINUX_GNU],
             sub: None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,7 @@ impl TargetTriple {
             "i686-unknown-freebsd" => Some("freebsd-i386"),
             "x86_64-unknown-freebsd" => Some("freebsd-amd64"),
             "aarch64-unknown-freebsd" => Some("freebsd-arm64"),
+            "powerpc64le-unknown-freebsd" => Some("freebsd-powerpc64le"),
             "x86_64-unknown-netbsd" => Some("netbsd-amd64"),
             "sparcv9-sun-solaris" => Some("solaris-sparc"),
             "x86_64-pc-solaris" => Some("solaris-amd64"),

--- a/targets.toml
+++ b/targets.toml
@@ -468,6 +468,14 @@ std = true
 build-std = true
 
 [[target]]
+target = "powerpc64le-unknown-freebsd"
+os = "ubuntu-latest"
+cpp = true
+dylib = true
+std = true
+build-std = true
+
+[[target]]
 target = "x86_64-unknown-netbsd"
 os = "ubuntu-latest"
 cpp = true


### PR DESCRIPTION
Adds a cross image and target entry for powerpc64le-unknown-freebsd,
mirroring the existing aarch64-unknown-freebsd support: a Dockerfile
that builds a binutils/gcc cross toolchain against a FreeBSD 13
powerpc64le sysroot (assembled from the release base.txz), the
freebsd-common.sh arch mapping (FreeBSD ships powerpc64le releases
under powerpc/powerpc64le/), and the targets.toml entry that drives
CI and codegen.

Also teach Architecture parsing the `powerpc64le` arch string: the
FreeBSD targets are TargetTriple::Other, so ImagePlatform::from_target
parses the arch substring, and the Ppc64Le variant lacked a
`powerpc64le` alias (it only matched the lowercase `ppc64le`), causing
"architecture powerpc64le is not supported". This mirrors the existing
`powerpc64` alias on Ppc64 and `aarch64` alias on Arm64.

src/docker/provided_images.rs regenerated via `cargo xtask codegen`.
