### PR TITLE
feat(remote): copy only build artifacts back from remote builds

### DIFF
--- a/.changes/1793.json
+++ b/.changes/1793.json
@@ -1,0 +1,5 @@
+{
+    "type": "added",
+    "description": "add CROSS_REMOTE_COPY_FULL_TARGET_DIR to copy the full target directory back from remote builds when build-script artifacts are needed on the host",
+    "issues": [1793]
+}

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -33,6 +33,10 @@ In-depth documentation with examples can be found [here][env-examples].
 - `CROSS_REMOTE`: Inform `cross` it is using a remote container engine, and use
   data volumes rather than local bind mounts. See [Remote][docs-remote] for
   more information using remote container engines.
+- `CROSS_REMOTE_COPY_FULL_TARGET_DIR`: Copy the entire target directory
+  back to the host after the build, instead of only the compiler artifacts.
+  Useful when build scripts generate files, such as the `OUT_DIR` contents,
+  that must be available on the host.
 - `QEMU_STRACE`: Get a backtrace of system calls from “foreign” (non x86_64)
   binaries when using `cross` run.
 - `CARGO_BUILD_TARGET`: Sets the default target, similar to specifying

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -126,6 +126,10 @@ provided to the build command.
   Is needed to support  private SSH dependencies.
 - `CROSS_REMOTE_COPY_CACHE`: Copy all directories, even those containing
   `CACHETAG.DIR` (a cache directory [tag](https://bford.info/cachedir/)).
+- `CROSS_REMOTE_COPY_FULL_TARGET_DIR`: Copy the entire target directory
+  back to the host after the build, instead of only the compiler artifacts.
+  Useful when build scripts generate files, such as the `OUT_DIR` contents,
+  that must be available on the host.
 - `CROSS_REMOTE_SKIP_BUILD_ARTIFACTS`: Do not copy any generated build
   artifacts back to the host after finishing the build. If using persistent
   data volumes, the artifacts will remain in the volume.

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -949,6 +949,12 @@ pub(crate) fn run(
     let skip_artifacts = env::var("CROSS_REMOTE_SKIP_BUILD_ARTIFACTS")
         .map(|s| bool_from_envvar(&s))
         .unwrap_or_default();
+    // Copy the full target directory back to the host instead of only the
+    // compiler artifacts, e.g. when build scripts emit files (OUT_DIR
+    // contents, generated code) that must be available on the host.
+    let copy_full_target_dir = env::var("CROSS_REMOTE_COPY_FULL_TARGET_DIR")
+        .map(|s| bool_from_envvar(&s))
+        .unwrap_or_default();
 
     let mut cmd = options.command_variant.safe_command();
 
@@ -990,14 +996,14 @@ pub(crate) fn run(
             final_args.push(target_dir.clone());
         }
 
-        if produces_artifacts && !skip_artifacts {
+        if produces_artifacts && !skip_artifacts && !copy_full_target_dir {
             final_args.push("--message-format=json".to_owned());
         }
 
         cmd.args(final_args);
     } else {
         cmd.args(args);
-        if produces_artifacts && !skip_artifacts {
+        if produces_artifacts && !skip_artifacts && !copy_full_target_dir {
             cmd.arg(&"--message-format=json".to_owned());
         }
     }
@@ -1075,7 +1081,7 @@ symlink_recurse \"${{prefix}}\"
     if !skip_artifacts
         && data_volume.container_path_exists(&mount_target_dir, mount_prefix, msg_info)?
     {
-        if produces_artifacts {
+        if produces_artifacts && !copy_full_target_dir {
             let artifact_files = parse_artifact_filenames(&command_stdout);
 
             if !artifact_files.is_empty() {

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -6,6 +6,9 @@ use std::{env, fs, time};
 
 use eyre::Context;
 use is_terminal::IsTerminal;
+use serde::Deserialize;
+
+use crate::extensions::OutputExt;
 
 use super::engine::Engine;
 use super::shared::*;
@@ -517,6 +520,83 @@ fn warn_symlinks(had_symlinks: bool, msg_info: &mut MessageInfo) -> Result<()> {
     }
 }
 
+#[derive(Debug, Deserialize)]
+struct CargoCompilerArtifact {
+    reason: String,
+    package_id: String,
+    filenames: Vec<String>,
+    executable: Option<String>,
+}
+
+/// Artifacts of workspace members have `path+file://` package ids,
+/// while registry and git dependencies have `registry+`/`git+` ids.
+/// Only the former should be copied back to the host.
+fn is_workspace_artifact(artifact: &CargoCompilerArtifact) -> bool {
+    artifact.package_id.starts_with("path+file://")
+}
+
+fn parse_artifact_filenames(json_output: &str) -> Vec<String> {
+    let mut filenames = Vec::new();
+    for line in json_output.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(artifact) = serde_json::from_str::<CargoCompilerArtifact>(line) {
+            if artifact.reason == "compiler-artifact" && is_workspace_artifact(&artifact) {
+                for f in artifact.filenames {
+                    if !filenames.contains(&f) {
+                        filenames.push(f);
+                    }
+                }
+                if let Some(exe) = artifact.executable {
+                    if !filenames.contains(&exe) {
+                        filenames.push(exe);
+                    }
+                }
+            }
+        }
+    }
+    filenames
+}
+
+fn copy_artifacts_from_container(
+    engine: &Engine,
+    container_id: &str,
+    artifact_files: &[String],
+    host_target_dir: &Path,
+    mount_target_dir: &str,
+    msg_info: &mut MessageInfo,
+) -> Result<()> {
+    for artifact_path in artifact_files {
+        let artifact_path = artifact_path.trim();
+        if artifact_path.is_empty() {
+            continue;
+        }
+
+        let relative = if let Some(pos) = artifact_path.find(mount_target_dir) {
+            &artifact_path[pos + mount_target_dir.len()..]
+        } else {
+            msg_info.warn(format_args!(
+                "artifact path {artifact_path} does not start with {mount_target_dir}, skipping"
+            ))?;
+            continue;
+        };
+
+        let host_path = host_target_dir.join(relative.trim_start_matches('/'));
+
+        if let Some(parent) = host_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        subcommand_or_exit(engine, "cp")?
+            .arg(format!("{container_id}:{artifact_path}"))
+            .arg(&host_path)
+            .run_and_get_status(msg_info, false)?;
+    }
+    Ok(())
+}
+
 #[derive(Debug)]
 struct Fingerprint {
     map: BTreeMap<String, time::SystemTime>,
@@ -868,16 +948,26 @@ pub(crate) fn run(
         }
     }
 
+    let skip_artifacts = env::var("CROSS_REMOTE_SKIP_BUILD_ARTIFACTS")
+        .map(|s| bool_from_envvar(&s))
+        .unwrap_or_default();
+
     let mut cmd = options.command_variant.safe_command();
 
     if msg_info.should_fail() {
         return Ok(None);
     }
 
+    let produces_artifacts = matches!(
+        subcommand,
+        Some(crate::Subcommand::Build)
+            | Some(crate::Subcommand::Run)
+            | Some(crate::Subcommand::Test)
+            | Some(crate::Subcommand::Bench)
+            | Some(crate::Subcommand::Rustc)
+    );
+
     if !options.command_variant.is_shell() {
-        // `clean` doesn't handle symlinks: it will just unlink the target
-        // directory, so we should just substitute it our target directory
-        // for it. we'll still have the same end behavior
         let mut final_args = vec![];
         let mut iter = args.iter().cloned();
         let mut has_target_dir = false;
@@ -902,9 +992,16 @@ pub(crate) fn run(
             final_args.push(target_dir.clone());
         }
 
+        if produces_artifacts && !skip_artifacts {
+            final_args.push("--message-format=json".to_owned());
+        }
+
         cmd.args(final_args);
     } else {
         cmd.args(args);
+        if produces_artifacts && !skip_artifacts {
+            cmd.arg(&"--message-format=json".to_owned());
+        }
     }
 
     // 5. create symlinks for copied data
@@ -960,31 +1057,57 @@ symlink_recurse \"${{prefix}}\"
     }
 
     bail_container_exited!();
-    let status = docker.run_and_get_status(msg_info, false);
+
+    let output = docker.run_and_get_output(msg_info)?;
+    let status = output.status;
+    // Per-artifact copies should land inside the host target directory
+    // itself, e.g. <project>/target/<triple>/debug/<bin>.
+    let host_target_dir = package_dirs.target().to_owned();
+    // `docker cp` of a directory into an existing directory creates
+    // <dest>/<source-basename>, so the full-directory fallback must use
+    // the project root to reproduce <project>/target.
+    let host_root_dir = package_dirs
+        .target()
+        .parent()
+        .expect("target directory should have a parent");
 
     // 7. copy data from our target dir back to host
-    // this might not exist if we ran `clean`.
-    let skip_artifacts = env::var("CROSS_REMOTE_SKIP_BUILD_ARTIFACTS")
-        .map(|s| bool_from_envvar(&s))
-        .unwrap_or_default();
     bail_container_exited!();
     let mount_target_dir = format!("{}/{}", package_dirs.mount_root(), target_dir);
+
     if !skip_artifacts
         && data_volume.container_path_exists(&mount_target_dir, mount_prefix, msg_info)?
     {
-        subcommand_or_exit(engine, "cp")?
-            .arg("-a")
-            .arg(format!("{container_id}:{mount_target_dir}",))
-            .arg(
-                package_dirs
-                    .target()
-                    .parent()
-                    .expect("target directory should have a parent"),
-            )
-            .run_and_get_status(msg_info, false)?;
+        if produces_artifacts {
+            let json_output = output.stdout()?;
+            let artifact_files = parse_artifact_filenames(&json_output);
+
+            if !artifact_files.is_empty() {
+                copy_artifacts_from_container(
+                    engine,
+                    &container_id,
+                    &artifact_files,
+                    &host_target_dir,
+                    &mount_target_dir,
+                    msg_info,
+                )?;
+            } else {
+                subcommand_or_exit(engine, "cp")?
+                    .arg("-a")
+                    .arg(format!("{container_id}:{mount_target_dir}"))
+                    .arg(host_root_dir)
+                    .run_and_get_status(msg_info, false)?;
+            }
+        } else {
+            subcommand_or_exit(engine, "cp")?
+                .arg("-a")
+                .arg(format!("{container_id}:{mount_target_dir}"))
+                .arg(host_root_dir)
+                .run_and_get_status(msg_info, false)?;
+        }
     }
 
     ChildContainer::finish_static(is_tty, msg_info);
 
-    status.map(Some)
+    Ok(Some(status))
 }

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -538,6 +538,15 @@ fn is_intermediate_artifact(path: &str) -> bool {
         || path.ends_with("build-script-build")
 }
 
+/// Returns `true` when `line` is one of cargo's `--message-format=json`
+/// machine messages. Such lines are needed only for artifact discovery and
+/// must be captured silently instead of being printed to the user's stdout.
+fn is_cargo_json_message(line: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(line.trim())
+        .map(|value| value.get("reason").is_some())
+        .unwrap_or(false)
+}
+
 fn parse_artifact_filenames(json_output: &str) -> Vec<String> {
     let mut filenames = Vec::new();
     for line in json_output.lines() {
@@ -1072,7 +1081,8 @@ symlink_recurse \"${{prefix}}\"
 
     bail_container_exited!();
 
-    let (status, command_stdout) = docker.run_and_get_output_streamed(msg_info)?;
+    let (status, command_stdout) =
+        docker.run_and_get_output_streamed(msg_info, |line| !is_cargo_json_message(line))?;
     // Per-artifact copies should land inside the host target directory
     // itself, e.g. <project>/target/<triple>/debug/<bin>.
     let host_target_dir = package_dirs.target().to_owned();
@@ -1126,7 +1136,25 @@ symlink_recurse \"${{prefix}}\"
 
 #[cfg(test)]
 mod tests {
-    use super::parse_artifact_filenames;
+    use super::{is_cargo_json_message, parse_artifact_filenames};
+
+    #[test]
+    fn cargo_json_message_detection() {
+        assert!(is_cargo_json_message(
+            r#"{"reason":"compiler-artifact","package_id":"path+file:///project/hello","target":{"kind":["bin"],"name":"hello"},"profile":{"opt_level":"s"},"features":[],"filenames":["/project/target/debug/hello"],"executable":"/project/target/debug/hello"}"#
+        ));
+        assert!(is_cargo_json_message(
+            r#"{"reason":"build-finished","success":true}"#
+        ));
+        assert!(is_cargo_json_message(
+            r#"{"reason":"compiler-message","message":{"level":"warning","message":"unused"}}"#
+        ));
+        assert!(!is_cargo_json_message("Hello, world!"));
+        assert!(!is_cargo_json_message(""));
+        assert!(!is_cargo_json_message("not json at all"));
+        assert!(!is_cargo_json_message(r#"{"without":"a reason key"}"#));
+        assert!(!is_cargo_json_message("   "));
+    }
 
     #[test]
     fn parse_workspace_artifacts() {

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -533,6 +533,11 @@ fn is_workspace_artifact(artifact: &CargoCompilerArtifact) -> bool {
     artifact.package_id.starts_with("path+file://")
 }
 
+fn is_intermediate_artifact(path: &str) -> bool {
+    path.contains("/deps/") && (path.ends_with("rlib") || path.ends_with("rmeta"))
+        || path.ends_with("build-script-build")
+}
+
 fn parse_artifact_filenames(json_output: &str) -> Vec<String> {
     let mut filenames = Vec::new();
     for line in json_output.lines() {
@@ -543,10 +548,15 @@ fn parse_artifact_filenames(json_output: &str) -> Vec<String> {
         if let Ok(artifact) = serde_json::from_str::<CargoCompilerArtifact>(line) {
             if artifact.reason == "compiler-artifact" && is_workspace_artifact(&artifact) {
                 for f in artifact.filenames {
+                    if is_intermediate_artifact(&f) {
+                        continue;
+                    }
                     if !filenames.contains(&f) {
                         filenames.push(f);
                     }
                 }
+                // Executables are final products even when cargo places
+                // them under `deps/` (e.g. test binaries).
                 if let Some(exe) = artifact.executable {
                     if !filenames.contains(&exe) {
                         filenames.push(exe);
@@ -1127,6 +1137,27 @@ mod tests {
             vec![
                 "/project/target/debug/hello",
                 "/project/target/debug/hello.d",
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_skips_deps_artifacts_keeps_executable() {
+        let json = concat!(
+            r#"{"reason":"compiler-artifact","package_id":"path+file:///project/lib","target":{"kind":["lib"],"name":"lib"},"profile":{"opt_level":"s"},"features":[],"filenames":["/project/target/debug/deps/liblib-abc123.rlib","/project/target/debug/deps/liblib-abc123.rmeta","/project/target/debug/deps/liblib-abc123.d"],"executable":null}"#,
+            "\n",
+            r#"{"reason":"compiler-artifact","package_id":"path+file:///project/app","target":{"kind":["bin"],"name":"app"},"profile":{"opt_level":"s"},"features":[],"filenames":["/project/target/debug/app","/project/target/debug/deps/app-def456"],"executable":"/project/target/debug/app"}"#,
+            "\n",
+            r#"{"reason":"compiler-artifact","package_id":"path+file:///project/itest","target":{"kind":["test"],"name":"itest"},"profile":{"test":true,"opt_level":"s"},"features":[],"filenames":["/project/target/debug/deps/itest-789abc"],"executable":"/project/target/debug/deps/itest-789abc"}"#,
+        );
+        let out = parse_artifact_filenames(json);
+        assert_eq!(
+            out,
+            vec![
+                "/project/target/debug/deps/liblib-abc123.d",
+                "/project/target/debug/app",
+                "/project/target/debug/deps/app-def456",
+                "/project/target/debug/deps/itest-789abc"
             ]
         );
     }

--- a/src/docker/remote.rs
+++ b/src/docker/remote.rs
@@ -8,8 +8,6 @@ use eyre::Context;
 use is_terminal::IsTerminal;
 use serde::Deserialize;
 
-use crate::extensions::OutputExt;
-
 use super::engine::Engine;
 use super::shared::*;
 use crate::TargetTriple;
@@ -1058,8 +1056,7 @@ symlink_recurse \"${{prefix}}\"
 
     bail_container_exited!();
 
-    let output = docker.run_and_get_output(msg_info)?;
-    let status = output.status;
+    let (status, command_stdout) = docker.run_and_get_output_streamed(msg_info)?;
     // Per-artifact copies should land inside the host target directory
     // itself, e.g. <project>/target/<triple>/debug/<bin>.
     let host_target_dir = package_dirs.target().to_owned();
@@ -1079,8 +1076,7 @@ symlink_recurse \"${{prefix}}\"
         && data_volume.container_path_exists(&mount_target_dir, mount_prefix, msg_info)?
     {
         if produces_artifacts {
-            let json_output = output.stdout()?;
-            let artifact_files = parse_artifact_filenames(&json_output);
+            let artifact_files = parse_artifact_filenames(&command_stdout);
 
             if !artifact_files.is_empty() {
                 copy_artifacts_from_container(
@@ -1110,4 +1106,39 @@ symlink_recurse \"${{prefix}}\"
     ChildContainer::finish_static(is_tty, msg_info);
 
     Ok(Some(status))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_artifact_filenames;
+
+    #[test]
+    fn parse_workspace_artifacts() {
+        let json = r#"{"reason":"compiler-artifact","package_id":"path+file:///project/hello","target":{"kind":["bin"],"name":"hello"},"profile":{"opt_level":"s"},"features":[],"filenames":["/project/target/debug/hello","/project/target/debug/hello.d"],"executable":"/project/target/debug/hello"}"#;
+        let out = parse_artifact_filenames(json);
+        assert_eq!(
+            out,
+            vec![
+                "/project/target/debug/hello",
+                "/project/target/debug/hello.d",
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_skips_program_output_and_non_workspace() {
+        let json = concat!(
+            "Hello, world!\n",
+            r#"{"reason":"compiler-artifact","package_id":"registry+https://github.com/rust-lang/crates.io-index#serde@1.0.0","target":{"kind":["lib"],"name":"serde"},"profile":{"opt_level":"s"},"features":[],"filenames":["/project/target/debug/deps/libserde.rlib"],"executable":null}"#,
+            "\n",
+            r#"{"reason":"build-finished","success":true}"#,
+        );
+        assert!(parse_artifact_filenames(json).is_empty());
+    }
+
+    #[test]
+    fn parse_skips_empty_input() {
+        assert!(parse_artifact_filenames("").is_empty());
+        assert!(parse_artifact_filenames("\n  \n").is_empty());
+    }
 }

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -50,6 +50,7 @@ pub trait CommandExt {
     fn run_and_get_output_streamed(
         &mut self,
         msg_info: &mut MessageInfo,
+        should_forward: impl FnMut(&str) -> bool,
     ) -> Result<(ExitStatus, String)>;
     fn command_pretty(
         &self,
@@ -202,11 +203,15 @@ impl CommandExt for Command {
     /// streaming stderr as-is.
     ///
     /// Unlike [`CommandExt::run_and_get_output`], the captured output is also
-    /// forwarded to the user, so programs' output is not swallowed.
+    /// forwarded to the user, so programs' output is not swallowed. Lines for
+    /// which `should_forward` returns `false` are still collected but are not
+    /// forwarded, so machine-readable output (e.g. cargo's
+    /// `--message-format=json`) can be intercepted without leaking to the user.
     #[track_caller]
     fn run_and_get_output_streamed(
         &mut self,
         msg_info: &mut MessageInfo,
+        mut should_forward: impl FnMut(&str) -> bool,
     ) -> Result<(ExitStatus, String)> {
         use std::io::{BufRead, Write};
 
@@ -234,7 +239,9 @@ impl CommandExt for Command {
                         collected.push_str(&line);
                         // Forward to the user's stdout, like `tee`. Ignore
                         // write errors, e.g. a broken pipe from `cross run | head`.
-                        let _ = std::io::stdout().lock().write_all(line.as_bytes());
+                        if should_forward(&line) {
+                            let _ = std::io::stdout().lock().write_all(line.as_bytes());
+                        }
                     }
                     Err(_) => break,
                 }

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -46,6 +46,11 @@ pub trait CommandExt {
     fn run_and_get_stdout(&mut self, msg_info: &mut MessageInfo) -> Result<String>;
     #[track_caller]
     fn run_and_get_output(&mut self, msg_info: &mut MessageInfo) -> Result<std::process::Output>;
+    #[track_caller]
+    fn run_and_get_output_streamed(
+        &mut self,
+        msg_info: &mut MessageInfo,
+    ) -> Result<(ExitStatus, String)>;
     fn command_pretty(
         &self,
         msg_info: &mut MessageInfo,
@@ -190,6 +195,58 @@ impl CommandExt for Command {
             }
             .to_section_report()
         })
+    }
+
+    /// Runs the command to completion, forwarding stdout line-by-line to the
+    /// real stdout (like `tee`) while collecting it for later parsing, and
+    /// streaming stderr as-is.
+    ///
+    /// Unlike [`CommandExt::run_and_get_output`], the captured output is also
+    /// forwarded to the user, so programs' output is not swallowed.
+    #[track_caller]
+    fn run_and_get_output_streamed(
+        &mut self,
+        msg_info: &mut MessageInfo,
+    ) -> Result<(ExitStatus, String)> {
+        use std::io::{BufRead, Write};
+
+        self.debug(msg_info)?;
+
+        let mut child = self
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| CommandError::CouldNotExecute {
+                source: Box::new(e),
+                command: self
+                    .command_pretty(msg_info, |cmd| STRIPPED_BINS.iter().any(|f| f == &cmd)),
+            })?;
+
+        let mut collected = String::new();
+        if let Some(stdout) = child.stdout.take() {
+            let mut reader = std::io::BufReader::new(stdout);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match reader.read_line(&mut line) {
+                    // EOF: all output has been forwarded and collected.
+                    Ok(0) => break,
+                    Ok(_) => {
+                        collected.push_str(&line);
+                        // Forward to the user's stdout, like `tee`. Ignore
+                        // write errors, e.g. a broken pipe from `cross run | head`.
+                        let _ = std::io::stdout().lock().write_all(line.as_bytes());
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+
+        let status = child.wait().map_err(|e| CommandError::CouldNotExecute {
+            source: Box::new(e),
+            command: self.command_pretty(msg_info, |cmd| STRIPPED_BINS.iter().any(|f| f == &cmd)),
+        })?;
+
+        Ok((status, collected))
     }
 }
 


### PR DESCRIPTION
Instead of copying the entire target directory back from the container (including the incremental build cache), parse cargo's --message-format=json output for compiler-artifact filenames and copy only those files via docker cp. Falls back to the full directory copy when no artifacts are parsed.

after:

<img width="3814" height="214" alt="image" src="https://github.com/user-attachments/assets/05f0bfb4-0773-4bbe-995e-35f9a0c9c15b" />