### PR TITLE
fix(remote): explicitly check for symlink before calling read_link

### DIFF
--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -470,13 +470,14 @@ where
 
         let src_path = file.path();
         let dst_path = dst.join(file.file_name());
-        if file.file_type()?.is_file() {
+        let file_type = file.file_type()?;
+        if file_type.is_file() {
             fs::copy(&src_path, &dst_path)
                 .wrap_err_with(|| format!("when copying file {src_path:?} -> {dst_path:?}"))?;
-        } else if file.file_type()?.is_dir() {
+        } else if file_type.is_dir() {
             fs::create_dir(&dst_path).ok();
             had_symlinks = copy_dir(&src_path, &dst_path, copy_symlinks, depth + 1, skip)?;
-        } else if copy_symlinks {
+        } else if file_type.is_symlink() && copy_symlinks {
             had_symlinks = true;
             let link_dst = fs::read_link(src_path)?;
 


### PR DESCRIPTION
### Summary

Fixes an issue where `cross build` with `CROSS_REMOTE=1` crashes with `Invalid argument (os error 22)` when encountering non-regular, non-directory, non-symlink entries in the workspace (such as UNIX domain sockets `*.sock` or FIFO pipes).

### Details

In `src/docker/remote.rs`, `copy_dir` iterates over directory entries. Previously, any entry where `file_type.is_file()` and `file_type.is_dir()` returned `false` fell through to `else if copy_symlinks`, assuming it was a symlink and executing:

```rust
let link_dst = fs::read_link(src_path)?;
```

On macOS/Unix, executing `readlink` on a UNIX domain socket (e.g., daemon sockets created by local tools like `.codegraph/daemon.sock`) returns `EINVAL` (`os error 22: Invalid argument`), causing `cross` to fail.

This PR adds an explicit `file_type.is_symlink()` check before attempting `fs::read_link`. Sockets, FIFOs, and other special Unix devices will fall through to the `else` block and be safely ignored without crashing.

Fixes #1791
