### PR TITLE
Bump musl libc and gcc version for *-musl targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,73 +200,81 @@ QEMU gets upset when you spawn multiple threads. This means that, if one of your
 unit tests spawns threads, then it's more likely to fail or, worst, never
 terminate.
 
-| Target                                 |  libc  |  GCC   | C++ | QEMU  | `test` |
-|----------------------------------------|-------:|-------:|:---:|------:|:------:|
-| `aarch64-linux-android` [1]            | 9.0.8  | 9.0.8  | ✓   | 6.1.0 |   ✓    |
-| `aarch64-unknown-linux-gnu`            | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `aarch64-unknown-linux-gnu:centos` [7] | 2.17   | 4.8.5  |     | 4.2.1 |   ✓    |
-| `aarch64-unknown-linux-musl`           | 1.2.3  | 9.2.0  | ✓   | 6.1.0 |   ✓    |
-| `aarch64_be-unknown-linux-gnu`         | 2.36   | 14.2.0 | ✓   | 6.1.0 |   ✓    |
-| `arm-linux-androideabi` [1]            | 9.0.8  | 9.0.8  | ✓   | 6.1.0 |   ✓    |
-| `arm-unknown-linux-gnueabi`            | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `arm-unknown-linux-gnueabihf`          | 2.31   | 8.5.0  | ✓   | 6.1.0 |   ✓    |
-| `arm-unknown-linux-musleabi`           | 1.2.3  | 9.2.0  | ✓   | 6.1.0 |   ✓    |
-| `arm-unknown-linux-musleabihf`         | 1.2.3  | 9.2.0  | ✓   | 6.1.0 |   ✓    |
-| `armv5te-unknown-linux-gnueabi`        | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `armv5te-unknown-linux-musleabi`       | 1.2.3  | 9.2.0  | ✓   | 6.1.0 |   ✓    |
-| `armv7-linux-androideabi` [1]          | 9.0.8  | 9.0.8  | ✓   | 6.1.0 |   ✓    |
-| `armv7-unknown-linux-gnueabi`          | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `armv7-unknown-linux-gnueabihf`        | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `armv7-unknown-linux-musleabi`         | 1.2.3  | 9.2.0  | ✓   | 6.1.0 |   ✓    |
-| `armv7-unknown-linux-musleabihf`       | 1.2.3  | 9.2.0  | ✓   | 6.1.0 |   ✓    |
-| `i586-unknown-linux-gnu`               | 2.31   | 9.4.0  | ✓   | N/A   |   ✓    |
-| `i586-unknown-linux-musl`              | 1.2.3  | 9.2.0  | ✓   | N/A   |   ✓    |
-| `i686-unknown-freebsd`                 | 1.6    | 13.3.0 | ✓   | N/A   |        |
-| `i686-linux-android` [1]               | 9.0.8  | 9.0.8  | ✓   | 6.1.0 |   ✓    |
-| `i686-pc-windows-gnu`                  | N/A    | 9.4    | ✓   | N/A   |   ✓    |
-| `i686-unknown-linux-gnu`               | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `loongarch64-unknown-linux-gnu`        | 2.36   | 14.2.0 | ✓   | 8.2.2 |   ✓    |
-| `loongarch64-unknown-linux-musl`       | 1.2.5  | 14.2.0 | ✓   | 8.2.2 |   ✓    |
-| `mips-unknown-linux-gnu`               | 2.30   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `mips-unknown-linux-musl`              | 1.2.3  | 9.2.0  | ✓   | 6.1.0 |   ✓    |
-| `mips64-unknown-linux-gnuabi64`        | 2.30   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `mips64-unknown-linux-muslabi64`       | 1.2.3  | 9.2.0  | ✓   | 6.1.0 |   ✓    |
-| `mips64el-unknown-linux-gnuabi64`      | 2.30   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `mips64el-unknown-linux-muslabi64`     | 1.2.3  | 9.2.0  | ✓   | 6.1.0 |   ✓    |
-| `mipsel-unknown-linux-gnu`             | 2.30   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `mipsel-unknown-linux-musl`            | 1.2.3  | 9.2.0  | ✓   | 6.1.0 |   ✓    |
-| `powerpc-unknown-linux-gnu`            | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `powerpc64-unknown-linux-gnu`          | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `powerpc64le-unknown-linux-gnu`        | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `riscv64gc-unknown-linux-gnu`          | 2.35   | 11.4.0 | ✓   | 8.2.2 |   ✓    |
-| `riscv64gc-unknown-linux-musl`         | 1.2.5  | 14.2.0 | ✓   | 8.2.2 |   ✓    |
-| `s390x-unknown-linux-gnu`              | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `sparc64-unknown-linux-gnu`            | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `sparcv9-sun-solaris`                  | 1.22.7 | 8.4.0  | ✓   | N/A   |        |
-| `thumbv6m-none-eabi` [4]               | 3.3.0  | 9.2.1  |     | N/A   |        |
-| `thumbv7em-none-eabi` [4]              | 3.3.0  | 9.2.1  |     | N/A   |        |
-| `thumbv7em-none-eabihf` [4]            | 3.3.0  | 9.2.1  |     | N/A   |        |
-| `thumbv7m-none-eabi` [4]               | 3.3.0  | 9.2.1  |     | N/A   |        |
-| `thumbv7neon-linux-androideabi` [1]    | 9.0.8  | 9.0.8  | ✓   | 6.1.0 |   ✓    |
-| `thumbv7neon-unknown-linux-gnueabihf`  | 2.31   | 9.4.0  | ✓   | N/A   |   ✓    |
-| `thumbv8m.base-none-eabi` [4]          | 3.3.0  | 9.2.1  |     | N/A   |        |
-| `thumbv8m.main-none-eabi` [4]          | 3.3.0  | 9.2.1  |     | N/A   |        |
-| `thumbv8m.main-none-eabihf` [4]        | 3.3.0  | 9.2.1  |     | N/A   |        |
-| `wasm32-unknown-emscripten` [6]        | 3.1.14 | 15.0.0 | ✓   | N/A   |   ✓    |
-| `x86_64-linux-android` [1]             | 9.0.8  | 9.0.8  | ✓   | 6.1.0 |   ✓    |
-| `x86_64-pc-windows-gnu`                | N/A    | 9.3    | ✓   | N/A   |   ✓    |
-| `x86_64-pc-solaris`                    | 1.22.7 | 8.4.0  | ✓   | N/A   |        |
-| `x86_64-unknown-freebsd`               | 1.6    | 13.3.0 | ✓   | N/A   |        |
-| `x86_64-unknown-dragonfly` [2] [3]     | 6.0.1  | 10.3.0 | ✓   | N/A   |        |
-| `x86_64-unknown-illumos`               | 1.20.4 | 8.4.0  | ✓   | N/A   |        |
-| `x86_64-unknown-linux-gnu`             | 2.31   | 9.4.0  | ✓   | 6.1.0 |   ✓    |
-| `x86_64-unknown-linux-gnu:centos` [5]  | 2.17   | 4.8.5  | ✓   | 4.2.1 |   ✓    |
-| `x86_64-unknown-linux-musl`            | 1.2.3  | 9.2.0  | ✓   | N/A   |   ✓    |
-| `x86_64-unknown-netbsd` [3]            | 9.2.0  | 9.4.0  | ✓   | N/A   |        |
-<!--| `asmjs-unknown-emscripten` [7]       | 3.1.14 | 15.0.0  | ✓   | N/A   |   ✓    |-->
+The versions below reflect the current Dockerfiles and toolchain configuration.
+Package-based entries use the versions supplied by Ubuntu 24.04 (Noble); those
+versions may change when the Ubuntu repositories are updated.
 
-[1] libc = bionic; Only works with native tests, that is, tests that do not
-    depends on the Android Runtime. For i686 some tests may fails with the
+| Target                                           | libc/API   | GCC/Clang | GFortran | C++ | QEMU  | `test` |
+|--------------------------------------------------|-----------:|----------:|---------:|:---:|------:|:------:|
+| `aarch64-linux-android` [1]                      | 9.0 / 28   | 14.0.7    | N/A      | ✓   | 10.1.0 |   ✓    |
+| `aarch64-unknown-freebsd`                        | 1.6        | 13.3.0    | 13.3.0   | ✓   | N/A    |        |
+| `aarch64-unknown-linux-gnu`                      | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `aarch64-unknown-linux-gnu:centos` [7]           | 2.17       | 4.8.5     | 4.8.5    | ✓   | 4.2.1  |   ✓    |
+| `aarch64-unknown-linux-musl`                     | 1.2.5      | 14.4.0    | 14.4.0   | ✓   | 10.1.0 |   ✓    |
+| `aarch64_be-unknown-linux-gnu`                   | 2.36       | 14.2.0    | 14.2.0   | ✓   | 10.1.0 |   ✓    |
+| `arm-linux-androideabi` [1]                      | 9.0 / 28   | 14.0.7    | N/A      | ✓   | 10.1.0 |   ✓    |
+| `arm-unknown-linux-gnueabi`                      | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `arm-unknown-linux-gnueabihf`                    | 2.17       | 8.3.0     | 8.3.0    | ✓   | 10.1.0 |   ✓    |
+| `arm-unknown-linux-musleabi`                     | 1.2.5      | 14.4.0    | 14.4.0   | ✓   | 10.1.0 |   ✓    |
+| `arm-unknown-linux-musleabihf`                   | 1.2.5      | 14.4.0    | 14.4.0   | ✓   | 10.1.0 |   ✓    |
+| `armv5te-unknown-linux-gnueabi`                  | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `armv5te-unknown-linux-musleabi`                 | 1.2.5      | 14.4.0    | 14.4.0   | ✓   | 10.1.0 |   ✓    |
+| `armv7-linux-androideabi` [1]                    | 9.0 / 28   | 14.0.7    | N/A      | ✓   | 10.1.0 |   ✓    |
+| `armv7-unknown-linux-gnueabi`                    | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `armv7-unknown-linux-gnueabihf`                  | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `armv7-unknown-linux-musleabi`                   | 1.2.5      | 14.4.0    | 14.4.0   | ✓   | 10.1.0 |   ✓    |
+| `armv7-unknown-linux-musleabihf`                 | 1.2.5      | 14.4.0    | 14.4.0   | ✓   | 10.1.0 |   ✓    |
+| `i586-unknown-linux-gnu`                         | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `i586-unknown-linux-musl`                        | 1.2.5      | 14.4.0    | 14.4.0   | ✓   | 10.1.0 |   ✓    |
+| `i686-linux-android` [1]                         | 9.0 / 28   | 14.0.7    | N/A      | ✓   | 10.1.0 |   ✓    |
+| `i686-pc-windows-gnu`                            | N/A        | 13.2.0    | 13.2.0   | ✓   | N/A    |   ✓    |
+| `i686-unknown-freebsd`                           | 1.6        | 13.3.0    | 13.3.0   | ✓   | N/A    |        |
+| `i686-unknown-linux-gnu`                         | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `i686-unknown-linux-musl`                        | 1.2.5      | 14.4.0    | 14.4.0   | ✓   | 10.1.0 |   ✓    |
+| `loongarch64-unknown-linux-gnu`                  | 2.36       | 14.2.0    | 14.2.0   | ✓   | 10.1.0 |   ✓    |
+| `loongarch64-unknown-linux-musl`                 | 1.2.5      | 14.2.0    | 14.2.0   | ✓   | 10.1.0 |   ✓    |
+| `mips-unknown-linux-gnu`                         | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `mips-unknown-linux-musl`                        | 1.2.5      | 14.4.0    | 14.4.0   | ✓   | 10.1.0 |   ✓    |
+| `mips64-unknown-linux-gnuabi64`                  | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `mips64-unknown-linux-muslabi64`                 | 1.2.5      | 14.4.0    | 14.4.0   | ✓   | 10.1.0 |   ✓    |
+| `mips64el-unknown-linux-gnuabi64`                | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `mips64el-unknown-linux-muslabi64`               | 1.2.5      | 14.4.0    | 14.4.0   | ✓   | 10.1.0 |   ✓    |
+| `mipsel-unknown-linux-gnu`                       | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `mipsel-unknown-linux-musl`                      | 1.2.5      | 14.4.0    | 14.4.0   | ✓   | 10.1.0 |   ✓    |
+| `powerpc-unknown-linux-gnu`                      | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `powerpc64-unknown-linux-gnu`                    | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `powerpc64le-unknown-linux-gnu`                  | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `riscv64gc-unknown-linux-gnu`                    | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `riscv64gc-unknown-linux-musl`                   | 1.2.5      | 14.2.0    | 14.2.0   | ✓   | 10.1.0 |   ✓    |
+| `s390x-unknown-linux-gnu`                        | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `sparc64-unknown-linux-gnu`                      | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `sparcv9-sun-solaris`                            | 1.22.7     | 8.4.0     | 8.4.0    | ✓   | N/A    |        |
+| `thumbv6m-none-eabi` [4]                         | 4.4.0      | 13.2.1    | N/A      | ✓   | 10.1.0 |        |
+| `thumbv7em-none-eabi` [4]                        | 4.4.0      | 13.2.1    | N/A      | ✓   | 10.1.0 |        |
+| `thumbv7em-none-eabihf` [4]                      | 4.4.0      | 13.2.1    | N/A      | ✓   | 10.1.0 |        |
+| `thumbv7m-none-eabi` [4]                         | 4.4.0      | 13.2.1    | N/A      | ✓   | 10.1.0 |        |
+| `thumbv7neon-linux-androideabi` [1]              | 9.0 / 28   | 14.0.7    | N/A      | ✓   | 10.1.0 |   ✓    |
+| `thumbv7neon-unknown-linux-gnueabihf`            | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `thumbv8m.base-none-eabi` [4]                    | 4.4.0      | 13.2.1    | N/A      | ✓   | 10.1.0 |        |
+| `thumbv8m.main-none-eabi` [4]                    | 4.4.0      | 13.2.1    | N/A      | ✓   | 10.1.0 |        |
+| `thumbv8m.main-none-eabihf` [4]                  | 4.4.0      | 13.2.1    | N/A      | ✓   | 10.1.0 |        |
+| `wasm32-unknown-emscripten` [6]                  | 3.1.74     | 20.0.0git | N/A      | ✓   | N/A    |   ✓    |
+| `x86_64-linux-android` [1]                       | 9.0 / 28   | 14.0.7    | N/A      | ✓   | 10.1.0 |   ✓    |
+| `x86_64-pc-solaris`                              | 1.22.7     | 8.4.0     | 8.4.0    | ✓   | N/A    |        |
+| `x86_64-pc-windows-gnu`                          | N/A        | 13.2.0    | 13.2.0   | ✓   | N/A    |   ✓    |
+| `x86_64-unknown-dragonfly` [2] [3]               | 6.0.1      | 10.3.0    | 10.3.0   | ✓   | N/A    |        |
+| `x86_64-unknown-freebsd`                         | 1.6        | 13.3.0    | 13.3.0   | ✓   | N/A    |        |
+| `x86_64-unknown-illumos`                         | 1.20.4     | 8.4.0     | 8.4.0    | ✓   | N/A    |        |
+| `x86_64-unknown-linux-gnu`                       | 2.39       | 13.3.0    | 13.3.0   | ✓   | 10.1.0 |   ✓    |
+| `x86_64-unknown-linux-gnu:centos` [5]            | 2.17       | 4.8.5     | 4.8.5    | ✓   | 4.2.1  |   ✓    |
+| `x86_64-unknown-linux-musl`                      | 1.2.5      | 14.4.0    | 14.4.0   | ✓   | N/A    |   ✓    |
+| `x86_64-unknown-netbsd` [3]                      | 9.3        | 9.4.0     | 9.4.0    | ✓   | N/A    |        |
+
+[1] libc = bionic; the libc/API column shows the default Android system release
+    and API level, and the GCC/Clang column shows the NDK Clang version.
+    GFortran is not included in the Android NDK. Only works with native tests,
+    that is, tests that do not depend on the Android Runtime. For i686 some
+    tests may fail with the
     error `assertion failed: signal(libc::SIGPIPE, libc::SIG_IGN) !=
     libc::SIG_ERR`, see [issue
     #140](https://github.com/cross-rs/cross/issues/140) for more information.
@@ -283,7 +291,8 @@ terminate.
     `Cross.toml` for `[target.x86_64-unknown-linux-gnu]` to use the
     CentOS7-compatible target.
 
-[6] libc = emscripten and GCC = clang
+[6] libc = emscripten and the GCC/Clang column shows the bundled Clang version.
+    GFortran is not included.
 
 [7] Must change
     `image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main-centos"` in

--- a/docker/Dockerfile.aarch64-unknown-linux-musl
+++ b/docker/Dockerfile.aarch64-unknown-linux-musl
@@ -10,11 +10,15 @@ RUN /cmake.sh
 
 FROM cross-base AS build
 
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/aarch64-unknown-linux-musl.config /
+RUN /crosstool-ng.sh aarch64-unknown-linux-musl.config 5
+
+ENV PATH=/x-tools/aarch64-unknown-linux-musl/bin/:$PATH
+
 COPY qemu.sh /
 RUN /qemu.sh aarch64
-
-COPY musl.sh /
-RUN /musl.sh TARGET=aarch64-linux-musl
 
 COPY tidyup.sh /
 RUN /tidyup.sh
@@ -22,18 +26,15 @@ RUN /tidyup.sh
 FROM scratch AS final
 COPY --from=build / /
 CMD ["/bin/bash"]
+ENV PATH=/x-tools/aarch64-unknown-linux-musl/bin/:$PATH
 
-ENV CROSS_TOOLCHAIN_PREFIX=aarch64-linux-musl-
-ENV CROSS_SYSROOT=/usr/local/aarch64-linux-musl
-COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_SYSROOT aarch64
-
-COPY musl-gcc.sh /usr/bin/"$CROSS_TOOLCHAIN_PREFIX"gcc.sh
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
+ENV CROSS_TOOLCHAIN_PREFIX=aarch64-unknown-linux-musl-
+ENV CROSS_SYSROOT=/x-tools/aarch64-unknown-linux-musl/aarch64-unknown-linux-musl/sysroot/
 ENV CROSS_TARGET_RUNNER="/qemu-runner aarch64"
-ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc.sh \
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_aarch64_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_aarch64_unknown_linux_musl="$CROSS_TOOLCHAIN_PREFIX"gcc \

--- a/docker/Dockerfile.arm-unknown-linux-musleabi
+++ b/docker/Dockerfile.arm-unknown-linux-musleabi
@@ -13,12 +13,12 @@ FROM cross-base AS build
 COPY qemu.sh /
 RUN /qemu.sh arm
 
-COPY musl.sh /
-RUN /musl.sh \
-    TARGET=arm-linux-musleabi \
-    "COMMON_CONFIG += --with-arch=armv6 \
-                      --with-float=soft \
-                      --with-mode=arm"
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/arm-unknown-linux-musleabi.config /
+RUN /crosstool-ng.sh arm-unknown-linux-musleabi.config 5
+
+ENV PATH=/x-tools/arm-unknown-linux-musleabi/bin/:$PATH
 
 COPY tidyup.sh /
 RUN /tidyup.sh
@@ -26,11 +26,10 @@ RUN /tidyup.sh
 FROM scratch AS final
 COPY --from=build / /
 CMD ["/bin/bash"]
+ENV PATH=/x-tools/arm-unknown-linux-musleabi/bin/:$PATH
 
-ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-musleabi-
-ENV CROSS_SYSROOT=/usr/local/arm-linux-musleabi
-COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_SYSROOT arm
+ENV CROSS_TOOLCHAIN_PREFIX=arm-unknown-linux-musleabi-
+ENV CROSS_SYSROOT=/x-tools/arm-unknown-linux-musleabi/arm-unknown-linux-musleabi/sysroot/
 
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake

--- a/docker/Dockerfile.arm-unknown-linux-musleabihf
+++ b/docker/Dockerfile.arm-unknown-linux-musleabihf
@@ -13,13 +13,12 @@ FROM cross-base AS build
 COPY qemu.sh /
 RUN /qemu.sh arm
 
-COPY musl.sh /
-RUN /musl.sh \
-    TARGET=arm-linux-musleabihf \
-    "COMMON_CONFIG += --with-arch=armv6 \
-                      --with-fpu=vfp \
-                      --with-float=hard \
-                      --with-mode=arm"
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/arm-unknown-linux-musleabihf.config /
+RUN /crosstool-ng.sh arm-unknown-linux-musleabihf.config 5
+
+ENV PATH=/x-tools/arm-unknown-linux-musleabihf/bin/:$PATH
 
 COPY tidyup.sh /
 RUN /tidyup.sh
@@ -27,11 +26,10 @@ RUN /tidyup.sh
 FROM scratch AS final
 COPY --from=build / /
 CMD ["/bin/bash"]
+ENV PATH=/x-tools/arm-unknown-linux-musleabihf/bin/:$PATH
 
-ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-musleabihf-
-ENV CROSS_SYSROOT=/usr/local/arm-linux-musleabihf
-COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_SYSROOT armhf
+ENV CROSS_TOOLCHAIN_PREFIX=arm-unknown-linux-musleabihf-
+ENV CROSS_SYSROOT=/x-tools/arm-unknown-linux-musleabihf/arm-unknown-linux-musleabihf/sysroot/
 
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake

--- a/docker/Dockerfile.armv5te-unknown-linux-musleabi
+++ b/docker/Dockerfile.armv5te-unknown-linux-musleabi
@@ -13,8 +13,12 @@ FROM cross-base AS build
 COPY qemu.sh /
 RUN /qemu.sh arm
 
-COPY musl.sh /
-RUN /musl.sh TARGET=arm-linux-musleabi "COMMON_CONFIG += --with-arch=armv5te --with-float=soft --with-mode=arm"
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/armv5te-unknown-linux-musleabi.config /
+RUN /crosstool-ng.sh armv5te-unknown-linux-musleabi.config 5
+
+ENV PATH=/x-tools/arm-unknown-linux-musleabi/bin/:$PATH
 
 COPY tidyup.sh /
 RUN /tidyup.sh
@@ -22,18 +26,16 @@ RUN /tidyup.sh
 FROM scratch AS final
 COPY --from=build / /
 CMD ["/bin/bash"]
+ENV PATH=/x-tools/arm-unknown-linux-musleabi/bin/:$PATH
 
-ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-musleabi-
-ENV CROSS_SYSROOT=/usr/local/arm-linux-musleabi
-COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_SYSROOT arm
+ENV CROSS_TOOLCHAIN_PREFIX=arm-unknown-linux-musleabi-
+ENV CROSS_SYSROOT=/x-tools/arm-unknown-linux-musleabi/arm-unknown-linux-musleabi/sysroot/
 
-COPY musl-gcc.sh /usr/bin/"$CROSS_TOOLCHAIN_PREFIX"gcc.sh
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TARGET_RUNNER="/qemu-runner arm"
-ENV CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc.sh \
+ENV CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_ARMV5TE_UNKNOWN_LINUX_MUSLEABI_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_armv5te_unknown_linux_musleabi="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_armv5te_unknown_linux_musleabi="$CROSS_TOOLCHAIN_PREFIX"gcc \

--- a/docker/Dockerfile.armv7-unknown-linux-musleabi
+++ b/docker/Dockerfile.armv7-unknown-linux-musleabi
@@ -13,13 +13,12 @@ FROM cross-base AS build
 COPY qemu.sh /
 RUN /qemu.sh arm
 
-COPY musl.sh /
-RUN /musl.sh \
-    TARGET=arm-linux-musleabi \
-    "COMMON_CONFIG += --with-arch=armv7-a \
-                      --with-float=soft \
-                      --with-mode=thumb \
-                      --with-mode=arm"
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/armv7-unknown-linux-musleabi.config /
+RUN /crosstool-ng.sh armv7-unknown-linux-musleabi.config 5
+
+ENV PATH=/x-tools/arm-unknown-linux-musleabi/bin/:$PATH
 
 COPY tidyup.sh /
 RUN /tidyup.sh
@@ -27,11 +26,10 @@ RUN /tidyup.sh
 FROM scratch AS final
 COPY --from=build / /
 CMD ["/bin/bash"]
+ENV PATH=/x-tools/arm-unknown-linux-musleabi/bin/:$PATH
 
-ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-musleabi-
-ENV CROSS_SYSROOT=/usr/local/arm-linux-musleabi
-COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_SYSROOT arm
+ENV CROSS_TOOLCHAIN_PREFIX=arm-unknown-linux-musleabi-
+ENV CROSS_SYSROOT=/x-tools/arm-unknown-linux-musleabi/arm-unknown-linux-musleabi/sysroot/
 
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake

--- a/docker/Dockerfile.armv7-unknown-linux-musleabihf
+++ b/docker/Dockerfile.armv7-unknown-linux-musleabihf
@@ -13,13 +13,12 @@ FROM cross-base AS build
 COPY qemu.sh /
 RUN /qemu.sh arm
 
-COPY musl.sh /
-RUN /musl.sh \
-    TARGET=arm-linux-musleabihf \
-    "COMMON_CONFIG += --with-arch=armv7-a \
-                      --with-float=hard \
-                      --with-mode=thumb \
-                      --with-fpu=vfp"
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/armv7-unknown-linux-musleabihf.config /
+RUN /crosstool-ng.sh armv7-unknown-linux-musleabihf.config 5
+
+ENV PATH=/x-tools/arm-unknown-linux-musleabihf/bin/:$PATH
 
 COPY tidyup.sh /
 RUN /tidyup.sh
@@ -27,11 +26,10 @@ RUN /tidyup.sh
 FROM scratch AS final
 COPY --from=build / /
 CMD ["/bin/bash"]
+ENV PATH=/x-tools/arm-unknown-linux-musleabihf/bin/:$PATH
 
-ENV CROSS_TOOLCHAIN_PREFIX=arm-linux-musleabihf-
-ENV CROSS_SYSROOT=/usr/local/arm-linux-musleabihf
-COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_SYSROOT armhf
+ENV CROSS_TOOLCHAIN_PREFIX=arm-unknown-linux-musleabihf-
+ENV CROSS_SYSROOT=/x-tools/arm-unknown-linux-musleabihf/arm-unknown-linux-musleabihf/sysroot/
 
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake

--- a/docker/Dockerfile.i586-unknown-linux-musl
+++ b/docker/Dockerfile.i586-unknown-linux-musl
@@ -10,8 +10,12 @@ RUN /cmake.sh
 
 FROM cross-base AS build
 
-COPY musl.sh /
-RUN /musl.sh TARGET=i586-linux-musl
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/i586-unknown-linux-musl.config /
+RUN /crosstool-ng.sh i586-unknown-linux-musl.config 5
+
+ENV PATH=/x-tools/i586-unknown-linux-musl/bin/:$PATH
 
 COPY qemu.sh /
 RUN /qemu.sh i386
@@ -22,11 +26,10 @@ RUN /tidyup.sh
 FROM scratch AS final
 COPY --from=build / /
 CMD ["/bin/bash"]
+ENV PATH=/x-tools/i586-unknown-linux-musl/bin/:$PATH
 
-ENV CROSS_TOOLCHAIN_PREFIX=i586-linux-musl-
-ENV CROSS_SYSROOT=/usr/local/i586-linux-musl
-COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_SYSROOT i386
+ENV CROSS_TOOLCHAIN_PREFIX=i586-unknown-linux-musl-
+ENV CROSS_SYSROOT=/x-tools/i586-unknown-linux-musl/i586-unknown-linux-musl/sysroot/
 
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake

--- a/docker/Dockerfile.i686-unknown-linux-musl
+++ b/docker/Dockerfile.i686-unknown-linux-musl
@@ -10,8 +10,12 @@ RUN /cmake.sh
 
 FROM cross-base AS build
 
-COPY musl.sh /
-RUN /musl.sh TARGET=i686-linux-musl
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/i686-unknown-linux-musl.config /
+RUN /crosstool-ng.sh i686-unknown-linux-musl.config 5
+
+ENV PATH=/x-tools/i686-unknown-linux-musl/bin/:$PATH
 
 COPY qemu.sh /
 RUN /qemu.sh i386
@@ -22,11 +26,10 @@ RUN /tidyup.sh
 FROM scratch AS final
 COPY --from=build / /
 CMD ["/bin/bash"]
+ENV PATH=/x-tools/i686-unknown-linux-musl/bin/:$PATH
 
-ENV CROSS_TOOLCHAIN_PREFIX=i686-linux-musl-
-ENV CROSS_SYSROOT=/usr/local/i686-linux-musl
-COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_SYSROOT i386
+ENV CROSS_TOOLCHAIN_PREFIX=i686-unknown-linux-musl-
+ENV CROSS_SYSROOT=/x-tools/i686-unknown-linux-musl/i686-unknown-linux-musl/sysroot/
 
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake

--- a/docker/Dockerfile.mips-unknown-linux-musl
+++ b/docker/Dockerfile.mips-unknown-linux-musl
@@ -15,10 +15,12 @@ RUN /qemu.sh mips
 
 # this is a soft-float target for the mips32r2 architecture
 # https://github.com/rust-lang/rust/blob/75d3027fb5ce1af6712e4503c9574802212101bd/compiler/rustc_target/src/spec/mips_unknown_linux_musl.rs#L7
-COPY musl.sh /
-RUN /musl.sh \
-    TARGET=mips-linux-muslsf \
-    "COMMON_CONFIG += -with-arch=mips32r2"
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/mips-unknown-linux-musl.config /
+RUN /crosstool-ng.sh mips-unknown-linux-musl.config 5
+
+ENV PATH=/x-tools/mips-unknown-linux-musl/bin/:$PATH
 
 COPY tidyup.sh /
 RUN /tidyup.sh
@@ -26,11 +28,10 @@ RUN /tidyup.sh
 FROM scratch AS final
 COPY --from=build / /
 CMD ["/bin/bash"]
+ENV PATH=/x-tools/mips-unknown-linux-musl/bin/:$PATH
 
-ENV CROSS_TOOLCHAIN_PREFIX=mips-linux-muslsf-
-ENV CROSS_SYSROOT=/usr/local/mips-linux-muslsf
-COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_SYSROOT mips-sf
+ENV CROSS_TOOLCHAIN_PREFIX=mips-unknown-linux-musl-
+ENV CROSS_SYSROOT=/x-tools/mips-unknown-linux-musl/mips-unknown-linux-musl/sysroot/
 
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake

--- a/docker/Dockerfile.mips64-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64-unknown-linux-muslabi64
@@ -15,10 +15,12 @@ RUN /qemu.sh mips64
 
 # this is a hard-float target for the mips64r2 architecture
 # https://github.com/rust-lang/rust/blob/75d3027fb5ce1af6712e4503c9574802212101bd/compiler/rustc_target/src/spec/mips64_unknown_linux_muslabi64.rs#L7
-COPY musl.sh /
-RUN /musl.sh \
-    TARGET=mips64-linux-musl \
-    "COMMON_CONFIG += -with-arch=mips64r2"
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/mips64-unknown-linux-muslabi64.config /
+RUN /crosstool-ng.sh mips64-unknown-linux-muslabi64.config 5
+
+ENV PATH=/x-tools/mips64-unknown-linux-musl/bin/:$PATH
 
 COPY tidyup.sh /
 RUN /tidyup.sh
@@ -26,22 +28,16 @@ RUN /tidyup.sh
 FROM scratch AS final
 COPY --from=build / /
 CMD ["/bin/bash"]
+ENV PATH=/x-tools/mips64-unknown-linux-musl/bin/:$PATH
 
-ENV CROSS_TOOLCHAIN_PREFIX=mips64-linux-musl-
-ENV CROSS_SYSROOT=/usr/local/mips64-linux-musl
-COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_SYSROOT mips64
-RUN mkdir -p $CROSS_SYSROOT/usr/lib64
-# needed for the C/C++ runners
-RUN ln -s $CROSS_SYSROOT/usr/lib/libc.so $CROSS_SYSROOT/usr/lib64/libc.so
-RUN ln -s $CROSS_SYSROOT/usr/lib/libc.so.1 $CROSS_SYSROOT/usr/lib64/libc.so.1
+ENV CROSS_TOOLCHAIN_PREFIX=mips64-unknown-linux-musl-
+ENV CROSS_SYSROOT=/x-tools/mips64-unknown-linux-musl/mips64-unknown-linux-musl/sysroot/
 
-COPY musl-gcc.sh /usr/bin/"$CROSS_TOOLCHAIN_PREFIX"gcc.sh
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TARGET_RUNNER="/qemu-runner mips64"
-ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc.sh \
+ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_MIPS64_UNKNOWN_LINUX_MUSLABI64_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_mips64_unknown_linux_muslabi64="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_mips64_unknown_linux_muslabi64="$CROSS_TOOLCHAIN_PREFIX"gcc \

--- a/docker/Dockerfile.mips64el-unknown-linux-muslabi64
+++ b/docker/Dockerfile.mips64el-unknown-linux-muslabi64
@@ -15,10 +15,12 @@ RUN /qemu.sh mips64el
 
 # this is a hard-float target for the mips64r2 architecture
 # https://github.com/rust-lang/rust/blob/75d3027fb5ce1af6712e4503c9574802212101bd/compiler/rustc_target/src/spec/mips64el_unknown_linux_muslabi64.rs#L6
-COPY musl.sh /
-RUN /musl.sh \
-    TARGET=mips64el-linux-musl \
-    "COMMON_CONFIG += -with-arch=mips64r2"
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/mips64el-unknown-linux-muslabi64.config /
+RUN /crosstool-ng.sh mips64el-unknown-linux-muslabi64.config 5
+
+ENV PATH=/x-tools/mips64el-unknown-linux-musl/bin/:$PATH
 
 COPY tidyup.sh /
 RUN /tidyup.sh
@@ -26,22 +28,16 @@ RUN /tidyup.sh
 FROM scratch AS final
 COPY --from=build / /
 CMD ["/bin/bash"]
+ENV PATH=/x-tools/mips64el-unknown-linux-musl/bin/:$PATH
 
-ENV CROSS_TOOLCHAIN_PREFIX=mips64el-linux-musl-
-ENV CROSS_SYSROOT=/usr/local/mips64el-linux-musl
-COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_SYSROOT mips64el
-RUN mkdir -p $CROSS_SYSROOT/usr/lib64
-# needed for the C/C++ runners
-RUN ln -s $CROSS_SYSROOT/usr/lib/libc.so $CROSS_SYSROOT/usr/lib64/libc.so
-RUN ln -s $CROSS_SYSROOT/usr/lib/libc.so.1 $CROSS_SYSROOT/usr/lib64/libc.so.1
+ENV CROSS_TOOLCHAIN_PREFIX=mips64el-unknown-linux-musl-
+ENV CROSS_SYSROOT=/x-tools/mips64el-unknown-linux-musl/mips64el-unknown-linux-musl/sysroot/
 
-COPY musl-gcc.sh /usr/bin/"$CROSS_TOOLCHAIN_PREFIX"gcc.sh
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
 
 ENV CROSS_TARGET_RUNNER="/qemu-runner mips64el"
-ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc.sh \
+ENV CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
     CARGO_TARGET_MIPS64EL_UNKNOWN_LINUX_MUSLABI64_RUNNER="$CROSS_TARGET_RUNNER" \
     AR_mips64el_unknown_linux_muslabi64="$CROSS_TOOLCHAIN_PREFIX"ar \
     CC_mips64el_unknown_linux_muslabi64="$CROSS_TOOLCHAIN_PREFIX"gcc \

--- a/docker/Dockerfile.mipsel-unknown-linux-musl
+++ b/docker/Dockerfile.mipsel-unknown-linux-musl
@@ -15,10 +15,12 @@ RUN /qemu.sh mipsel
 
 # this is a soft-float target for the mips32r2 architecture
 # https://github.com/rust-lang/rust/blob/75d3027fb5ce1af6712e4503c9574802212101bd/compiler/rustc_target/src/spec/mipsel_unknown_linux_musl.rs#L6
-COPY musl.sh /
-RUN /musl.sh \
-    TARGET=mipsel-linux-muslsf \
-    "COMMON_CONFIG += -with-arch=mips32r2"
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/mipsel-unknown-linux-musl.config /
+RUN /crosstool-ng.sh mipsel-unknown-linux-musl.config 5
+
+ENV PATH=/x-tools/mipsel-unknown-linux-musl/bin/:$PATH
 
 COPY tidyup.sh /
 RUN /tidyup.sh
@@ -26,11 +28,10 @@ RUN /tidyup.sh
 FROM scratch AS final
 COPY --from=build / /
 CMD ["/bin/bash"]
+ENV PATH=/x-tools/mipsel-unknown-linux-musl/bin/:$PATH
 
-ENV CROSS_TOOLCHAIN_PREFIX=mipsel-linux-muslsf-
-ENV CROSS_SYSROOT=/usr/local/mipsel-linux-muslsf
-COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_SYSROOT mipsel-sf
+ENV CROSS_TOOLCHAIN_PREFIX=mipsel-unknown-linux-musl-
+ENV CROSS_SYSROOT=/x-tools/mipsel-unknown-linux-musl/mipsel-unknown-linux-musl/sysroot/
 
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake

--- a/docker/Dockerfile.x86_64-unknown-linux-musl
+++ b/docker/Dockerfile.x86_64-unknown-linux-musl
@@ -10,8 +10,12 @@ RUN /cmake.sh
 
 FROM cross-base AS build
 
-COPY musl.sh /
-RUN /musl.sh TARGET=x86_64-linux-musl
+ARG VERBOSE
+COPY crosstool-ng.sh /
+COPY crosstool-config/x86_64-unknown-linux-musl.config /
+RUN /crosstool-ng.sh x86_64-unknown-linux-musl.config 5
+
+ENV PATH=/x-tools/x86_64-unknown-linux-musl/bin/:$PATH
 
 COPY qemu.sh /
 RUN /qemu.sh x86_64
@@ -22,14 +26,17 @@ RUN /tidyup.sh
 FROM scratch AS final
 COPY --from=build / /
 CMD ["/bin/bash"]
-
-ENV CROSS_TOOLCHAIN_PREFIX=x86_64-linux-musl-
-ENV CROSS_SYSROOT=/usr/local/x86_64-linux-musl
-COPY musl-symlink.sh /
-RUN /musl-symlink.sh $CROSS_SYSROOT x86_64
+ENV PATH=/x-tools/x86_64-unknown-linux-musl/bin/:$PATH
 
 COPY qemu-runner base-runner.sh /
 COPY toolchain.cmake /opt/toolchain.cmake
+
+ENV CROSS_TOOLCHAIN_PREFIX=x86_64-unknown-linux-musl-
+ENV CROSS_SYSROOT=/x-tools/x86_64-unknown-linux-musl/x86_64-unknown-linux-musl/sysroot/
+
+# Allow dynamically-linked musl binaries to run natively.
+RUN ln -sf "$CROSS_SYSROOT/lib/ld-musl-x86_64.so.1" /lib/ld-musl-x86_64.so.1 \
+    && echo "$CROSS_SYSROOT/lib" > /etc/ld-musl-x86_64.path
 
 ENV CROSS_TARGET_RUNNER="/qemu-runner x86_64"
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \

--- a/docker/crosstool-config/aarch64-unknown-linux-musl.config
+++ b/docker/crosstool-config/aarch64-unknown-linux-musl.config
@@ -1,0 +1,46 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_ARM=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_64=y
+CT_ARCH_FLOAT_HW=y
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_BINUTILS_V_2_45=y
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.45"
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.4.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y
+CT_CC_LANG_FORTRAN=y
+CT_CC_GCC_LIBGOMP=y
+CT_BUILD_MANUALS=n
+CT_REMOVE_DOCS=y
+CT_LOG_PROGRESS_BAR=n
+CT_LOG_ALL=y

--- a/docker/crosstool-config/arm-unknown-linux-musleabi.config
+++ b/docker/crosstool-config/arm-unknown-linux-musleabi.config
@@ -1,0 +1,46 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_ARM=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_ARCH="armv6"
+CT_ARCH_FLOAT_SW=y
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_BINUTILS_V_2_45=y
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.45"
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.4.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y
+CT_CC_LANG_FORTRAN=y
+CT_CC_GCC_LIBGOMP=y
+CT_BUILD_MANUALS=n
+CT_REMOVE_DOCS=y
+CT_LOG_PROGRESS_BAR=n
+CT_LOG_ALL=y

--- a/docker/crosstool-config/arm-unknown-linux-musleabihf.config
+++ b/docker/crosstool-config/arm-unknown-linux-musleabihf.config
@@ -1,0 +1,47 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_ARM=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_ARCH="armv6"
+CT_ARCH_FPU="vfp"
+CT_ARCH_FLOAT_HW=y
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_BINUTILS_V_2_45=y
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.45"
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.4.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y
+CT_CC_LANG_FORTRAN=y
+CT_CC_GCC_LIBGOMP=y
+CT_BUILD_MANUALS=n
+CT_REMOVE_DOCS=y
+CT_LOG_PROGRESS_BAR=n
+CT_LOG_ALL=y

--- a/docker/crosstool-config/armv5te-unknown-linux-musleabi.config
+++ b/docker/crosstool-config/armv5te-unknown-linux-musleabi.config
@@ -1,0 +1,46 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_ARM=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_ARCH="armv5te"
+CT_ARCH_FLOAT_SW=y
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_BINUTILS_V_2_45=y
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.45"
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.4.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y
+CT_CC_LANG_FORTRAN=y
+CT_CC_GCC_LIBGOMP=y
+CT_BUILD_MANUALS=n
+CT_REMOVE_DOCS=y
+CT_LOG_PROGRESS_BAR=n
+CT_LOG_ALL=y

--- a/docker/crosstool-config/armv7-unknown-linux-musleabi.config
+++ b/docker/crosstool-config/armv7-unknown-linux-musleabi.config
@@ -1,0 +1,46 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_ARM=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_ARCH="armv7-a"
+CT_ARCH_FLOAT_SW=y
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_BINUTILS_V_2_45=y
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.45"
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.4.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y
+CT_CC_LANG_FORTRAN=y
+CT_CC_GCC_LIBGOMP=y
+CT_BUILD_MANUALS=n
+CT_REMOVE_DOCS=y
+CT_LOG_PROGRESS_BAR=n
+CT_LOG_ALL=y

--- a/docker/crosstool-config/armv7-unknown-linux-musleabihf.config
+++ b/docker/crosstool-config/armv7-unknown-linux-musleabihf.config
@@ -1,0 +1,48 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_ARM=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_ARCH="armv7-a"
+CT_ARCH_FPU="vfpv3-d16"
+CT_ARCH_FLOAT_HW=y
+CT_ARCH_ARM_MODE_THUMB=y
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_BINUTILS_V_2_45=y
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.45"
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.4.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y
+CT_CC_LANG_FORTRAN=y
+CT_CC_GCC_LIBGOMP=y
+CT_BUILD_MANUALS=n
+CT_REMOVE_DOCS=y
+CT_LOG_PROGRESS_BAR=n
+CT_LOG_ALL=y

--- a/docker/crosstool-config/i586-unknown-linux-musl.config
+++ b/docker/crosstool-config/i586-unknown-linux-musl.config
@@ -1,0 +1,45 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_X86=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_ARCH="pentium"
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_BINUTILS_V_2_45=y
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.45"
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.4.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y
+CT_CC_LANG_FORTRAN=y
+CT_CC_GCC_LIBGOMP=y
+CT_BUILD_MANUALS=n
+CT_REMOVE_DOCS=y
+CT_LOG_PROGRESS_BAR=n
+CT_LOG_ALL=y

--- a/docker/crosstool-config/i686-unknown-linux-musl.config
+++ b/docker/crosstool-config/i686-unknown-linux-musl.config
@@ -1,0 +1,45 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_X86=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_ARCH="i686"
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_BINUTILS_V_2_45=y
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.45"
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.4.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y
+CT_CC_LANG_FORTRAN=y
+CT_CC_GCC_LIBGOMP=y
+CT_BUILD_MANUALS=n
+CT_REMOVE_DOCS=y
+CT_LOG_PROGRESS_BAR=n
+CT_LOG_ALL=y

--- a/docker/crosstool-config/mips-unknown-linux-musl.config
+++ b/docker/crosstool-config/mips-unknown-linux-musl.config
@@ -1,0 +1,47 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_MIPS=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_ARCH="mips32r2"
+CT_ARCH_FLOAT_SW=y
+CT_ARCH_mips_o32=y
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_BINUTILS_V_2_45=y
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.45"
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.4.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y
+CT_CC_LANG_FORTRAN=y
+CT_CC_GCC_LIBGOMP=y
+CT_BUILD_MANUALS=n
+CT_REMOVE_DOCS=y
+CT_LOG_PROGRESS_BAR=n
+CT_LOG_ALL=y

--- a/docker/crosstool-config/mips64-unknown-linux-muslabi64.config
+++ b/docker/crosstool-config/mips64-unknown-linux-muslabi64.config
@@ -1,0 +1,48 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_MIPS=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_ARCH="mips64r2"
+CT_ARCH_64=y
+CT_ARCH_FLOAT_HW=y
+CT_ARCH_mips_n64=y
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_BINUTILS_V_2_45=y
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.45"
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.4.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y
+CT_CC_LANG_FORTRAN=y
+CT_CC_GCC_LIBGOMP=y
+CT_BUILD_MANUALS=n
+CT_REMOVE_DOCS=y
+CT_LOG_PROGRESS_BAR=n
+CT_LOG_ALL=y

--- a/docker/crosstool-config/mips64el-unknown-linux-muslabi64.config
+++ b/docker/crosstool-config/mips64el-unknown-linux-muslabi64.config
@@ -1,0 +1,49 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_MIPS=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_LE=y
+CT_ARCH_ARCH="mips64r2"
+CT_ARCH_64=y
+CT_ARCH_FLOAT_HW=y
+CT_ARCH_mips_n64=y
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_BINUTILS_V_2_45=y
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.45"
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.4.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y
+CT_CC_LANG_FORTRAN=y
+CT_CC_GCC_LIBGOMP=y
+CT_BUILD_MANUALS=n
+CT_REMOVE_DOCS=y
+CT_LOG_PROGRESS_BAR=n
+CT_LOG_ALL=y

--- a/docker/crosstool-config/mipsel-unknown-linux-musl.config
+++ b/docker/crosstool-config/mipsel-unknown-linux-musl.config
@@ -1,0 +1,48 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_MIPS=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_LE=y
+CT_ARCH_ARCH="mips32r2"
+CT_ARCH_FLOAT_SW=y
+CT_ARCH_mips_o32=y
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_BINUTILS_V_2_45=y
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.45"
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.4.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y
+CT_CC_LANG_FORTRAN=y
+CT_CC_GCC_LIBGOMP=y
+CT_BUILD_MANUALS=n
+CT_REMOVE_DOCS=y
+CT_LOG_PROGRESS_BAR=n
+CT_LOG_ALL=y

--- a/docker/crosstool-config/x86_64-unknown-linux-musl.config
+++ b/docker/crosstool-config/x86_64-unknown-linux-musl.config
@@ -1,0 +1,45 @@
+CT_CONFIG_VERSION="4"
+CT_EXPERIMENTAL=y
+CT_PREFIX_DIR="/x-tools/${CT_TARGET}"
+CT_ARCH_X86=y
+# CT_DEMULTILIB is not set
+CT_ARCH_USE_MMU=y
+CT_ARCH_64=y
+CT_KERNEL_LINUX=y
+CT_LINUX_V_5_19=y
+# CT_LINUX_NO_VERSIONS is not set
+CT_LINUX_VERSION="5.19.16"
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_BINUTILS_V_2_45=y
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.45"
+CT_LIBC_MUSL=y
+CT_MUSL_V_1_2_5=y
+# CT_MUSL_NO_VERSIONS is not set
+CT_MUSL_VERSION="1.2.5"
+CT_GCC_V_14=y
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="14.4.0"
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
+CT_GCC_4_8_or_later=y
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+CT_CC_LANG_CXX=y
+CT_CC_LANG_FORTRAN=y
+CT_CC_GCC_LIBGOMP=y
+CT_BUILD_MANUALS=n
+CT_REMOVE_DOCS=y
+CT_LOG_PROGRESS_BAR=n
+CT_LOG_ALL=y

--- a/docker/crosstool-ng.sh
+++ b/docker/crosstool-ng.sh
@@ -9,7 +9,7 @@ set -eo pipefail
 main() {
     local config="${1}"
     local nproc="${2}"
-    local ctng_version=${3:-crosstool-ng-1.28.0}
+    local ctng_version=${3:-crosstool-ng-1.29.0}
     local ctng_url="https://github.com/crosstool-ng/crosstool-ng"
     local username=crosstool
     local crosstooldir=/opt/crosstool


### PR DESCRIPTION
Close #1794 

This PR updates the existing *-musl targets to use a newer musl toolchain while keeping the previous toolchain available for compatibility.

 - Migrate the affected musl targets from musl-cross-make to crosstool-ng.
 - Upgrade the default toolchain from musl 1.2.3 / GCC 9.2.0 to musl 1.2.5 / GCC 14.3.0.
 - Keep the previous musl 1.2.3 / GCC 9.2.0 toolchain available through :legacy images.
 - Refresh the target/toolchain table in the README and document how to use the legacy images.