### PR TITLE
enh: add all Ubuntu ports architectures to sources

### DIFF
--- a/docker/ubuntu.sources
+++ b/docker/ubuntu.sources
@@ -8,7 +8,7 @@ Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 Types: deb deb-src
 URIs: http://ports.ubuntu.com/ubuntu-ports
 Suites: noble noble-updates noble-backports noble-security
-Architectures: arm64 armhf
+Architectures: arm64 armhf riscv64 s390x ppc64el
 Components: main restricted universe multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 


### PR DESCRIPTION
If a particular architecture is not available on a particular Ubuntu version, APT emits a notice, but does not fail. However, those 3 added architectures are available on Ubuntu 24.04 and 22.04 ports both, hence on all currently use Ubuntu base images.

That only the ARM architectures were present looks more like an oversight than intended. An alternative would be to remove the `Architectures:` line. But then, APT would query the repo even if no matching `dpkg --add-architecture` was done, and throw a warning if it does not support the native one, i.e. x86_64.