### PR TITLE
Fix typos in comments, docs and an error message

### DIFF
--- a/docs/custom_images.md
+++ b/docs/custom_images.md
@@ -23,7 +23,7 @@ use case out there.
 
 ## Adding Dependencies to Existing Images
 
-If you simply need to install a dependency availaible in ubuntus package
+If you simply need to install a dependency available in ubuntus package
 manager, see [`target.TARGET.pre-build`][config-target-pre-build]:
 
 ```toml
@@ -75,7 +75,7 @@ that instead:
 image = "my/image:tag"
 ```
 
-In thie case, `cross` will use a image named `my/image:tag` instead of the
+In this case, `cross` will use a image named `my/image:tag` instead of the
 default one. Normal Docker behavior applies, so:
 
 - Docker will first look for a local image named `my/image:tag`

--- a/src/docker/build.rs
+++ b/src/docker/build.rs
@@ -21,7 +21,7 @@ impl FromStr for Progress {
             "plain" => Progress::Plain,
             "auto" => Progress::Auto,
             "tty" => Progress::Tty,
-            s => eyre::bail!("unexpect progress type: expected plain, auto, or tty and got {s}"),
+            s => eyre::bail!("unexpected progress type: expected plain, auto, or tty and got {s}"),
         })
     }
 }

--- a/src/docker/shared.rs
+++ b/src/docker/shared.rs
@@ -1894,7 +1894,7 @@ mod tests {
         }
 
         #[test]
-        fn test_parse_missing_user_moutns() {
+        fn test_parse_missing_user_mounts() {
             let actual = dockerinfo_parse_user_mounts(&json!([{
                 "Id": "test",
             }]));

--- a/xtask/src/build_docker_image.rs
+++ b/xtask/src/build_docker_image.rs
@@ -316,7 +316,7 @@ pub fn build_docker_image(
                 .buildkit_warning();
             if gha && targets.len() > 1 {
                 if let Err(e) = &result {
-                    // TODO: Determine what instruction errorred, and place warning on that line with appropriate warning
+                    // TODO: Determine what instruction errored, and place warning on that line with appropriate warning
                     gha_error(&format!("file=docker/{dockerfile},title=Build failed::{e}"));
                 }
             }


### PR DESCRIPTION
A few spelling fixes:

- `unexpect progress type` -> `unexpected progress type` in the `Progress` parse error (`src/docker/build.rs`)
- `test_parse_missing_user_moutns` -> `..._mounts` (test name, `src/docker/shared.rs`)
- `errorred` -> `errored` in a TODO comment (`xtask/src/build_docker_image.rs`)
- `availaible` -> `available` and `thie` -> `this` in `docs/custom_images.md`

`cargo check` is clean and nothing asserts on the changed error string.